### PR TITLE
Limit historical patch filter options

### DIFF
--- a/apps/web/components/AnalyticsPatchFilter.tsx
+++ b/apps/web/components/AnalyticsPatchFilter.tsx
@@ -2,7 +2,10 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { type LolAnalyticsPatchOption } from "@/lib/lolPatchFilters";
+import {
+  getVisibleAnalyticsPatches,
+  type LolAnalyticsPatchOption
+} from "@/lib/lolPatchFilters";
 
 export function AnalyticsPatchFilter({
   patches,
@@ -16,8 +19,9 @@ export function AnalyticsPatchFilter({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const visiblePatches = getVisibleAnalyticsPatches(patches);
   const normalizedActivePatch = activePatch?.trim() ?? "";
-  const hasActivePatchOption = patches.some((option) => option.patch === normalizedActivePatch);
+  const hasActivePatchOption = visiblePatches.some((option) => option.patch === normalizedActivePatch);
 
   function handleChange(event: React.ChangeEvent<HTMLSelectElement>) {
     const patch = event.target.value;
@@ -43,7 +47,7 @@ export function AnalyticsPatchFilter({
       {normalizedActivePatch && !hasActivePatchOption ? (
         <option value={normalizedActivePatch}>Patch {normalizedActivePatch}</option>
       ) : null}
-      {patches.map((option) => (
+      {visiblePatches.map((option) => (
         <option key={option.patch} value={option.patch}>
           {option.isActive ? `Current (${option.patch})` : `Patch ${option.patch}`}
         </option>

--- a/apps/web/lib/lolPatchFilters.test.ts
+++ b/apps/web/lib/lolPatchFilters.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { buildPatchPreservingParams, normalizeAnalyticsPatch } from "./lolPatchFilters";
+import {
+  buildPatchPreservingParams,
+  getVisibleAnalyticsPatches,
+  normalizeAnalyticsPatch
+} from "./lolPatchFilters";
 
 describe("normalizeAnalyticsPatch", () => {
   it("trims patch values", () => {
@@ -27,3 +31,50 @@ describe("buildPatchPreservingParams", () => {
     expect(params.toString()).toBe("role=MIDDLE&region=KR&patch=15.1");
   });
 });
+
+describe("getVisibleAnalyticsPatches", () => {
+  it("keeps the active patch and the three most recent historical patches", () => {
+    const patches = [
+      buildPatch("15.4", true),
+      buildPatch("15.3"),
+      buildPatch("15.2"),
+      buildPatch("15.1"),
+      buildPatch("14.24"),
+      buildPatch("14.23")
+    ];
+
+    expect(getVisibleAnalyticsPatches(patches).map((patch) => patch.patch)).toEqual([
+      "15.4",
+      "15.3",
+      "15.2",
+      "15.1"
+    ]);
+  });
+
+  it("preserves active patches even when they are not first", () => {
+    const patches = [
+      buildPatch("15.3"),
+      buildPatch("15.2"),
+      buildPatch("15.1"),
+      buildPatch("14.24"),
+      buildPatch("15.4", true)
+    ];
+
+    expect(getVisibleAnalyticsPatches(patches).map((patch) => patch.patch)).toEqual([
+      "15.3",
+      "15.2",
+      "15.1",
+      "15.4"
+    ]);
+  });
+});
+
+function buildPatch(patch: string, isActive = false) {
+  return {
+    patch,
+    releasedAtUtc: null,
+    detectedAtUtc: null,
+    isActive,
+    rankedSoloDuoMatchCount: 0
+  };
+}

--- a/apps/web/lib/lolPatchFilters.ts
+++ b/apps/web/lib/lolPatchFilters.ts
@@ -6,10 +6,28 @@ export type LolAnalyticsPatchOption = {
   rankedSoloDuoMatchCount: number;
 };
 
+const DEFAULT_VISIBLE_HISTORICAL_PATCH_COUNT = 3;
+
 export function normalizeAnalyticsPatch(patch: string | undefined | null): string | null {
   if (!patch) return null;
   const trimmed = patch.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+export function getVisibleAnalyticsPatches(
+  patches: readonly LolAnalyticsPatchOption[],
+  historicalPatchCount = DEFAULT_VISIBLE_HISTORICAL_PATCH_COUNT
+): LolAnalyticsPatchOption[] {
+  const visibleHistoricalPatchCount = Math.max(0, historicalPatchCount);
+  let historicalPatchesShown = 0;
+
+  return patches.filter((patch) => {
+    if (patch.isActive) return true;
+    if (historicalPatchesShown >= visibleHistoricalPatchCount) return false;
+
+    historicalPatchesShown += 1;
+    return true;
+  });
 }
 
 export function buildPatchPreservingParams(params: Record<string, string | null | undefined>): URLSearchParams {


### PR DESCRIPTION
## Summary
- Limit shared LoL analytics patch filter rendering to the active patch plus the three most recent historical patches.
- Preserve the currently selected patch as an option when a deep link references a hidden older patch.
- Add unit coverage for visible patch filtering behavior.

## Verification
- `/Users/kronic/Library/pnpm/pnpm --filter web test -- lolPatchFilters.test.ts`
- `/Users/kronic/Library/pnpm/pnpm --filter web lint`
- `/Users/kronic/Library/pnpm/pnpm --filter web build`
- Playwright browser check against local `http://localhost:3000/lol/tierlist` with `TRN_BACKEND_BASE_URL=https://api.kronic.one`, confirming options: Current Patch, Current (16.10), Patch 16.9, Patch 16.8, Patch 16.7