### PR TITLE
Add historical patch selection for LoL analytics

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -53,7 +53,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         ChampionAnalyticsFilter filter,
         CancellationToken ct)
     {
-        var patchContext = await GetActivePatchContextAsync(ct);
+        var patchContext = await ResolvePatchContextAsync(filter.Patch, ct);
         if (string.IsNullOrWhiteSpace(patchContext.Patch))
         {
             return new ChampionWinRateSummary(
@@ -70,7 +70,8 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         {
             RankTier = normalizedRankTier == "all" ? null : normalizedRankTier,
             Region = AnalyticsRegionCatalog.NormalizeToFilter(NormalizeAnalyticsRegion(filter.Region)),
-            Role = string.IsNullOrWhiteSpace(filter.Role) ? null : filter.Role.Trim().ToUpperInvariant()
+            Role = string.IsNullOrWhiteSpace(filter.Role) ? null : filter.Role.Trim().ToUpperInvariant(),
+            Patch = currentPatch
         };
 
         // Build cache key based on normalized filter parameters
@@ -98,9 +99,10 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         string? role,
         string? rankTier,
         string? region,
+        string? patch,
         CancellationToken ct)
     {
-        var patchContext = await GetActivePatchContextAsync(ct);
+        var patchContext = await ResolvePatchContextAsync(patch, ct);
         var normalizedRegion = NormalizeAnalyticsRegion(region);
         if (string.IsNullOrWhiteSpace(patchContext.Patch))
         {
@@ -154,9 +156,10 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         string role,
         string? rankTier,
         string? region,
+        string? patch,
         CancellationToken ct)
     {
-        var patchContext = await GetActivePatchContextAsync(ct);
+        var patchContext = await ResolvePatchContextAsync(patch, ct);
         var normalizedRole = role.ToUpperInvariant();
         var normalizedTier = NormalizeRankTier(rankTier);
         var normalizedRegion = NormalizeAnalyticsRegion(region);
@@ -172,10 +175,10 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
                 [],
                 BuildSampleMetadata(0, patchContext));
 
-        var patch = patchContext.Patch!;
+        var selectedPatch = patchContext.Patch!;
 
-        var cacheKey = $"{BuildsCacheKeyPrefix}{championId}:{normalizedRole}:{normalizedTier}:{normalizedRegion}:{patch}";
-        var tags = new[] { AnalyticsCacheTag, $"patch:{patch}", "builds" };
+        var cacheKey = $"{BuildsCacheKeyPrefix}{championId}:{normalizedRole}:{normalizedTier}:{normalizedRegion}:{selectedPatch}";
+        var tags = new[] { AnalyticsCacheTag, $"patch:{selectedPatch}", "builds" };
 
         var response = await _cache.GetOrCreateAsync(
             cacheKey,
@@ -184,7 +187,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
                 normalizedRole,
                 normalizedTier == "all" ? null : normalizedTier,
                 normalizedRegion,
-                patch,
+                selectedPatch,
                 cancel),
             AnalyticsCacheOptions,
             tags,
@@ -200,8 +203,8 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         string? patch,
         CancellationToken ct)
     {
-        var patchContext = await GetActivePatchContextAsync(ct);
-        var resolvedPatch = string.IsNullOrWhiteSpace(patch) ? patchContext.Patch : patch.Trim();
+        var patchContext = await ResolvePatchContextAsync(patch, ct);
+        var resolvedPatch = patchContext.Patch;
         var normalizedRole = string.IsNullOrWhiteSpace(role) ? "ALL" : role.Trim().ToUpperInvariant();
         var normalizedRegion = string.IsNullOrWhiteSpace(region) ? "ALL" : region.Trim().ToUpperInvariant();
 
@@ -241,9 +244,10 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         string role,
         string? rankTier,
         string? region,
+        string? patch,
         CancellationToken ct)
     {
-        var patchContext = await GetActivePatchContextAsync(ct);
+        var patchContext = await ResolvePatchContextAsync(patch, ct);
         var normalizedRole = role.ToUpperInvariant();
         var normalizedTier = NormalizeRankTier(rankTier);
         var normalizedRegion = NormalizeAnalyticsRegion(region);
@@ -264,9 +268,9 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             };
         }
 
-        var patch = patchContext.Patch!;
-        var cacheKey = $"{MatchupsCacheKeyPrefix}{championId}:{normalizedRole}:{normalizedTier}:{normalizedRegion}:{patch}";
-        var tags = new[] { AnalyticsCacheTag, $"patch:{patch}", "matchups" };
+        var selectedPatch = patchContext.Patch!;
+        var cacheKey = $"{MatchupsCacheKeyPrefix}{championId}:{normalizedRole}:{normalizedTier}:{normalizedRegion}:{selectedPatch}";
+        var tags = new[] { AnalyticsCacheTag, $"patch:{selectedPatch}", "matchups" };
 
         var response = await _cache.GetOrCreateAsync(
             cacheKey,
@@ -275,7 +279,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
                 normalizedRole,
                 normalizedTier == "all" ? null : normalizedTier,
                 normalizedRegion,
-                patch,
+                selectedPatch,
                 cancel),
             AnalyticsCacheOptions,
             tags,
@@ -289,8 +293,30 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         await _cache.RemoveByTagAsync(AnalyticsCacheTag, ct);
     }
 
-    private async Task<ActivePatchContext> GetActivePatchContextAsync(CancellationToken ct)
+    private async Task<ActivePatchContext> ResolvePatchContextAsync(string? requestedPatch, CancellationToken ct)
     {
+        var normalizedRequestedPatch = string.IsNullOrWhiteSpace(requestedPatch)
+            ? null
+            : requestedPatch.Trim();
+
+        if (!string.IsNullOrWhiteSpace(normalizedRequestedPatch))
+        {
+            var requestedPatchMetadata = await _context.Patches
+                .AsNoTracking()
+                .Where(p => p.Version == normalizedRequestedPatch)
+                .Select(p => new { p.Version, p.ReleaseDate })
+                .FirstOrDefaultAsync(ct);
+
+            if (requestedPatchMetadata == null)
+                return new ActivePatchContext(
+                    normalizedRequestedPatch,
+                    0,
+                    false,
+                    AnalyticsPatchPhase.Steady);
+
+            return BuildPatchContext(requestedPatchMetadata.Version, requestedPatchMetadata.ReleaseDate);
+        }
+
         var activePatch = await _context.Patches
             .AsNoTracking()
             .Where(p => p.IsActive)
@@ -300,13 +326,18 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         if (activePatch == null || string.IsNullOrWhiteSpace(activePatch.Version))
             return new ActivePatchContext(null, 0, false, AnalyticsPatchPhase.Bootstrap);
 
-        var releaseUtc = activePatch.ReleaseDate.Kind == DateTimeKind.Utc
-            ? activePatch.ReleaseDate
-            : DateTime.SpecifyKind(activePatch.ReleaseDate, DateTimeKind.Utc);
+        return BuildPatchContext(activePatch.Version, activePatch.ReleaseDate);
+    }
+
+    private ActivePatchContext BuildPatchContext(string patch, DateTime releaseDate)
+    {
+        var releaseUtc = releaseDate.Kind == DateTimeKind.Utc
+            ? releaseDate
+            : DateTime.SpecifyKind(releaseDate, DateTimeKind.Utc);
         var patchAgeHours = Math.Max(0, (DateTime.UtcNow - releaseUtc).TotalHours);
         var patchPhase = AnalyticsPatchPhaseCalculator.Resolve(patchAgeHours, _computeOptions);
         return new ActivePatchContext(
-            activePatch.Version,
+            patch,
             patchAgeHours,
             patchPhase != AnalyticsPatchPhase.Steady,
             patchPhase);

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsService.cs
@@ -25,6 +25,7 @@ public interface IChampionAnalyticsService
         string? role,
         string? rankTier,
         string? region,
+        string? patch,
         CancellationToken ct);
 
     /// <summary>
@@ -36,6 +37,7 @@ public interface IChampionAnalyticsService
         string role,
         string? rankTier,
         string? region,
+        string? patch,
         CancellationToken ct);
 
     Task<ChampionProBuildsResponse> GetProBuildsAsync(
@@ -55,6 +57,7 @@ public interface IChampionAnalyticsService
         string role,
         string? rankTier,
         string? region,
+        string? patch,
         CancellationToken ct);
 
     /// <summary>

--- a/Transcendence.Service.Core/Services/Analytics/Models/AnalyticsPatchStatusDto.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/AnalyticsPatchStatusDto.cs
@@ -5,3 +5,11 @@ public record AnalyticsPatchStatusDto(
     DateTime? ActivePatchReleasedAtUtc,
     DateTime? ActivePatchDetectedAtUtc
 );
+
+public record AnalyticsPatchOptionDto(
+    string Patch,
+    DateTime? ReleasedAtUtc,
+    DateTime? DetectedAtUtc,
+    bool IsActive,
+    int RankedSoloDuoMatchCount
+);

--- a/Transcendence.Service.Core/Services/Analytics/Models/ChampionAnalyticsFilter.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/ChampionAnalyticsFilter.cs
@@ -6,8 +6,10 @@ namespace Transcendence.Service.Core.Services.Analytics.Models;
 /// <param name="RankTier">ALL, EMERALD_PLUS, Iron, Bronze, Silver, Gold, Platinum, Emerald, Diamond, Master, Grandmaster, Challenger</param>
 /// <param name="Region">Optional region filter (default: global)</param>
 /// <param name="Role">TOP, JUNGLE, MIDDLE, BOTTOM, UTILITY</param>
+/// <param name="Patch">Optional analytics patch version. Defaults to active patch.</param>
 public record ChampionAnalyticsFilter(
     string? RankTier = null,
     string? Region = null,
-    string? Role = null
+    string? Role = null,
+    string? Patch = null
 );

--- a/Transcendence.Service.Core/Services/Jobs/RefreshChampionAnalyticsJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/RefreshChampionAnalyticsJob.cs
@@ -166,7 +166,7 @@ public class RefreshChampionAnalyticsJob(
                 {
                     try
                     {
-                        await analyticsService.GetTierListAsync(role, tier, null, ct);
+                        await analyticsService.GetTierListAsync(role, tier, null, null, ct);
                         logger.LogDebug("Pre-warmed tier list: {Role}/{Tier}", role, tier);
                     }
                     catch (Exception ex)
@@ -178,7 +178,7 @@ public class RefreshChampionAnalyticsJob(
                 // Also pre-warm "all tiers" tier list per role
                 try
                 {
-                    await analyticsService.GetTierListAsync(role, null, null, ct);
+                    await analyticsService.GetTierListAsync(role, null, null, null, ct);
                     logger.LogDebug("Pre-warmed tier list: {Role}/all", role);
                 }
                 catch (Exception ex)
@@ -190,8 +190,8 @@ public class RefreshChampionAnalyticsJob(
             // Step 4: Pre-warm unified tier lists
             try
             {
-                await analyticsService.GetTierListAsync("ALL", null, null, ct);
-                await analyticsService.GetTierListAsync("ALL", "EMERALD_PLUS", null, ct);
+                await analyticsService.GetTierListAsync("ALL", null, null, null, ct);
+                await analyticsService.GetTierListAsync("ALL", "EMERALD_PLUS", null, null, ct);
                 logger.LogDebug("Pre-warmed unified tier list variants");
             }
             catch (Exception ex)
@@ -220,8 +220,8 @@ public class RefreshChampionAnalyticsJob(
                             new ChampionAnalyticsFilter(Role: role),
                             ct);
 
-                        await analyticsService.GetBuildsAsync(champ.ChampionId, role, null, null, ct);
-                        await analyticsService.GetMatchupsAsync(champ.ChampionId, role, null, null, ct);
+                        await analyticsService.GetBuildsAsync(champ.ChampionId, role, null, null, null, ct);
+                        await analyticsService.GetMatchupsAsync(champ.ChampionId, role, null, null, null, ct);
 
                         preWarmCount++;
                         logger.LogDebug("Pre-warmed analytics for champion {ChampId} in {Role}",

--- a/Transcendence.WebAPI/Controllers/AnalyticsController.cs
+++ b/Transcendence.WebAPI/Controllers/AnalyticsController.cs
@@ -4,9 +4,11 @@ using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Match;
 using Transcendence.Service.Core.Services.Analytics.Interfaces;
 using Transcendence.Service.Core.Services.Analytics.Models;
 using Transcendence.Service.Core.Services.Jobs.Configuration;
+using Transcendence.Service.Core.Services.RiotApi;
 using Transcendence.WebAPI.Security;
 
 namespace Transcendence.WebAPI.Controllers;
@@ -28,6 +30,7 @@ public class AnalyticsController(
     /// <param name="role">Optional role filter (TOP, JUNGLE, MIDDLE, BOTTOM, UTILITY). Leave empty for unified tier list across all roles.</param>
     /// <param name="rankTier">Optional rank tier filter (ALL, EMERALD_PLUS, IRON, BRONZE, SILVER, GOLD, PLATINUM, EMERALD, DIAMOND, MASTER, GRANDMASTER, CHALLENGER)</param>
     /// <param name="region">Optional platform region filter (for example NA1, EUW1, KR). Defaults to ALL/global.</param>
+    /// <param name="patch">Optional patch version. Defaults to the active analytics patch.</param>
     /// <param name="ct">Cancellation token</param>
     [HttpGet("tierlist")]
     [ProducesResponseType(typeof(TierListResponse), StatusCodes.Status200OK)]
@@ -35,9 +38,10 @@ public class AnalyticsController(
         [FromQuery] string? role = null,
         [FromQuery] string? rankTier = null,
         [FromQuery] string? region = null,
+        [FromQuery] string? patch = null,
         CancellationToken ct = default)
     {
-        var tierList = await analyticsService.GetTierListAsync(role, rankTier, region, ct);
+        var tierList = await analyticsService.GetTierListAsync(role, rankTier, region, patch, ct);
         return Ok(tierList);
     }
 
@@ -46,6 +50,56 @@ public class AnalyticsController(
     public IActionResult GetRegions()
     {
         return Ok(AnalyticsRegionCatalog.BuildAvailableRegions(multiRegionOptions.Value));
+    }
+
+    [HttpGet("patches")]
+    [ProducesResponseType(typeof(IReadOnlyList<AnalyticsPatchOptionDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPatches(CancellationToken ct = default)
+    {
+        var rankedSoloDuoMatchCounts = await db.Matches
+            .AsNoTracking()
+            .Where(m => m.Status == FetchStatus.Success)
+            .Where(m => m.Patch != null && m.Patch != string.Empty)
+            .Where(m => m.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
+                        (m.QueueId == 0 && m.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .GroupBy(m => m.Patch!)
+            .Select(g => new { Patch = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+
+        var matchCountsByPatch = rankedSoloDuoMatchCounts.ToDictionary(x => x.Patch, x => x.Count);
+        var patchesWithMatches = matchCountsByPatch.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var patchMetadata = await db.Patches
+            .AsNoTracking()
+            .Where(p => p.IsActive || patchesWithMatches.Contains(p.Version))
+            .Select(p => new { p.Version, p.ReleaseDate, p.DetectedAt, p.IsActive })
+            .ToListAsync(ct);
+
+        var optionsByPatch = patchMetadata
+            .Select(p => new AnalyticsPatchOptionDto(
+                p.Version,
+                p.ReleaseDate,
+                p.DetectedAt,
+                p.IsActive,
+                matchCountsByPatch.GetValueOrDefault(p.Version)))
+            .ToDictionary(x => x.Patch, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var matchCount in rankedSoloDuoMatchCounts)
+        {
+            optionsByPatch.TryAdd(matchCount.Patch, new AnalyticsPatchOptionDto(
+                matchCount.Patch,
+                null,
+                null,
+                false,
+                matchCount.Count));
+        }
+
+        var options = optionsByPatch.Values
+            .OrderByDescending(x => x.IsActive)
+            .ThenByDescending(x => x.ReleasedAtUtc ?? x.DetectedAtUtc ?? DateTime.MinValue)
+            .ThenByDescending(x => x.Patch)
+            .ToList();
+
+        return Ok(options);
     }
 
     [HttpGet("status")]

--- a/Transcendence.WebAPI/Controllers/ChampionAnalyticsController.cs
+++ b/Transcendence.WebAPI/Controllers/ChampionAnalyticsController.cs
@@ -22,6 +22,7 @@ public class ChampionAnalyticsController(IChampionAnalyticsService analyticsServ
     /// <param name="rankTier">Optional rank tier filter (ALL, EMERALD_PLUS, IRON, BRONZE, SILVER, GOLD, PLATINUM, EMERALD, DIAMOND, MASTER, GRANDMASTER, CHALLENGER)</param>
     /// <param name="region">Optional region filter (e.g., NA1, EUW1)</param>
     /// <param name="role">Optional role filter (TOP, JUNGLE, MIDDLE, BOTTOM, UTILITY)</param>
+    /// <param name="patch">Optional patch version. Defaults to the active analytics patch.</param>
     /// <param name="ct">Cancellation token</param>
     [HttpGet("{championId}/winrates")]
     [ProducesResponseType(typeof(ChampionWinRateSummary), StatusCodes.Status200OK)]
@@ -31,6 +32,7 @@ public class ChampionAnalyticsController(IChampionAnalyticsService analyticsServ
         [FromQuery] string? rankTier = null,
         [FromQuery] string? region = null,
         [FromQuery] string? role = null,
+        [FromQuery] string? patch = null,
         CancellationToken ct = default)
     {
         if (championId <= 0)
@@ -39,7 +41,8 @@ public class ChampionAnalyticsController(IChampionAnalyticsService analyticsServ
         var filter = new ChampionAnalyticsFilter(
             RankTier: rankTier,
             Region: region,
-            Role: role
+            Role: role,
+            Patch: patch
         );
 
         var summary = await analyticsService.GetWinRatesAsync(championId, filter, ct);
@@ -55,6 +58,7 @@ public class ChampionAnalyticsController(IChampionAnalyticsService analyticsServ
     /// <param name="role">Role: TOP, JUNGLE, MIDDLE, BOTTOM, UTILITY</param>
     /// <param name="rankTier">Optional: Filter by rank tier</param>
     /// <param name="region">Optional: Filter by platform region</param>
+    /// <param name="patch">Optional patch version. Defaults to the active analytics patch.</param>
     [HttpGet("{championId}/builds")]
     [ProducesResponseType(typeof(ChampionBuildsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -63,12 +67,13 @@ public class ChampionAnalyticsController(IChampionAnalyticsService analyticsServ
         [FromQuery] string role,
         [FromQuery] string? rankTier = null,
         [FromQuery] string? region = null,
+        [FromQuery] string? patch = null,
         CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(role))
             return BadRequest("Role parameter is required");
 
-        var result = await analyticsService.GetBuildsAsync(championId, role, rankTier, region, ct);
+        var result = await analyticsService.GetBuildsAsync(championId, role, rankTier, region, patch, ct);
         return Ok(result);
     }
 
@@ -101,6 +106,7 @@ public class ChampionAnalyticsController(IChampionAnalyticsService analyticsServ
     /// <param name="role">Role: TOP, JUNGLE, MIDDLE, BOTTOM, UTILITY</param>
     /// <param name="rankTier">Optional: Filter by rank tier</param>
     /// <param name="region">Optional: Filter by platform region</param>
+    /// <param name="patch">Optional patch version. Defaults to the active analytics patch.</param>
     [HttpGet("{championId}/matchups")]
     [ProducesResponseType(typeof(ChampionMatchupsResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -109,12 +115,13 @@ public class ChampionAnalyticsController(IChampionAnalyticsService analyticsServ
         [FromQuery] string role,
         [FromQuery] string? rankTier = null,
         [FromQuery] string? region = null,
+        [FromQuery] string? patch = null,
         CancellationToken ct = default)
     {
         if (string.IsNullOrEmpty(role))
             return BadRequest("Role parameter is required");
 
-        var result = await analyticsService.GetMatchupsAsync(championId, role, rankTier, region, ct);
+        var result = await analyticsService.GetMatchupsAsync(championId, role, rankTier, region, patch, ct);
         return Ok(result);
     }
 

--- a/apps/web/app/lol/champions/[championId]/page.tsx
+++ b/apps/web/app/lol/champions/[championId]/page.tsx
@@ -17,6 +17,8 @@ import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { pickMostSevereAnalyticsSample, type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { formatGames, formatPercent } from "@/lib/format";
+import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
+import { normalizeAnalyticsPatch } from "@/lib/lolPatchFilters";
 import { normalizeRankTierParam, rankTierDisplayLabel } from "@/lib/ranks";
 import { roleDisplayLabel } from "@/lib/roles";
 import {
@@ -71,7 +73,7 @@ export default async function ChampionDetailPage({
   searchParams
 }: {
   params: Promise<{ championId: string }>;
-  searchParams?: Promise<{ role?: string; rankTier?: string; region?: string }>;
+  searchParams?: Promise<{ role?: string; rankTier?: string; region?: string; patch?: string }>;
 }) {
   const resolvedParams = await params;
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
@@ -90,16 +92,19 @@ export default async function ChampionDetailPage({
 
   const explicitRole = normalizeRole(resolvedSearchParams?.role);
   const normalizedRankTier = normalizeRankTierParam(resolvedSearchParams?.rankTier);
+  const selectedPatch = normalizeAnalyticsPatch(resolvedSearchParams?.patch);
   const winrateQuery = new URLSearchParams();
   if (normalizedRankTier) winrateQuery.set("rankTier", normalizedRankTier);
   if (activeRegion !== "ALL") winrateQuery.set("region", activeRegion);
+  if (selectedPatch) winrateQuery.set("patch", selectedPatch);
   const qsTier = winrateQuery.toString() ? `?${winrateQuery.toString()}` : "";
 
   const verbosity = getErrorVerbosity();
-  const [staticData, itemStatic, runeStatic, winRes] = await Promise.all([
+  const [staticData, itemStatic, runeStatic, patchOptions, winRes] = await Promise.all([
     fetchChampionMap(),
     fetchItemMap(),
     fetchRunesReforged(),
+    fetchLolAnalyticsPatches(),
     fetchBackendJson<ChampionWinRateSummary>(
       `${getBackendBaseUrl()}/api/lol/analytics/champions/${championId}/winrates${qsTier}`,
       { next: { revalidate: 60 * 60 } }
@@ -116,6 +121,7 @@ export default async function ChampionDetailPage({
   ) {
     const fallbackQuery = new URLSearchParams();
     if (activeRegion !== "ALL") fallbackQuery.set("region", activeRegion);
+    if (selectedPatch) fallbackQuery.set("patch", selectedPatch);
     const fallbackWinRes = await fetchBackendJson<ChampionWinRateSummary>(
       `${getBackendBaseUrl()}/api/lol/analytics/champions/${championId}/winrates${fallbackQuery.toString() ? `?${fallbackQuery.toString()}` : ""}`,
       { next: { revalidate: 60 * 60 } }
@@ -132,6 +138,7 @@ export default async function ChampionDetailPage({
   const buildMatchupQuery = new URLSearchParams({ role: effectiveRole });
   if (normalizedRankTier) buildMatchupQuery.set("rankTier", normalizedRankTier);
   if (activeRegion !== "ALL") buildMatchupQuery.set("region", activeRegion);
+  if (selectedPatch) buildMatchupQuery.set("patch", selectedPatch);
 
   const [buildRes, matchupRes] = await Promise.all([
     fetchBackendJson<ChampionBuildsResponse>(
@@ -200,6 +207,12 @@ export default async function ChampionDetailPage({
     (builds as { sample?: unknown } | null)?.sample as AnalyticsSampleLike,
     (matchups as { sample?: unknown } | null)?.sample as AnalyticsSampleLike
   );
+  const linkParams = new URLSearchParams();
+  if (normalizedRankTier) linkParams.set("rankTier", normalizedRankTier);
+  if (activeRegion !== "ALL") linkParams.set("region", activeRegion);
+  if (selectedPatch) linkParams.set("patch", selectedPatch);
+  const linkQuery = linkParams.toString();
+  const sharedFilterParams = selectedPatch ? { patch: selectedPatch } : {};
 
   return (
     <div className="grid gap-8">
@@ -245,13 +258,13 @@ export default async function ChampionDetailPage({
                 Ban Rate —
               </span>
               <Link
-                href={`/lol/matchups/${championId}?role=${encodeURIComponent(effectiveRole)}${normalizedRankTier ? `&rankTier=${encodeURIComponent(normalizedRankTier)}` : ""}${activeRegion !== "ALL" ? `&region=${encodeURIComponent(activeRegion)}` : ""}`}
+                href={`/lol/matchups/${championId}?role=${encodeURIComponent(effectiveRole)}${linkQuery ? `&${linkQuery}` : ""}`}
                 className="rounded-full border border-primary/40 bg-primary/10 px-2 py-1 text-primary hover:bg-primary/20"
               >
                 Matchup Analysis
               </Link>
               <Link
-                href={`/lol/pro-builds/${championId}${activeRegion !== "ALL" ? `?region=${encodeURIComponent(activeRegion)}` : ""}`}
+                href={`/lol/pro-builds/${championId}${linkQuery ? `?${linkQuery}` : ""}`}
                 className="rounded-full border border-primary/40 bg-primary/10 px-2 py-1 text-primary hover:bg-primary/20"
               >
                 Pro Builds
@@ -275,6 +288,9 @@ export default async function ChampionDetailPage({
           activeRank={normalizedRankTier ?? "all"}
           regionOptions={regionOptions}
           activeRegion={activeRegion}
+          patchOptions={patchOptions}
+          activePatch={selectedPatch}
+          extraParams={sharedFilterParams}
           baseHref={`/lol/champions/${championId}`}
         />
         <div className="mt-3">
@@ -294,7 +310,7 @@ export default async function ChampionDetailPage({
             <p className="mt-1 text-xs text-muted">Try selecting a different region or check back after patch data has been processed.</p>
           </div>
         ) : winrateRows.length === 0 ? (
-          <p className="mt-2 text-sm text-fg/75">No games have been added for this patch yet.</p>
+          <p className="mt-2 text-sm text-fg/75">No games have been added for the selected patch yet.</p>
         ) : (
           <div className="mt-4 overflow-x-auto">
             <table className="w-full text-left text-sm">
@@ -447,7 +463,7 @@ export default async function ChampionDetailPage({
                           className="flex items-center justify-between rounded-md border border-border/50 bg-white/[0.02] px-3 py-2"
                         >
                           <Link
-                            href={`/lol/champions/${opponentChampionId}`}
+                            href={`/lol/champions/${opponentChampionId}${linkQuery ? `?${linkQuery}` : ""}`}
                             className="flex min-w-0 items-center gap-2 hover:underline"
                           >
                             <ChampionPortrait
@@ -496,7 +512,7 @@ export default async function ChampionDetailPage({
                           className="flex items-center justify-between rounded-md border border-border/50 bg-white/[0.02] px-3 py-2"
                         >
                           <Link
-                            href={`/lol/champions/${opponentChampionId}`}
+                            href={`/lol/champions/${opponentChampionId}${linkQuery ? `?${linkQuery}` : ""}`}
                             className="flex min-w-0 items-center gap-2 hover:underline"
                           >
                             <ChampionPortrait

--- a/apps/web/app/lol/matchups/[championId]/page.tsx
+++ b/apps/web/app/lol/matchups/[championId]/page.tsx
@@ -14,6 +14,8 @@ import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { pickMostSevereAnalyticsSample, type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { formatGames } from "@/lib/format";
+import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
+import { normalizeAnalyticsPatch } from "@/lib/lolPatchFilters";
 import { normalizeRankTierParam, rankTierDisplayLabel } from "@/lib/ranks";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl, fetchChampionMap } from "@/lib/staticData";
@@ -53,17 +55,20 @@ function buildSortHref({
   role,
   rankTier,
   region,
+  patch,
   sort
 }: {
   championId: number;
   role: string;
   rankTier: string | null;
   region: string;
+  patch: string | null;
   sort: string;
 }) {
   const params = new URLSearchParams({ role, sort });
   if (rankTier) params.set("rankTier", rankTier);
   if (region !== "ALL") params.set("region", region);
+  if (patch) params.set("patch", patch);
   return `/lol/matchups/${championId}?${params.toString()}`;
 }
 
@@ -72,7 +77,7 @@ export default async function MatchupAnalysisPage({
   searchParams
 }: {
   params: Promise<{ championId: string }>;
-  searchParams?: Promise<{ role?: string; rankTier?: string; sort?: string; region?: string }>;
+  searchParams?: Promise<{ role?: string; rankTier?: string; sort?: string; region?: string; patch?: string }>;
 }) {
   const resolvedParams = await params;
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
@@ -86,15 +91,18 @@ export default async function MatchupAnalysisPage({
 
   const explicitRole = normalizeRole(resolvedSearchParams?.role);
   const normalizedRankTier = normalizeRankTierParam(resolvedSearchParams?.rankTier);
+  const selectedPatch = normalizeAnalyticsPatch(resolvedSearchParams?.patch);
   const sortKey = resolvedSearchParams?.sort === "games" ? "games" : "winRate";
 
   const verbosity = getErrorVerbosity();
   const winrateQuery = new URLSearchParams();
   if (normalizedRankTier) winrateQuery.set("rankTier", normalizedRankTier);
   if (activeRegion !== "ALL") winrateQuery.set("region", activeRegion);
+  if (selectedPatch) winrateQuery.set("patch", selectedPatch);
   const qsTier = winrateQuery.toString() ? `?${winrateQuery.toString()}` : "";
-  const [staticData, winRes] = await Promise.all([
+  const [staticData, patchOptions, winRes] = await Promise.all([
     fetchChampionMap(),
+    fetchLolAnalyticsPatches(),
     fetchBackendJson<ChampionWinRateSummary>(
       `${getBackendBaseUrl()}/api/lol/analytics/champions/${championId}/winrates${qsTier}`,
       { next: { revalidate: 60 * 60 } }
@@ -107,6 +115,7 @@ export default async function MatchupAnalysisPage({
   const matchupQuery = new URLSearchParams({ role: effectiveRole });
   if (normalizedRankTier) matchupQuery.set("rankTier", normalizedRankTier);
   if (activeRegion !== "ALL") matchupQuery.set("region", activeRegion);
+  if (selectedPatch) matchupQuery.set("patch", selectedPatch);
   const matchupRes = await fetchBackendJson<ChampionMatchupsResponse>(
     `${getBackendBaseUrl()}/api/lol/analytics/champions/${championId}/matchups?${matchupQuery.toString()}`,
     { next: { revalidate: 60 * 60 } }
@@ -163,6 +172,12 @@ export default async function MatchupAnalysisPage({
     (winrates as { sample?: unknown } | null)?.sample as AnalyticsSampleLike,
     (matchups as { sample?: unknown } | null)?.sample as AnalyticsSampleLike
   );
+  const championLinkParams = new URLSearchParams();
+  if (normalizedRankTier) championLinkParams.set("rankTier", normalizedRankTier);
+  if (activeRegion !== "ALL") championLinkParams.set("region", activeRegion);
+  if (selectedPatch) championLinkParams.set("patch", selectedPatch);
+  const championLinkQuery = championLinkParams.toString();
+  const sharedFilterParams = selectedPatch ? { patch: selectedPatch } : {};
 
   return (
     <div className="grid gap-6">
@@ -179,7 +194,7 @@ export default async function MatchupAnalysisPage({
             <h1 className="type-page-title">
               Matchup Analysis
             </h1>
-            <p className="type-ui mt-2 text-fg/75">How {championName} performs into the current field.</p>
+            <p className="type-ui mt-2 text-fg/75">How {championName} performs into the selected patch field.</p>
           </div>
         </div>
 
@@ -199,6 +214,9 @@ export default async function MatchupAnalysisPage({
           activeRank={normalizedRankTier ?? "all"}
           regionOptions={regionOptions}
           activeRegion={activeRegion}
+          patchOptions={patchOptions}
+          activePatch={selectedPatch}
+          extraParams={sharedFilterParams}
           baseHref={`/lol/matchups/${championId}`}
         />
         <div className="mt-3">
@@ -219,7 +237,7 @@ export default async function MatchupAnalysisPage({
                 const opponent = champions[String(opponentId)];
                 return (
                   <li key={`${opponentId}-${idx}`} className="surface-subtle flex items-center justify-between rounded-card px-3 py-2">
-                    <Link href={`/lol/champions/${opponentId}${activeRegion !== "ALL" ? `?region=${encodeURIComponent(activeRegion)}` : ""}`} className="min-w-0 hover:underline">
+                    <Link href={`/lol/champions/${opponentId}${championLinkQuery ? `?${championLinkQuery}` : ""}`} className="min-w-0 hover:underline">
                       <ChampionPortrait
                         championSlug={opponent?.id ?? "Unknown"}
                         championName={opponent?.name ?? `Champion ${opponentId}`}
@@ -249,7 +267,7 @@ export default async function MatchupAnalysisPage({
                 const opponent = champions[String(opponentId)];
                 return (
                   <li key={`${opponentId}-${idx}`} className="surface-subtle flex items-center justify-between rounded-card px-3 py-2">
-                    <Link href={`/lol/champions/${opponentId}${activeRegion !== "ALL" ? `?region=${encodeURIComponent(activeRegion)}` : ""}`} className="min-w-0 hover:underline">
+                    <Link href={`/lol/champions/${opponentId}${championLinkQuery ? `?${championLinkQuery}` : ""}`} className="min-w-0 hover:underline">
                       <ChampionPortrait
                         championSlug={opponent?.id ?? "Unknown"}
                         championName={opponent?.name ?? `Champion ${opponentId}`}
@@ -278,6 +296,7 @@ export default async function MatchupAnalysisPage({
                 role: effectiveRole,
                 rankTier: normalizedRankTier,
                 region: activeRegion,
+                patch: selectedPatch,
                 sort: "winRate"
               })}
               className={`control-tab type-ui px-3 py-2 ${
@@ -295,6 +314,7 @@ export default async function MatchupAnalysisPage({
                 role: effectiveRole,
                 rankTier: normalizedRankTier,
                 region: activeRegion,
+                patch: selectedPatch,
                 sort: "games"
               })}
               className={`control-tab type-ui px-3 py-2 ${
@@ -334,7 +354,7 @@ export default async function MatchupAnalysisPage({
                   return (
                     <tr key={`${opponentId}-${idx}`} className="border-b border-border/20">
                       <td className="py-2.5 pr-4">
-                        <Link href={`/lol/champions/${opponentId}${activeRegion !== "ALL" ? `?region=${encodeURIComponent(activeRegion)}` : ""}`} className="hover:underline">
+                        <Link href={`/lol/champions/${opponentId}${championLinkQuery ? `?${championLinkQuery}` : ""}`} className="hover:underline">
                           <ChampionPortrait
                             championSlug={opponent?.id ?? "Unknown"}
                             championName={opponent?.name ?? `Champion ${opponentId}`}

--- a/apps/web/app/lol/pro-builds/[championId]/page.tsx
+++ b/apps/web/app/lol/pro-builds/[championId]/page.tsx
@@ -4,6 +4,7 @@ import type { components } from "@transcendence/api-client";
 
 import { BackendErrorCard } from "@/components/BackendErrorCard";
 import { AnalyticsSampleBanner } from "@/components/AnalyticsSampleBanner";
+import { AnalyticsPatchFilter } from "@/components/AnalyticsPatchFilter";
 import { AnalyticsRegionFilter } from "@/components/AnalyticsRegionFilter";
 import { RoleFilterTabs } from "@/components/RoleFilterTabs";
 import { RuneSetupDisplay } from "@/components/RuneSetupDisplay";
@@ -15,6 +16,7 @@ import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { pickMostSevereAnalyticsSample, type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { formatDateTimeMs, formatRelativeTime } from "@/lib/format";
+import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
 import {
   buildProBuildFilterParams,
   buildProBuildPageHref,
@@ -104,15 +106,18 @@ export default async function ProBuildsChampionPage({
     patch: patchFilter
   });
   const proFilterQuery = proFilters.toString();
+  const winrateQuery = new URLSearchParams();
+  if (patchFilter) winrateQuery.set("patch", patchFilter);
 
   const verbosity = getErrorVerbosity();
-  const [{ version, champions }, itemStatic, runeStatic, winratesRes, proBuildsRes] =
+  const [{ version, champions }, itemStatic, runeStatic, patchOptions, winratesRes, proBuildsRes] =
     await Promise.all([
     fetchChampionMap(),
     fetchItemMap(),
     fetchRunesReforged(),
+    fetchLolAnalyticsPatches(),
     fetchBackendJson<ChampionWinRateSummary>(
-      `${getBackendBaseUrl()}/api/lol/analytics/champions/${championId}/winrates`,
+      `${getBackendBaseUrl()}/api/lol/analytics/champions/${championId}/winrates${winrateQuery.toString() ? `?${winrateQuery.toString()}` : ""}`,
       { next: { revalidate: 60 * 60 } }
     ),
     fetchBackendJson<ChampionProBuildsResponse>(
@@ -214,40 +219,19 @@ export default async function ProBuildsChampionPage({
             extraParams={roleExtraParams}
           />
           <AnalyticsRegionFilter options={regionOptions} activeRegion={activeRegion} />
-          <form action={`/lol/pro-builds/${championId}`} method="get" className="flex flex-wrap items-center gap-2">
-            {roleFilter !== "ALL" ? <input type="hidden" name="role" value={roleFilter} /> : null}
-            {regionFilter !== "ALL" ? (
-              <input type="hidden" name="region" value={regionFilter} />
-            ) : null}
-            <label htmlFor="patch" className="text-xs text-muted">
-              Patch
-            </label>
-            <input
-              id="patch"
-              name="patch"
-              defaultValue={patchFilter ?? ""}
-              placeholder="14.5"
-              className="control-input h-9 w-28 rounded-control px-3 text-sm"
-            />
-            <button
-              type="submit"
-              className="h-9 rounded-control border border-primary/40 bg-primary/10 px-3 text-sm font-semibold text-primary hover:bg-primary/20"
+          <AnalyticsPatchFilter patches={patchOptions} activePatch={patchFilter} />
+          {patchFilter ? (
+            <Link
+              href={buildProBuildPageHref(championId, {
+                role: roleFilter,
+                region: regionFilter,
+                patch: null
+              })}
+              className="control-tab type-ui h-9 px-3"
             >
-              Apply
-            </button>
-            {patchFilter ? (
-              <Link
-                href={buildProBuildPageHref(championId, {
-                  role: roleFilter,
-                  region: regionFilter,
-                  patch: null
-                })}
-                className="control-tab type-ui h-9 px-3"
-              >
-                Clear
-              </Link>
-            ) : null}
-          </form>
+              Clear Patch
+            </Link>
+          ) : null}
         </div>
       </Card>
 

--- a/apps/web/app/lol/tierlist/page.tsx
+++ b/apps/web/app/lol/tierlist/page.tsx
@@ -14,6 +14,8 @@ import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { GLOBAL_ANALYTICS_REGION } from "@/lib/analyticsRegionShared";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
+import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
+import { normalizeAnalyticsPatch } from "@/lib/lolPatchFilters";
 import {
   DEFAULT_TIERLIST_RANK_TIER,
   normalizeRankTierParam,
@@ -28,7 +30,7 @@ type TierListResponse = components["schemas"]["TierListResponse"];
 export default async function TierListPage({
   searchParams
 }: {
-  searchParams?: Promise<{ role?: string; rankTier?: string; region?: string }>;
+  searchParams?: Promise<{ role?: string; rankTier?: string; region?: string; patch?: string }>;
 }) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const { activeRegion, activeRegionLabel, options: regionOptions } = await resolveAnalyticsRegion(
@@ -37,6 +39,7 @@ export default async function TierListPage({
   const roleParam = (resolvedSearchParams?.role ?? "").toUpperCase();
   const rawRankParam = resolvedSearchParams?.rankTier ?? null;
   const normalizedRankParam = normalizeRankTierParam(rawRankParam);
+  const selectedPatch = normalizeAnalyticsPatch(resolvedSearchParams?.patch);
   const useDefaultRank = rawRankParam == null || rawRankParam.trim().length === 0;
   const effectiveRankParam = useDefaultRank ? DEFAULT_TIERLIST_RANK_TIER : normalizedRankParam;
 
@@ -46,6 +49,7 @@ export default async function TierListPage({
     if (roleParam && roleParam !== "ALL") requestQuery.set("role", roleParam);
     if (effectiveRankParam) requestQuery.set("rankTier", effectiveRankParam);
     if (region !== GLOBAL_ANALYTICS_REGION) requestQuery.set("region", region);
+    if (selectedPatch) requestQuery.set("patch", selectedPatch);
 
     return fetchBackendJson<TierListResponse>(
       `${getBackendBaseUrl()}/api/lol/analytics/tierlist?${requestQuery.toString()}`,
@@ -61,6 +65,8 @@ export default async function TierListPage({
     effectiveRegionLabel,
     fallbackMessage
   } = resolveAnalyticsRegionPresentation(activeRegion, activeRegionLabel, regionOptions, usedGlobalFallback);
+  const patchOptions = await fetchLolAnalyticsPatches();
+  const sharedFilterParams = selectedPatch ? { patch: selectedPatch } : {};
 
   if (!res.ok) {
     return (
@@ -89,6 +95,9 @@ export default async function TierListPage({
             activeRank={effectiveRankParam ?? "all"}
             regionOptions={regionOptions}
             activeRegion={activeRegion}
+            patchOptions={patchOptions}
+            activePatch={selectedPatch}
+            extraParams={sharedFilterParams}
             baseHref="/lol/tierlist"
             className="mt-0"
           />
@@ -141,6 +150,9 @@ export default async function TierListPage({
           activeRank={effectiveRankParam ?? "all"}
           regionOptions={regionOptions}
           activeRegion={effectiveRegion}
+          patchOptions={patchOptions}
+          activePatch={selectedPatch}
+          extraParams={sharedFilterParams}
           baseHref="/lol/tierlist"
           className="mt-4"
         />
@@ -152,6 +164,7 @@ export default async function TierListPage({
         version={version}
         rankTierValue={rankTierValue}
         activeRegion={effectiveRegion}
+        activePatch={selectedPatch}
       />
     </div>
   );

--- a/apps/web/components/AnalyticsPatchFilter.tsx
+++ b/apps/web/components/AnalyticsPatchFilter.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { type LolAnalyticsPatchOption } from "@/lib/lolPatchFilters";
+
+export function AnalyticsPatchFilter({
+  patches,
+  activePatch,
+  className
+}: {
+  patches: readonly LolAnalyticsPatchOption[];
+  activePatch?: string | null;
+  className?: string;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const normalizedActivePatch = activePatch?.trim() ?? "";
+  const hasActivePatchOption = patches.some((option) => option.patch === normalizedActivePatch);
+
+  function handleChange(event: React.ChangeEvent<HTMLSelectElement>) {
+    const patch = event.target.value;
+    const nextParams = new URLSearchParams(searchParams.toString());
+    if (patch) {
+      nextParams.set("patch", patch);
+    } else {
+      nextParams.delete("patch");
+    }
+
+    const nextUrl = nextParams.toString() ? `${pathname}?${nextParams.toString()}` : pathname;
+    router.push(nextUrl);
+  }
+
+  return (
+    <select
+      value={normalizedActivePatch}
+      onChange={handleChange}
+      className={className ?? "control-select min-w-[148px]"}
+      aria-label="Patch"
+    >
+      <option value="">Current Patch</option>
+      {normalizedActivePatch && !hasActivePatchOption ? (
+        <option value={normalizedActivePatch}>Patch {normalizedActivePatch}</option>
+      ) : null}
+      {patches.map((option) => (
+        <option key={option.patch} value={option.patch}>
+          {option.isActive ? `Current (${option.patch})` : `Patch ${option.patch}`}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/apps/web/components/AnalyticsSampleBanner.tsx
+++ b/apps/web/components/AnalyticsSampleBanner.tsx
@@ -44,7 +44,7 @@ export function AnalyticsSampleBanner({ sample }: AnalyticsSampleBannerProps) {
             card: "border-danger/40 bg-danger/10",
             badge: "border-danger/40 bg-danger/20 text-fg",
             kicker: "Early sample",
-            summary: "Treat this as early direction until more current-patch games land."
+            summary: "Treat this as early direction until more selected-patch games land."
           };
   const phaseLabel =
     normalized.patchPhase === "bootstrap"

--- a/apps/web/components/FilterBar.tsx
+++ b/apps/web/components/FilterBar.tsx
@@ -2,8 +2,10 @@
 
 import { cn } from "@/lib/cn";
 import { type AnalyticsRegionOption } from "@/lib/analyticsRegionShared";
+import { type LolAnalyticsPatchOption } from "@/lib/lolPatchFilters";
 import { RANK_TIER_FILTERS } from "@/lib/ranks";
 
+import { AnalyticsPatchFilter } from "./AnalyticsPatchFilter";
 import { AnalyticsRegionFilter } from "./AnalyticsRegionFilter";
 import { RankFilterDropdown } from "./RankFilterDropdown";
 import { RoleFilterTabs } from "./RoleFilterTabs";
@@ -18,6 +20,9 @@ export function FilterBar({
   activeRank = "all",
   regionOptions,
   activeRegion,
+  patchOptions,
+  activePatch,
+  extraParams,
   baseHref,
   className
 }: {
@@ -27,15 +32,25 @@ export function FilterBar({
   activeRank?: string;
   regionOptions?: readonly AnalyticsRegionOption[];
   activeRegion?: string;
+  patchOptions?: readonly LolAnalyticsPatchOption[];
+  activePatch?: string | null;
+  extraParams?: Record<string, string | null | undefined>;
   baseHref: string;
   className?: string;
 }) {
-  const roleExtraParams: Record<string, string> = {};
+  const sharedExtraParams: Record<string, string> = {};
+  if (extraParams) {
+    for (const [key, value] of Object.entries(extraParams)) {
+      if (value && value.toLowerCase() !== "all") sharedExtraParams[key] = value;
+    }
+  }
+
+  const roleExtraParams: Record<string, string> = { ...sharedExtraParams };
   if (activeRank && activeRank.toLowerCase() !== "all") {
     roleExtraParams.rankTier = activeRank;
   }
 
-  const rankExtraParams: Record<string, string> = {};
+  const rankExtraParams: Record<string, string> = { ...sharedExtraParams };
   if (activeRole && activeRole.toUpperCase() !== "ALL") {
     rankExtraParams.role = activeRole;
   }
@@ -56,6 +71,9 @@ export function FilterBar({
       />
       {regionOptions && activeRegion ? (
         <AnalyticsRegionFilter options={regionOptions} activeRegion={activeRegion} />
+      ) : null}
+      {patchOptions ? (
+        <AnalyticsPatchFilter patches={patchOptions} activePatch={activePatch} />
       ) : null}
     </div>
   );

--- a/apps/web/components/TierListTable.tsx
+++ b/apps/web/components/TierListTable.tsx
@@ -89,13 +89,15 @@ export function TierListTable({
   champions,
   version,
   rankTierValue,
-  activeRegion
+  activeRegion,
+  activePatch
 }: {
   entries: UITierListEntry[];
   champions: TierListChampionMap;
   version: string;
   rankTierValue: string | null;
   activeRegion: string;
+  activePatch?: string | null;
 }) {
   const [sortCol, setSortCol] = useState<SortColumn>("rank");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
@@ -292,6 +294,11 @@ export function TierListTable({
     const championName = champion?.name ?? `Champion ${entry.championId}`;
     const championSlug = champion?.id ?? "Unknown";
     const championSubtitle = champion?.title ?? "";
+    const rowParams = new URLSearchParams({ role: entry.role });
+    if (rankTierValue) rowParams.set("rankTier", rankTierValue);
+    if (activeRegion !== "ALL") rowParams.set("region", activeRegion);
+    if (activePatch) rowParams.set("patch", activePatch);
+    const rowQuery = rowParams.toString();
 
     return (
       <tr key={`${entry.tier}-${entry.role}-${entry.championId}`} className="tierlist-row border-b border-border/20 text-sm">
@@ -301,7 +308,7 @@ export function TierListTable({
         </td>
         <td className="px-2 py-3 md:px-3">
           <Link
-            href={`/lol/champions/${entry.championId}?role=${encodeURIComponent(entry.role)}${rankTierValue ? `&rankTier=${encodeURIComponent(rankTierValue)}` : ""}${activeRegion !== "ALL" ? `&region=${encodeURIComponent(activeRegion)}` : ""}`}
+            href={`/lol/champions/${entry.championId}?${rowQuery}`}
             className="flex items-center gap-2 hover:underline md:gap-2.5"
           >
             <Image
@@ -345,7 +352,7 @@ export function TierListTable({
         </td>
         <td className="hidden px-3 py-3 text-right lg:table-cell">
           <Link
-            href={`/lol/matchups/${entry.championId}?role=${encodeURIComponent(entry.role)}${rankTierValue ? `&rankTier=${encodeURIComponent(rankTierValue)}` : ""}`}
+            href={`/lol/matchups/${entry.championId}?${rowQuery}`}
             className="text-xs text-primary hover:underline"
           >
             Analyze
@@ -353,7 +360,7 @@ export function TierListTable({
         </td>
         <td className="hidden px-3 py-3 text-right lg:table-cell">
           <Link
-            href={`/lol/champions/${entry.championId}?role=${encodeURIComponent(entry.role)}${rankTierValue ? `&rankTier=${encodeURIComponent(rankTierValue)}` : ""}#builds`}
+            href={`/lol/champions/${entry.championId}?${rowQuery}#builds`}
             className="text-xs text-primary hover:underline"
           >
             Open

--- a/apps/web/lib/lolAnalyticsPatches.ts
+++ b/apps/web/lib/lolAnalyticsPatches.ts
@@ -1,0 +1,14 @@
+import "server-only";
+
+import { fetchBackendJson } from "@/lib/backendCall";
+import { getBackendBaseUrl } from "@/lib/env";
+import { type LolAnalyticsPatchOption } from "@/lib/lolPatchFilters";
+
+export async function fetchLolAnalyticsPatches(): Promise<LolAnalyticsPatchOption[]> {
+  const res = await fetchBackendJson<LolAnalyticsPatchOption[]>(
+    `${getBackendBaseUrl()}/api/lol/analytics/patches`,
+    { next: { revalidate: 60 * 10 } }
+  );
+
+  return res.ok ? (res.body ?? []) : [];
+}

--- a/apps/web/lib/lolPatchFilters.test.ts
+++ b/apps/web/lib/lolPatchFilters.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPatchPreservingParams, normalizeAnalyticsPatch } from "./lolPatchFilters";
+
+describe("normalizeAnalyticsPatch", () => {
+  it("trims patch values", () => {
+    expect(normalizeAnalyticsPatch(" 15.1 ")).toBe("15.1");
+  });
+
+  it("treats blank patches as absent", () => {
+    expect(normalizeAnalyticsPatch("")).toBeNull();
+    expect(normalizeAnalyticsPatch("   ")).toBeNull();
+    expect(normalizeAnalyticsPatch(null)).toBeNull();
+  });
+});
+
+describe("buildPatchPreservingParams", () => {
+  it("keeps meaningful query params and drops ALL-like defaults", () => {
+    const params = buildPatchPreservingParams({
+      role: "MIDDLE",
+      rankTier: "all",
+      region: "KR",
+      patch: "15.1",
+      empty: ""
+    });
+
+    expect(params.toString()).toBe("role=MIDDLE&region=KR&patch=15.1");
+  });
+});

--- a/apps/web/lib/lolPatchFilters.ts
+++ b/apps/web/lib/lolPatchFilters.ts
@@ -1,0 +1,23 @@
+export type LolAnalyticsPatchOption = {
+  patch: string;
+  releasedAtUtc?: string | null;
+  detectedAtUtc?: string | null;
+  isActive: boolean;
+  rankedSoloDuoMatchCount: number;
+};
+
+export function normalizeAnalyticsPatch(patch: string | undefined | null): string | null {
+  if (!patch) return null;
+  const trimmed = patch.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function buildPatchPreservingParams(params: Record<string, string | null | undefined>): URLSearchParams {
+  const next = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (!value) continue;
+    if (value.toLowerCase() === "all") continue;
+    next.set(key, value);
+  }
+  return next;
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -120,6 +120,7 @@ Example (`SummonerAcceptedResponse`):
 - `GET /api/lol/analytics/tierlist`
 - `GET /api/lol/analytics/regions`
 - `GET /api/lol/analytics/status`
+- `GET /api/lol/analytics/patches`
 - `GET /api/lol/analytics/champions/{championId}/winrates`
 - `GET /api/lol/analytics/champions/{championId}/builds`
 - `GET /api/lol/analytics/champions/{championId}/pro-builds`
@@ -127,7 +128,8 @@ Example (`SummonerAcceptedResponse`):
 - `POST /api/lol/analytics/cache/invalidate` (`AppOnly`)
 
 Early-patch semantics:
-- Analytics endpoints return **current active patch data only** (no previous-patch fallback payloads).
+- Analytics endpoints default to the active patch and support a `patch` query parameter for stored historical patches.
+- Historical patch requests do not fall back to another patch; unknown patch values return empty `200 OK` payloads with the requested patch echoed.
 - Responses now include `sample` metadata for UI messaging:
   - `sampleStatus` (`sufficient`, `low_sample`, `no_data`)
   - `sampleSize`
@@ -137,7 +139,7 @@ Early-patch semantics:
   - `patchPhase` (`bootstrap`, `provisional`, `maturing`, `steady`)
   - `isProvisional`
 - `low_sample` and `no_data` are expected during early patch windows while ingestion ramps up.
-- Tier-list entries may omit `movement` / `previousTier` while previous-patch comparisons are unavailable; current-patch rankings remain the primary response.
+- Tier-list entries may omit `movement` / `previousTier` while previous-patch comparisons are unavailable; selected-patch rankings remain the primary response.
 
 `rankTier` query semantics across tier list, win rates, builds, and matchups:
 - `all` (or omitted): no rank filter
@@ -150,10 +152,22 @@ Early-patch semantics:
 - Supported public region tokens are discoverable via `GET /api/lol/analytics/regions`
 - Tier list, builds, and matchup responses now echo the resolved `region` field so the UI can badge active scope without guessing
 
+`patch` query semantics across tier list, win rates, builds, matchups, and pro builds:
+- Omitted: use the backend-owned active analytics patch
+- Exact patch token: query that patch's persisted match/static-data slice
+- Available patch options are discoverable via `GET /api/lol/analytics/patches`
+
 `GET /api/lol/analytics/status` returns the backend-owned active LoL analytics patch metadata:
 - `patch`
 - `activePatchReleasedAtUtc`
 - `activePatchDetectedAtUtc`
+
+`GET /api/lol/analytics/patches` returns public patch options:
+- `patch`
+- `releasedAtUtc`
+- `detectedAtUtc`
+- `isActive`
+- `rankedSoloDuoMatchCount`
 
 `GET /api/lol/analytics/champions/{championId}/builds` includes full rune setup per build:
 - `primaryStyleId`, `subStyleId`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -211,9 +211,11 @@ Operational implication:
 
 ### Analytics Response Semantics
 
-- Analytics APIs intentionally do not fall back to previous patch payloads.
-- Responses include sample metadata (`sampleStatus`, `sampleSize`, `minimumRecommendedSampleSize`, `patchAgeHours`, `isEarlyPatchWindow`) so web surfaces can show early-patch low-sample/no-data states explicitly.
+- Analytics APIs default to the active patch and can query stored historical patches with a `patch` query parameter.
+- Analytics APIs intentionally do not fall back to a different patch payload when the selected patch has no data.
+- Responses include sample metadata (`sampleStatus`, `sampleSize`, `minimumRecommendedSampleSize`, `patchAgeHours`, `isEarlyPatchWindow`) so web surfaces can show selected-patch low-sample/no-data states explicitly.
 - `GET /api/lol/analytics/status` is the lightweight source of truth for the active LoL analytics patch used by public web chrome and landing surfaces.
+- `GET /api/lol/analytics/patches` lists active and historical LoL patches available to public analytics filters.
 
 ### Match Queue Scope and History
 

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -1072,6 +1072,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "patch",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1168,6 +1175,64 @@
                   "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/AnalyticsRegionDto"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/lol/analytics/patches": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "responses": {
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AnalyticsPatchOptionDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AnalyticsPatchOptionDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AnalyticsPatchOptionDto"
                   }
                 }
               }
@@ -1886,6 +1951,13 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "patch",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1983,6 +2055,13 @@
           },
           {
             "name": "region",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "patch",
             "in": "query",
             "schema": {
               "type": "string"
@@ -2185,6 +2264,13 @@
           },
           {
             "name": "region",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "patch",
             "in": "query",
             "schema": {
               "type": "string"
@@ -5690,6 +5776,33 @@
               "$ref": "#/components/schemas/AdminServiceLogDto"
             },
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AnalyticsPatchOptionDto": {
+        "type": "object",
+        "properties": {
+          "patch": {
+            "type": "string",
+            "nullable": true
+          },
+          "releasedAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "detectedAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "rankedSoloDuoMatchCount": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -1013,6 +1013,7 @@ export interface paths {
                     role?: string;
                     rankTier?: string;
                     region?: string;
+                    patch?: string;
                 };
                 header?: never;
                 path?: never;
@@ -1077,6 +1078,54 @@ export interface paths {
                         "text/plain": components["schemas"]["AnalyticsRegionDto"][];
                         "application/json": components["schemas"]["AnalyticsRegionDto"][];
                         "text/json": components["schemas"]["AnalyticsRegionDto"][];
+                    };
+                };
+                /** @description Too Many Requests */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["ProblemDetails"];
+                        "application/json": components["schemas"]["ProblemDetails"];
+                        "text/json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/lol/analytics/patches": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["AnalyticsPatchOptionDto"][];
+                        "application/json": components["schemas"]["AnalyticsPatchOptionDto"][];
+                        "text/json": components["schemas"]["AnalyticsPatchOptionDto"][];
                     };
                 };
                 /** @description Too Many Requests */
@@ -1752,6 +1801,7 @@ export interface paths {
                     rankTier?: string;
                     region?: string;
                     role?: string;
+                    patch?: string;
                 };
                 header?: never;
                 path: {
@@ -1817,6 +1867,7 @@ export interface paths {
                     role?: string;
                     rankTier?: string;
                     region?: string;
+                    patch?: string;
                 };
                 header?: never;
                 path: {
@@ -1947,6 +1998,7 @@ export interface paths {
                     role?: string;
                     rankTier?: string;
                     region?: string;
+                    patch?: string;
                 };
                 header?: never;
                 path: {
@@ -4370,6 +4422,16 @@ export interface components {
         AdminServiceLogsResponse: {
             source?: components["schemas"]["AdminLogSourceDto"];
             items?: components["schemas"]["AdminServiceLogDto"][] | null;
+        };
+        AnalyticsPatchOptionDto: {
+            patch?: string | null;
+            /** Format: date-time */
+            releasedAtUtc?: string | null;
+            /** Format: date-time */
+            detectedAtUtc?: string | null;
+            isActive?: boolean;
+            /** Format: int32 */
+            rankedSoloDuoMatchCount?: number;
         };
         /**
          * Format: int32

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
@@ -37,7 +37,7 @@ public class ChampionAnalyticsServiceTests
         });
         await harness.Db.SaveChangesAsync();
 
-        var result = await harness.Service.GetTierListAsync("ALL", null, null, CancellationToken.None);
+        var result = await harness.Service.GetTierListAsync("ALL", null, null, null, CancellationToken.None);
 
         result.Patch.Should().Be("Unknown");
         result.Entries.Should().BeEmpty();
@@ -136,13 +136,99 @@ public class ChampionAnalyticsServiceTests
     }
 
     [Fact]
+    public async Task GetWinRatesAsync_RequestedHistoricalPatch_UsesRequestedPatchAndStableSamplePhase()
+    {
+        await using var harness = await Harness.CreateAsync();
+        harness.SetActivePatch("15.2", DateTime.UtcNow.AddHours(-2));
+        harness.SetInactivePatch("15.1", DateTime.UtcNow.AddHours(-400));
+        harness.ComputeService
+            .Setup(x => x.ComputeWinRatesAsync(
+                103,
+                It.Is<ChampionAnalyticsFilter>(filter => filter.Patch == "15.1"),
+                "15.1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ChampionWinRateDto(103, "MIDDLE", "EMERALD_PLUS", 24, 14, 0.583, 0.12, 0.01, 2, 40, "15.1")
+            ]);
+        await harness.Db.SaveChangesAsync();
+
+        var result = await harness.Service.GetWinRatesAsync(
+            103,
+            new ChampionAnalyticsFilter(RankTier: "EMERALD_PLUS", Patch: "15.1"),
+            CancellationToken.None);
+
+        result.Patch.Should().Be("15.1");
+        result.Sample.Should().NotBeNull();
+        result.Sample!.PatchPhase.Should().Be(AnalyticsPatchPhase.Steady);
+        result.Sample.IsProvisional.Should().BeFalse();
+        result.Sample.IsEarlyPatchWindow.Should().BeFalse();
+        harness.ComputeService.Verify(x => x.ComputeWinRatesAsync(
+            103,
+            It.Is<ChampionAnalyticsFilter>(filter => filter.Patch == "15.1"),
+            "15.1",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetWinRatesAsync_SelectedPatch_IsPartOfCacheIdentity()
+    {
+        await using var harness = await Harness.CreateAsync();
+        harness.SetActivePatch("15.2", DateTime.UtcNow.AddHours(-2));
+        harness.SetInactivePatch("15.1", DateTime.UtcNow.AddHours(-400));
+        harness.ComputeService
+            .Setup(x => x.ComputeWinRatesAsync(
+                103,
+                It.IsAny<ChampionAnalyticsFilter>(),
+                "15.2",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ChampionWinRateDto(103, "MIDDLE", "EMERALD_PLUS", 5, 3, 0.6, 0.12, 0.01, 1, 40, "15.2")
+            ]);
+        harness.ComputeService
+            .Setup(x => x.ComputeWinRatesAsync(
+                103,
+                It.IsAny<ChampionAnalyticsFilter>(),
+                "15.1",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+            [
+                new ChampionWinRateDto(103, "MIDDLE", "EMERALD_PLUS", 24, 14, 0.583, 0.12, 0.01, 2, 40, "15.1")
+            ]);
+        await harness.Db.SaveChangesAsync();
+
+        var activeResult = await harness.Service.GetWinRatesAsync(
+            103,
+            new ChampionAnalyticsFilter(RankTier: "EMERALD_PLUS"),
+            CancellationToken.None);
+        var historicalResult = await harness.Service.GetWinRatesAsync(
+            103,
+            new ChampionAnalyticsFilter(RankTier: "EMERALD_PLUS", Patch: "15.1"),
+            CancellationToken.None);
+
+        activeResult.Patch.Should().Be("15.2");
+        historicalResult.Patch.Should().Be("15.1");
+        harness.ComputeService.Verify(x => x.ComputeWinRatesAsync(
+            103,
+            It.IsAny<ChampionAnalyticsFilter>(),
+            "15.2",
+            It.IsAny<CancellationToken>()), Times.Once);
+        harness.ComputeService.Verify(x => x.ComputeWinRatesAsync(
+            103,
+            It.IsAny<ChampionAnalyticsFilter>(),
+            "15.1",
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task GetTierListAsync_UnsupportedRegion_FallsBackToGlobal()
     {
         await using var harness = await Harness.CreateAsync();
         harness.SetActivePatch("15.2", DateTime.UtcNow.AddHours(-6));
         await harness.Db.SaveChangesAsync();
 
-        await harness.Service.GetTierListAsync("ALL", null, "OCE1", CancellationToken.None);
+        await harness.Service.GetTierListAsync("ALL", null, "OCE1", null, CancellationToken.None);
 
         harness.ComputeService.Verify(x => x.ComputeTierListAsync(
             "ALL",
@@ -238,6 +324,17 @@ public class ChampionAnalyticsServiceTests
             {
                 Version = version,
                 IsActive = true,
+                ReleaseDate = releaseUtc,
+                DetectedAt = releaseUtc
+            });
+        }
+
+        public void SetInactivePatch(string version, DateTime releaseUtc)
+        {
+            Db.Patches.Add(new Patch
+            {
+                Version = version,
+                IsActive = false,
                 ReleaseDate = releaseUtc,
                 DetectedAt = releaseUtc
             });

--- a/tests/Transcendence.WebAPI.Tests/AnalyticsControllerTests.cs
+++ b/tests/Transcendence.WebAPI.Tests/AnalyticsControllerTests.cs
@@ -4,11 +4,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Moq;
 using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Match;
 using Transcendence.Data.Models.LoL.Static;
 using Transcendence.Service.Core.Services.Analytics.Interfaces;
 using Transcendence.Service.Core.Services.Analytics.Models;
 using Transcendence.Service.Core.Services.Jobs.Configuration;
 using Transcendence.WebAPI.Controllers;
+using MatchEntity = Transcendence.Data.Models.LoL.Match.Match;
 
 namespace Transcendence.WebAPI.Tests;
 
@@ -40,6 +42,79 @@ public class AnalyticsControllerTests
         payload.Patch.Should().Be("16.6");
         payload.ActivePatchReleasedAtUtc.Should().NotBeNull();
         payload.ActivePatchDetectedAtUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetPatches_ReturnsActivePatchAndPatchesWithSuccessfulRankedMatches()
+    {
+        await using var db = CreateDbContext();
+        var now = DateTime.UtcNow;
+        db.Patches.AddRange(
+            new Patch { Version = "15.2", ReleaseDate = now.AddHours(-2), DetectedAt = now.AddHours(-1), IsActive = true },
+            new Patch { Version = "15.1", ReleaseDate = now.AddDays(-14), DetectedAt = now.AddDays(-14), IsActive = false },
+            new Patch { Version = "14.24", ReleaseDate = now.AddDays(-28), DetectedAt = now.AddDays(-28), IsActive = false });
+        db.Matches.AddRange(
+            new MatchEntity
+            {
+                Id = Guid.NewGuid(),
+                MatchId = "NA1_15_1_ranked",
+                Patch = "15.1",
+                QueueId = 420,
+                QueueType = "RANKED_SOLO_5x5",
+                Status = FetchStatus.Success
+            },
+            new MatchEntity
+            {
+                Id = Guid.NewGuid(),
+                MatchId = "NA1_14_24_ranked_failed",
+                Patch = "14.24",
+                QueueId = 420,
+                QueueType = "RANKED_SOLO_5x5",
+                Status = FetchStatus.TemporaryFailure
+            },
+            new MatchEntity
+            {
+                Id = Guid.NewGuid(),
+                MatchId = "NA1_13_20_ranked",
+                Patch = "13.20",
+                QueueId = 420,
+                QueueType = "RANKED_SOLO_5x5",
+                Status = FetchStatus.Success
+            });
+        await db.SaveChangesAsync();
+
+        var controller = new AnalyticsController(
+            Mock.Of<IChampionAnalyticsService>(),
+            db,
+            Options.Create(new MultiRegionIngestionOptions()));
+
+        var result = await controller.GetPatches(CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeAssignableTo<IReadOnlyList<AnalyticsPatchOptionDto>>().Subject;
+        payload.Select(x => x.Patch).Should().Equal("15.2", "15.1", "13.20");
+        payload.First(x => x.Patch == "15.2").IsActive.Should().BeTrue();
+        payload.First(x => x.Patch == "15.1").RankedSoloDuoMatchCount.Should().Be(1);
+        payload.First(x => x.Patch == "13.20").ReleasedAtUtc.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetTierList_ForwardsPatchFilter()
+    {
+        await using var db = CreateDbContext();
+        var service = new Mock<IChampionAnalyticsService>();
+        service
+            .Setup(x => x.GetTierListAsync("TOP", "EMERALD_PLUS", "KR", "15.1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TierListResponse("15.1", "TOP", "EMERALD_PLUS", "KR", []));
+        var controller = new AnalyticsController(
+            service.Object,
+            db,
+            Options.Create(new MultiRegionIngestionOptions()));
+
+        var result = await controller.GetTierList("TOP", "EMERALD_PLUS", "KR", "15.1", CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        service.Verify(x => x.GetTierListAsync("TOP", "EMERALD_PLUS", "KR", "15.1", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     private static TranscendenceContext CreateDbContext()

--- a/tests/Transcendence.WebAPI.Tests/ChampionAnalyticsControllerTests.cs
+++ b/tests/Transcendence.WebAPI.Tests/ChampionAnalyticsControllerTests.cs
@@ -1,0 +1,69 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Transcendence.Service.Core.Services.Analytics.Interfaces;
+using Transcendence.Service.Core.Services.Analytics.Models;
+using Transcendence.WebAPI.Controllers;
+
+namespace Transcendence.WebAPI.Tests;
+
+public class ChampionAnalyticsControllerTests
+{
+    [Fact]
+    public async Task GetWinRates_ForwardsPatchFilter()
+    {
+        var service = new Mock<IChampionAnalyticsService>();
+        service
+            .Setup(x => x.GetWinRatesAsync(
+                103,
+                It.Is<ChampionAnalyticsFilter>(filter => filter.Patch == "15.1"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChampionWinRateSummary(103, "15.1", []));
+        var controller = new ChampionAnalyticsController(service.Object);
+
+        var result = await controller.GetWinRates(103, "EMERALD_PLUS", "KR", "MIDDLE", "15.1", CancellationToken.None);
+
+        result.Should().BeOfType<OkObjectResult>();
+        service.Verify(x => x.GetWinRatesAsync(
+            103,
+            It.Is<ChampionAnalyticsFilter>(filter => filter.Patch == "15.1"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetBuilds_ForwardsPatchFilter()
+    {
+        var service = new Mock<IChampionAnalyticsService>();
+        service
+            .Setup(x => x.GetBuildsAsync(103, "MIDDLE", "EMERALD_PLUS", "KR", "15.1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChampionBuildsResponse(103, "MIDDLE", "EMERALD_PLUS", "KR", "15.1", [], []));
+        var controller = new ChampionAnalyticsController(service.Object);
+
+        var result = await controller.GetBuilds(103, "MIDDLE", "EMERALD_PLUS", "KR", "15.1", CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(x => x.GetBuildsAsync(103, "MIDDLE", "EMERALD_PLUS", "KR", "15.1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMatchups_ForwardsPatchFilter()
+    {
+        var service = new Mock<IChampionAnalyticsService>();
+        service
+            .Setup(x => x.GetMatchupsAsync(103, "MIDDLE", "EMERALD_PLUS", "KR", "15.1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChampionMatchupsResponse
+            {
+                ChampionId = 103,
+                Role = "MIDDLE",
+                RankTier = "EMERALD_PLUS",
+                Region = "KR",
+                Patch = "15.1"
+            });
+        var controller = new ChampionAnalyticsController(service.Object);
+
+        var result = await controller.GetMatchups(103, "MIDDLE", "EMERALD_PLUS", "KR", "15.1", CancellationToken.None);
+
+        result.Result.Should().BeOfType<OkObjectResult>();
+        service.Verify(x => x.GetMatchupsAsync(103, "MIDDLE", "EMERALD_PLUS", "KR", "15.1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add public LoL analytics patch discovery via `GET /api/lol/analytics/patches`
- add optional `patch` filtering to LoL tier list, winrates, builds, matchups, and align pro builds
- add reusable frontend patch dropdowns across LoL analytics pages
- update OpenAPI/client output and analytics docs

## Verification
- `dotnet test tests/Transcendence.Service.Core.Tests/Transcendence.Service.Core.Tests.csproj -v minimal`
- `dotnet test tests/Transcendence.WebAPI.Tests/Transcendence.WebAPI.Tests.csproj -v minimal`
- `pnpm api:gen`
- `pnpm web:test`
- `pnpm web:lint`
- `pnpm web:build`

Note: `pnpm api:check` regenerated the spec/client successfully and then reported the expected OpenAPI diff for this API change.