### PR TITLE
Redesign landings + LoL tier list (u.gg-style lane filters)

### DIFF
--- a/apps/web/app/lol/page.tsx
+++ b/apps/web/app/lol/page.tsx
@@ -4,6 +4,7 @@ import type { components } from "@transcendence/api-client/schema";
 
 import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
+import { LaneIcon } from "@/components/ui/LaneIcon";
 import { AnalyticsRegionFilter } from "@/components/AnalyticsRegionFilter";
 import { GlobalSearchLauncher } from "@/components/GlobalSearchLauncher";
 import { fetchBackendJson } from "@/lib/backendCall";
@@ -70,17 +71,14 @@ export default async function HomePage({
         </div>
 
         <h1 className="type-display mt-4 max-w-3xl">
-          League of Legends tier lists, builds, and matchup tools for the current patch.
+          League tier lists, matchups, and builds.
         </h1>
-        <p className="type-lead mt-4 max-w-2xl">
-          Start with the live tier list. Search is there when you already know the champion or player you want.
-        </p>
 
         {/* Action zone */}
         <div className="mt-8 grid gap-3 lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)] lg:items-center">
           <Link
             href={hrefWithRegion("/lol/tierlist")}
-            className="type-ui inline-flex h-14 items-center justify-center rounded-full bg-primary px-5 text-center font-semibold text-bg transition hover:bg-primary/92"
+            className="type-ui inline-flex h-14 items-center justify-center rounded-xl bg-primary px-5 text-center font-semibold text-bg transition hover:bg-primary/92"
           >
             Browse tier list
           </Link>
@@ -89,9 +87,6 @@ export default async function HomePage({
             className="h-14 w-full px-4 text-left lg:max-w-none"
           />
         </div>
-        <p className="type-ui mt-3 text-fg/60">
-          Use search for direct lookups. Use the tier list to get oriented fast.
-        </p>
 
         {/* Navigation zone */}
         <div className="mt-8 grid gap-4 border-t border-border/25 pt-4">
@@ -140,7 +135,7 @@ export default async function HomePage({
                 <thead className="type-overline text-muted">
                   <tr className="border-b border-border/30">
                     <th className="px-4 py-2">Champion</th>
-                    <th className="px-3 py-2">Role</th>
+                    <th className="px-3 py-2">Lane</th>
                     <th className="px-3 py-2 text-right">Win Rate</th>
                     <th className="px-3 py-2 text-right">Games</th>
                   </tr>
@@ -169,7 +164,12 @@ export default async function HomePage({
                             </span>
                           </Link>
                         </td>
-                        <td className="px-3 py-2.5 text-xs text-fg/80">{roleDisplayLabel(entry.role)}</td>
+                        <td className="px-3 py-2.5 text-xs text-fg/80">
+                          <span className="inline-flex items-center gap-1.5">
+                            <LaneIcon role={entry.role} className="h-4 w-4 shrink-0 text-fg/55" />
+                            {roleDisplayLabel(entry.role)}
+                          </span>
+                        </td>
                         <td className="px-3 py-2.5 text-right text-fg/90">
                           {formatPercent(entry.winRate, { decimals: 2 })}
                         </td>
@@ -223,10 +223,6 @@ export default async function HomePage({
 
           <Card className="p-5">
             <p className="type-kicker text-fg/56">Player Tools</p>
-            <h2 className="type-section mt-2 text-fg">Builds, matchups, and player routes</h2>
-            <p className="type-ui mt-2 text-fg/80">
-              Matchup breakdowns, pro builds, and player profiles.
-            </p>
             <div className="mt-4 grid gap-3 border-t border-border/25 pt-4">
               <Link
                 href={hrefWithRegion("/lol/matchups")}

--- a/apps/web/app/lol/tierlist/page.tsx
+++ b/apps/web/app/lol/tierlist/page.tsx
@@ -2,7 +2,7 @@ import type { components } from "@transcendence/api-client";
 
 import { BackendErrorCard } from "@/components/BackendErrorCard";
 import { AnalyticsSampleBanner } from "@/components/AnalyticsSampleBanner";
-import { FilterBar } from "@/components/FilterBar";
+import { TierListFilterBar } from "@/components/TierListFilterBar";
 import { TierListTable } from "@/components/TierListTable";
 import { Badge } from "@/components/ui/Badge";
 import {
@@ -90,7 +90,7 @@ export default async function TierListPage({
           <p className="type-ui text-fg/70">
             Try switching back to Global or another region.
           </p>
-          <FilterBar
+          <TierListFilterBar
             activeRole={roleParam || "ALL"}
             activeRank={effectiveRankParam ?? "all"}
             regionOptions={regionOptions}
@@ -116,17 +116,12 @@ export default async function TierListPage({
       : null;
 
   return (
-    <div className="grid gap-8">
-      <header className="page-hero p-5 md:p-8">
+    <div className="grid gap-5">
+      <header className="page-hero p-5 md:p-7">
         <p className="type-kicker text-muted">League Analytics</p>
-        <h1 className="type-page-title mt-3">
-          Tier List
-        </h1>
-        <p className="type-ui mt-3 text-fg/75">
-          See which champions are winning most often for this role, rank, and region.
-        </p>
+        <h1 className="type-page-title mt-2">Tier List</h1>
 
-        <div className="mt-3 flex flex-wrap items-center gap-2">
+        <div className="mt-4 flex flex-wrap items-center gap-2">
           <Badge className="border-primary/40 bg-primary/10 text-primary">
             Patch {tierlist.patch ?? "Unknown"}
           </Badge>
@@ -144,8 +139,10 @@ export default async function TierListPage({
             sample={(tierlist as { sample?: unknown } | null)?.sample as AnalyticsSampleLike}
           />
         </div>
+      </header>
 
-        <FilterBar
+      <div className="grid gap-3">
+        <TierListFilterBar
           activeRole={roleParam || "ALL"}
           activeRank={effectiveRankParam ?? "all"}
           regionOptions={regionOptions}
@@ -154,18 +151,17 @@ export default async function TierListPage({
           activePatch={selectedPatch}
           extraParams={sharedFilterParams}
           baseHref="/lol/tierlist"
-          className="mt-4"
         />
-      </header>
 
-      <TierListTable
-        entries={normalizedEntries}
-        champions={champions}
-        version={version}
-        rankTierValue={rankTierValue}
-        activeRegion={effectiveRegion}
-        activePatch={selectedPatch}
-      />
+        <TierListTable
+          entries={normalizedEntries}
+          champions={champions}
+          version={version}
+          rankTierValue={rankTierValue}
+          activeRegion={effectiveRegion}
+          activePatch={selectedPatch}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,8 +1,23 @@
+import Image from "next/image";
 import Link from "next/link";
+import type { components } from "@transcendence/api-client/schema";
 
 import { GlobalSearchLauncher } from "@/components/GlobalSearchLauncher";
+import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
+import { LaneIcon } from "@/components/ui/LaneIcon";
+import { fetchBackendJson } from "@/lib/backendCall";
+import { getBackendBaseUrl } from "@/lib/env";
 import { TFT_FRONTEND_ENABLED } from "@/lib/featureFlags";
+import { fetchLolAnalyticsStatus } from "@/lib/lolAnalyticsStatus";
+import { formatPercent } from "@/lib/format";
+import { DEFAULT_TIERLIST_RANK_TIER } from "@/lib/ranks";
+import { roleDisplayLabel } from "@/lib/roles";
+import { championIconUrl, fetchChampionMap } from "@/lib/staticData";
+import { normalizeTierListEntries } from "@/lib/tierlist";
+import type { TftCompListItem } from "@/lib/tft";
+
+type TierListResponse = components["schemas"]["TierListResponse"];
 
 const EXAMPLE_PROFILE = {
   label: "Hide on bush#KR1",
@@ -10,182 +25,198 @@ const EXAMPLE_PROFILE = {
   tftHref: "/tft/summoners/kr/Hide%20on%20bush-KR1"
 } as const;
 
-const games = [
-  {
-    href: "/lol",
-    eyebrow: "League of Legends",
-    title: "Tier lists, builds, matchup tools, pro builds, and player profiles.",
-    description:
-      "Open the current board, jump to a champion page, or pull up a player profile in a few clicks.",
-    starter:
-      "Best first move: open the tier list when you need a fast read on what is strong right now.",
-    links: [
-      { label: "Tier List", href: "/lol/tierlist" },
-      { label: "Champions", href: "/lol/champions" },
-      { label: `Open ${EXAMPLE_PROFILE.label}`, href: EXAMPLE_PROFILE.lolHref }
-    ]
-  }
-] as const;
+const lolGame = {
+  href: "/lol",
+  eyebrow: "League of Legends",
+  title: "Tier lists, champion builds, matchups, pro builds, and player profiles.",
+  links: [
+    { label: "Tier List", href: "/lol/tierlist" },
+    { label: "Champions", href: "/lol/champions" },
+    { label: EXAMPLE_PROFILE.label, href: EXAMPLE_PROFILE.lolHref }
+  ]
+} as const;
 
 const tftGame = {
   href: "/tft",
   eyebrow: "Teamfight Tactics",
   title: "Meta comps, unit and item lookups, augments, traits, and player history.",
-  description:
-    "Check the live set, compare top comps, and review player results without digging through tabs.",
-  starter:
-    "Best first move: open comps when you want a stable starting board before queueing.",
   links: [
     { label: "Comps", href: "/tft/comps" },
     { label: "Units", href: "/tft/champions" },
-    { label: `Open ${EXAMPLE_PROFILE.label}`, href: EXAMPLE_PROFILE.tftHref }
+    { label: EXAMPLE_PROFILE.label, href: EXAMPLE_PROFILE.tftHref }
   ]
 } as const;
 
-export default function LandingPage() {
-  const visibleGames = TFT_FRONTEND_ENABLED ? [...games, tftGame] : games;
+type HomeLiveData = {
+  version: string;
+  champions: Awaited<ReturnType<typeof fetchChampionMap>>["champions"];
+  patch: string | null;
+  lolTop: ReturnType<typeof normalizeTierListEntries>;
+  tftTop: TftCompListItem[];
+};
+
+// The "Live now" strip is best-effort. fetchChampionMap throws on a Data Dragon
+// outage (unlike fetchBackendJson), so the whole batch is guarded — a CDN hiccup
+// degrades the strip to nothing instead of crashing the root page. Rank is
+// pinned to the tier list's default (Emerald+) so the preview matches where its
+// links lead.
+async function loadHomeLiveData(): Promise<HomeLiveData> {
+  try {
+    const [{ version, champions }, analyticsStatus, tierListRes, tftCompsRes] = await Promise.all([
+      fetchChampionMap(),
+      fetchLolAnalyticsStatus(),
+      fetchBackendJson<TierListResponse>(
+        `${getBackendBaseUrl()}/api/lol/analytics/tierlist?rankTier=${DEFAULT_TIERLIST_RANK_TIER}`,
+        { next: { revalidate: 60 * 60 } }
+      ),
+      TFT_FRONTEND_ENABLED
+        ? fetchBackendJson<TftCompListItem[]>(`${getBackendBaseUrl()}/api/tft/analytics/comps`, {
+            next: { revalidate: 60 * 10 }
+          })
+        : Promise.resolve(null)
+    ]);
+
+    return {
+      version,
+      champions,
+      patch: analyticsStatus?.patch ?? tierListRes.body?.patch ?? null,
+      lolTop: tierListRes.ok
+        ? normalizeTierListEntries(tierListRes.body?.entries ?? []).slice(0, 3)
+        : [],
+      tftTop: tftCompsRes && tftCompsRes.ok ? (tftCompsRes.body ?? []).slice(0, 3) : []
+    };
+  } catch {
+    return { version: "", champions: {}, patch: null, lolTop: [], tftTop: [] };
+  }
+}
+
+export default async function LandingPage() {
+  const visibleGames = TFT_FRONTEND_ENABLED ? [lolGame, tftGame] : [lolGame];
+  const { version, champions, patch, lolTop, tftTop } = await loadHomeLiveData();
+  const hasLive = lolTop.length > 0 || tftTop.length > 0;
 
   return (
-    <div className="grid gap-10">
+    <div className="grid gap-8">
       <section className="page-hero p-6 sm:p-8 md:p-10">
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(18rem,0.8fr)] xl:items-start">
-          <div>
-            <p className="type-kicker text-muted">Transcendence</p>
-            <h1 className="type-display mt-4 max-w-4xl">
-              Fast League and TFT lookups for ranked players.
-            </h1>
-            <p className="type-lead mt-4 max-w-2xl">
-              Start with the live board when you need direction. Use search when you already know the player, champion, or page you want.
-            </p>
+        <p className="type-kicker text-muted">Transcendence</p>
+        <h1 className="type-display mt-4 max-w-4xl">
+          Fast League and TFT lookups for ranked players.
+        </h1>
 
-            <div className="mt-7 grid gap-3 lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)] lg:items-center">
-              <Link
-                href="/lol/tierlist"
-                className="type-ui inline-flex min-h-12 items-center justify-center rounded-full bg-primary px-5 py-3 font-semibold text-bg transition hover:bg-primary/92"
-              >
-                Start with LoL tier list
-              </Link>
-              <GlobalSearchLauncher className="h-12 w-full px-4 text-left lg:max-w-none" />
-            </div>
-
-            <div className="mt-6 grid gap-3 md:grid-cols-2">
-              <div className="page-panel p-4">
-                <p className="type-kicker text-fg/58">Start from browse</p>
-                <p className="type-title mt-2 text-fg">Need the current meta first?</p>
-                <p className="type-ui mt-2 text-fg/76">
-                  Open tier lists or comps to get oriented before you commit to a game.
-                </p>
-                <div className="mt-4 flex flex-wrap gap-3">
-                  <Link
-                    href="/lol/tierlist"
-                    className="type-ui inline-flex items-center border-b border-border/45 px-0.5 pb-1 text-fg/80 transition hover:border-border/72 hover:text-fg"
-                  >
-                    League tier list
-                  </Link>
-                  {TFT_FRONTEND_ENABLED ? (
-                    <Link
-                      href="/tft/comps"
-                      className="type-ui inline-flex items-center border-b border-border/45 px-0.5 pb-1 text-fg/80 transition hover:border-border/72 hover:text-fg"
-                    >
-                      TFT comps
-                    </Link>
-                  ) : null}
-                </div>
-              </div>
-
-              <div className="page-panel p-4">
-                <p className="type-kicker text-fg/58">Start from direct lookup</p>
-                <p className="type-title mt-2 text-fg">Already know the name?</p>
-                <p className="type-ui mt-2 text-fg/76">
-                  Use global search for player profiles, champion pages, and route shortcuts without digging through navigation.
-                </p>
-                <p className="type-ui mt-4 text-fg/62">
-                  Working example:
-                  {" "}
-                  <Link href={EXAMPLE_PROFILE.lolHref} className="font-semibold text-primary transition hover:text-primary/80">
-                    {EXAMPLE_PROFILE.label}
-                  </Link>
-                  {" "}
-                  on KR.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <aside className="page-panel grid gap-4 p-5">
-            <div>
-              <p className="type-kicker text-fg/58">Start Here</p>
-              <h2 className="type-title mt-2 text-fg">Two fast ways to get value</h2>
-            </div>
-            <div className="grid gap-3">
-              <div className="rounded-2xl border border-border/28 bg-surface/40 p-4">
-                <p className="type-kicker text-primary/88">01</p>
-                <p className="type-ui mt-2 font-semibold text-fg">Browse the live board</p>
-                <p className="type-ui mt-1 text-fg/72">
-                  Best for first-time visits, patch checks, and quick pre-queue decisions.
-                </p>
-              </div>
-              <div className="rounded-2xl border border-border/28 bg-surface/40 p-4">
-                <p className="type-kicker text-primary/88">02</p>
-                <p className="type-ui mt-2 font-semibold text-fg">Jump straight to a name</p>
-                <p className="type-ui mt-1 text-fg/72">
-                  Best when you already have a Riot ID, champion, comp, or page in mind.
-                </p>
-              </div>
-            </div>
-            <div className="border-t border-border/25 pt-4">
-              <p className="type-kicker text-fg/58">Suggested first click</p>
-              <div className="mt-2 flex flex-wrap gap-3">
-                <Link
-                  href="/lol"
-                  className="type-ui inline-flex items-center border-b border-border/45 px-0.5 pb-1 text-fg/78 transition hover:border-border/72 hover:text-fg"
-                >
-                  Open League
-                </Link>
-                {TFT_FRONTEND_ENABLED ? (
-                  <Link
-                    href="/tft"
-                    className="type-ui inline-flex items-center border-b border-border/45 px-0.5 pb-1 text-fg/78 transition hover:border-border/72 hover:text-fg"
-                  >
-                    Open TFT
-                  </Link>
-                ) : null}
-              </div>
-            </div>
-          </aside>
+        <div className="mt-7 grid gap-3 sm:grid-cols-2 sm:items-stretch">
+          <Link
+            href="/lol/tierlist"
+            className="type-ui inline-flex min-h-12 w-full items-center justify-center rounded-xl bg-primary px-5 py-3 font-semibold text-bg transition hover:bg-primary/92"
+          >
+            Open LoL tier list
+          </Link>
+          <GlobalSearchLauncher className="h-12 w-full px-4 text-left" />
         </div>
       </section>
 
+      {hasLive ? (
+        <section className="page-panel grid gap-4 p-5 sm:p-6">
+          <p className="type-kicker text-fg/58">Live now</p>
+
+          <div
+            className={`grid gap-5 ${
+              lolTop.length > 0 && tftTop.length > 0 ? "sm:grid-cols-2" : ""
+            }`}
+          >
+            {lolTop.length > 0 ? (
+              <div className="grid gap-3">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="inline-flex items-center gap-2">
+                    <span className="type-kicker text-fg/58">League · Top picks</span>
+                    {patch ? (
+                      <Badge className="border-primary/40 bg-primary/10 text-primary">
+                        Patch {patch}
+                      </Badge>
+                    ) : null}
+                  </span>
+                  <Link href="/lol/tierlist" className="type-ui font-semibold text-primary hover:underline">
+                    Tier list
+                  </Link>
+                </div>
+                <div className="grid">
+                  {lolTop.map((entry) => {
+                    const champ = champions[String(entry.championId)];
+                    const name = champ?.name ?? `Champion ${entry.championId}`;
+                    return (
+                      <Link
+                        key={`${entry.championId}-${entry.role}`}
+                        href={`/lol/champions/${entry.championId}?role=${entry.role}`}
+                        className="flex items-center gap-2.5 border-b border-border/20 py-2 transition last:border-0 hover:border-border/45"
+                      >
+                        <Image
+                          src={championIconUrl(version, champ?.id ?? "Unknown")}
+                          alt={name}
+                          width={26}
+                          height={26}
+                          sizes="26px"
+                          className="rounded-md"
+                        />
+                        <span className="type-ui min-w-0 flex-1 truncate text-fg">{name}</span>
+                        <span className="inline-flex items-center gap-1.5 text-xs text-muted">
+                          <LaneIcon role={entry.role} className="h-3.5 w-3.5 shrink-0 text-fg/45" />
+                          <span className="sr-only">{roleDisplayLabel(entry.role)} lane, </span>
+                          {formatPercent(entry.winRate, { decimals: 1 })} WR
+                        </span>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
+
+            {tftTop.length > 0 ? (
+              <div className="grid gap-3">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="type-kicker text-fg/58">TFT · Top comps</p>
+                  <Link href="/tft/comps" className="type-ui font-semibold text-primary hover:underline">
+                    Comps
+                  </Link>
+                </div>
+                <div className="grid">
+                  {tftTop.map((comp) => (
+                    <Link
+                      key={comp.compSlug}
+                      href={`/tft/comps/${comp.compSlug}`}
+                      className="flex items-center gap-2.5 border-b border-border/20 py-2 transition last:border-0 hover:border-border/45"
+                    >
+                      <span className="type-ui min-w-0 flex-1 truncate text-fg">{comp.name}</span>
+                      <span className="text-xs text-muted">Avg {comp.avgPlacement.toFixed(2)}</span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
       <section className="grid gap-5 lg:grid-cols-2">
         {visibleGames.map((game) => (
-          <Card key={game.href} className="grid gap-5 p-6">
+          <Card key={game.href} className="grid gap-4 p-6">
             <div>
-              <p className="type-kicker text-muted">
-                {game.eyebrow}
-              </p>
-              <p className="type-title mt-3 text-fg">{game.title}</p>
-              <p className="type-ui measure mt-3 text-fg/75">{game.description}</p>
-              <p className="type-ui mt-4 text-fg/60">{game.starter}</p>
-            </div>
-            <div className="grid gap-3 border-t border-border/25 pt-4">
+              <p className="type-kicker text-muted">{game.eyebrow}</p>
               <Link
                 href={game.href}
-                className="type-ui inline-flex w-fit items-center gap-2 font-semibold text-primary transition hover:text-primary/80"
+                className="type-title mt-3 inline-block text-fg transition hover:text-primary"
               >
-                Open {game.eyebrow === "League of Legends" ? "LoL" : "TFT"}
-                <span aria-hidden="true">/</span>
+                {game.title}
               </Link>
-              <div className="flex flex-wrap gap-x-4 gap-y-2">
-                {game.links.map((link) => (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className="type-ui inline-flex items-center border-b border-border/45 px-0.5 pb-1 text-fg/76 transition hover:border-primary/35 hover:text-fg"
-                  >
-                    {link.label}
-                  </Link>
-                ))}
-              </div>
+            </div>
+            <div className="flex flex-wrap gap-x-4 gap-y-2 border-t border-border/25 pt-4">
+              {game.links.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="type-ui inline-flex items-center border-b border-border/45 px-0.5 pb-1 text-fg/76 transition hover:border-primary/35 hover:text-fg"
+                >
+                  {link.label}
+                </Link>
+              ))}
             </div>
           </Card>
         ))}

--- a/apps/web/app/tft/page.tsx
+++ b/apps/web/app/tft/page.tsx
@@ -49,25 +49,22 @@ export default async function TftHomePage() {
           <Link href="/tft/comps" className="control-tab type-ui font-semibold" data-active="true">
             Explore Comps
           </Link>
-          <Link href="/tft/champions" className="control-tab type-ui">
-            Units
-          </Link>
-          <Link href="/tft/items" className="control-tab type-ui">
-            Items
-          </Link>
           <Link href={EXAMPLE_SUMMONER_HREF} className="control-tab type-ui">
             Example Profile
           </Link>
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-4">
+      <section className="flex flex-wrap items-center gap-2">
+        <p className="type-kicker mr-1 text-muted">Browse</p>
         {counts.map((item) => (
-          <Link key={item.label} href={item.href}>
-            <Card className="page-stat-card p-5">
-              <p className="type-kicker text-muted">{item.label}</p>
-              <p className="type-tabular mt-2 text-3xl font-semibold text-fg">{item.value.toLocaleString()}</p>
-            </Card>
+          <Link
+            key={item.label}
+            href={item.href}
+            className="surface-chip type-ui inline-flex items-center gap-2 rounded-xl px-3 py-1.5 text-fg/80 transition hover:border-border-strong/70 hover:text-fg"
+          >
+            {item.label}
+            <span className="type-tabular text-fg/55">{item.value.toLocaleString()}</span>
           </Link>
         ))}
       </section>
@@ -75,7 +72,7 @@ export default async function TftHomePage() {
       <section className="grid gap-4">
         <div>
           <h2 className="type-title">Top Comps</h2>
-          <p className="type-ui mt-2 text-fg/75">The default view starts on the live set at Emerald+.</p>
+          <p className="type-ui mt-2 text-fg/75">Emerald+ ranked · live set.</p>
         </div>
 
         {topComps.length === 0 ? (

--- a/apps/web/components/LaneTabs.tsx
+++ b/apps/web/components/LaneTabs.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+
+import { cn } from "@/lib/cn";
+import { roleDisplayLabel } from "@/lib/roles";
+
+import { LaneIcon } from "./ui/LaneIcon";
+
+/**
+ * The prominent lane selector for the tier list — official LoL position icons
+ * over gold-underline tabs, URL-driven (sets `?role=`). Sits directly above the
+ * champion table so the chosen lane reads right onto the rows it filters.
+ */
+export function LaneTabs({
+  roles,
+  activeRole,
+  baseHref,
+  extraParams,
+  className
+}: {
+  roles: readonly string[];
+  activeRole: string;
+  baseHref: string;
+  extraParams?: Record<string, string>;
+  className?: string;
+}) {
+  function buildHref(role: string) {
+    const params = new URLSearchParams();
+    if (role.toUpperCase() !== "ALL") params.set("role", role);
+    if (extraParams) {
+      for (const [key, value] of Object.entries(extraParams)) {
+        if (value && value.toLowerCase() !== "all") params.set(key, value);
+      }
+    }
+    const qs = params.toString();
+    return qs ? `${baseHref}?${qs}` : baseHref;
+  }
+
+  return (
+    <nav className={cn("flex flex-wrap gap-x-1 gap-y-1", className)}>
+      {roles.map((role) => {
+        const active = role.toUpperCase() === activeRole.toUpperCase();
+        return (
+          <Link
+            key={role}
+            href={buildHref(role)}
+            data-active={active}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "group relative inline-flex min-h-11 items-center gap-2 px-3 py-2 text-fg/64 transition-colors duration-200 ease-[cubic-bezier(0.25,1,0.5,1)] hover:text-fg",
+              "after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:origin-center after:scale-x-0 after:rounded-full after:bg-primary after:transition-transform after:duration-200 after:[transition-timing-function:var(--ease-out-quart)] motion-reduce:after:transition-none",
+              active && "text-primary after:scale-x-100"
+            )}
+          >
+            <LaneIcon
+              role={role}
+              className="h-[18px] w-[18px] shrink-0 opacity-80 transition-opacity group-hover:opacity-100"
+            />
+            <span className="type-ui font-medium">{roleDisplayLabel(role)}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/components/TierListFilterBar.tsx
+++ b/apps/web/components/TierListFilterBar.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { type AnalyticsRegionOption } from "@/lib/analyticsRegionShared";
+import { type LolAnalyticsPatchOption } from "@/lib/lolPatchFilters";
+import { RANK_TIER_FILTERS } from "@/lib/ranks";
+
+import { LaneTabs } from "./LaneTabs";
+import { AnalyticsPatchFilter } from "./AnalyticsPatchFilter";
+import { AnalyticsRegionFilter } from "./AnalyticsRegionFilter";
+import { RankFilterDropdown } from "./RankFilterDropdown";
+
+const DEFAULT_ROLES = ["ALL", "TOP", "JUNGLE", "MIDDLE", "BOTTOM", "UTILITY"] as const;
+const DEFAULT_RANKS = RANK_TIER_FILTERS;
+
+/**
+ * Tier-list-specific filter layout. Rank / Region / Patch sit in a quiet
+ * controls row; the Lane selector is a prominent icon-tab bar pinned to the
+ * bottom so it reads directly onto the champion table beneath it (u.gg-style).
+ * Reuses the shared analytics filter children + FilterBar's query-param
+ * cross-wiring; the shared FilterBar (champion/matchup detail pages) is left
+ * untouched.
+ */
+export function TierListFilterBar({
+  roles = DEFAULT_ROLES,
+  activeRole = "ALL",
+  ranks = DEFAULT_RANKS,
+  activeRank = "all",
+  regionOptions,
+  activeRegion,
+  patchOptions,
+  activePatch,
+  extraParams,
+  baseHref,
+  className
+}: {
+  roles?: readonly string[];
+  activeRole?: string;
+  ranks?: readonly string[];
+  activeRank?: string;
+  regionOptions?: readonly AnalyticsRegionOption[];
+  activeRegion?: string;
+  patchOptions?: readonly LolAnalyticsPatchOption[];
+  activePatch?: string | null;
+  extraParams?: Record<string, string | null | undefined>;
+  baseHref: string;
+  className?: string;
+}) {
+  const sharedExtraParams: Record<string, string> = {};
+  if (extraParams) {
+    for (const [key, value] of Object.entries(extraParams)) {
+      if (value && value.toLowerCase() !== "all") sharedExtraParams[key] = value;
+    }
+  }
+
+  const roleExtraParams: Record<string, string> = { ...sharedExtraParams };
+  if (activeRank && activeRank.toLowerCase() !== "all") {
+    roleExtraParams.rankTier = activeRank;
+  }
+
+  const rankExtraParams: Record<string, string> = { ...sharedExtraParams };
+  if (activeRole && activeRole.toUpperCase() !== "ALL") {
+    rankExtraParams.role = activeRole;
+  }
+
+  return (
+    <div className={cn("grid gap-4", className)}>
+      {/* Rank · Region · Patch — quiet refinement controls. */}
+      <div className="flex flex-wrap items-end gap-x-7 gap-y-4">
+        <label className="grid gap-1.5">
+          <span className="type-kicker text-fg/55">Rank</span>
+          <RankFilterDropdown
+            ranks={ranks}
+            activeRank={activeRank}
+            baseHref={baseHref}
+            extraParams={rankExtraParams}
+            className="w-full sm:w-44"
+          />
+        </label>
+
+        {regionOptions && activeRegion ? (
+          <div className="grid gap-1.5" role="group" aria-label="Region">
+            <span className="type-kicker text-fg/55">Region</span>
+            <AnalyticsRegionFilter
+              options={regionOptions}
+              activeRegion={activeRegion}
+              className="-ml-1 flex flex-wrap gap-x-2 gap-y-1"
+            />
+          </div>
+        ) : null}
+
+        {patchOptions ? (
+          <label className="grid gap-1.5">
+            <span className="type-kicker text-fg/55">Patch</span>
+            <AnalyticsPatchFilter
+              patches={patchOptions}
+              activePatch={activePatch}
+              className="control-select min-w-[148px]"
+            />
+          </label>
+        ) : null}
+      </div>
+
+      {/* Lane — the prominent primary choice, pinned to the table edge. */}
+      <div className="-mx-1 flex items-end gap-x-3 border-b border-border/40 px-1">
+        <span className="type-kicker hidden shrink-0 pb-3 text-fg/45 sm:block">Lane</span>
+        <LaneTabs
+          roles={roles}
+          activeRole={activeRole}
+          baseHref={baseHref}
+          extraParams={roleExtraParams}
+          className="-mb-px"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/TierListTable.tsx
+++ b/apps/web/components/TierListTable.tsx
@@ -9,6 +9,7 @@ import { TierBadge } from "@/components/TierBadge";
 import { WinRateText } from "@/components/WinRateText";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { LaneIcon } from "@/components/ui/LaneIcon";
 import { cn } from "@/lib/cn";
 import { formatGames, formatPercent } from "@/lib/format";
 import { roleDisplayLabel } from "@/lib/roles";
@@ -39,7 +40,7 @@ const COLUMNS: { label: string; sortKey?: SortColumn; className: string; hiddenM
   { label: "#", sortKey: "rank", className: "w-10 px-2 text-center md:px-4" },
   { label: "Tier", className: "w-10 px-2" },
   { label: "Champion", className: "px-2 md:px-3" },
-  { label: "Role", className: "px-2 md:px-3" },
+  { label: "Lane", className: "px-2 md:px-3" },
   { label: "Win Rate", sortKey: "winRate", className: "px-2 text-right md:px-3" },
   { label: "Pick Rate", sortKey: "pickRate", className: "px-3 text-right", hiddenMobile: true },
   { label: "Ban Rate", className: "px-3 text-right", hiddenMobile: true },
@@ -68,20 +69,6 @@ function startVisualTransition(update: () => void) {
   }
 
   startTransition(update);
-}
-
-function sortLabel(sortCol: SortColumn) {
-  switch (sortCol) {
-    case "winRate":
-      return "Win rate";
-    case "pickRate":
-      return "Pick rate";
-    case "games":
-      return "Games";
-    case "rank":
-    default:
-      return "Composite rank";
-  }
 }
 
 export function TierListTable({
@@ -162,8 +149,6 @@ export function TierListTable({
     [summary.tierCounts]
   );
 
-  const leadEntry = sortedEntries[0] ?? null;
-  const leadChampion = leadEntry ? champions[String(leadEntry.championId)] : null;
   const showTierRail = isDefaultSort && focusTier === "ALL" && visibleTiers.length > 1;
 
   useEffect(() => {
@@ -328,7 +313,12 @@ export function TierListTable({
             </span>
           </Link>
         </td>
-        <td className="px-2 py-3 text-xs text-muted md:px-3">{roleDisplayLabel(entry.role)}</td>
+        <td className="px-2 py-3 md:px-3">
+          <span className="inline-flex items-center gap-1.5 text-xs text-muted">
+            <LaneIcon role={entry.role} className="h-[18px] w-[18px] shrink-0 text-fg/55" />
+            <span className="sr-only sm:not-sr-only">{roleDisplayLabel(entry.role)}</span>
+          </span>
+        </td>
         <td className="px-2 py-3 text-right md:px-3">
           <WinRateText value={entry.winRate} decimals={2} />
         </td>
@@ -372,82 +362,40 @@ export function TierListTable({
 
   return (
     <div className="grid gap-4">
-      <Card className="tierlist-toolbar p-4 sm:p-5">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-          <div className="grid gap-1.5">
-            <p className="type-kicker text-primary/88">Board view</p>
-            <p className="type-ui text-fg/74">
-              {focusTier === "ALL"
-                ? `${allSummary.visibleCount} champions ranked for this patch window.`
-                : `Showing Tier ${focusTier} champions only.`}
-            </p>
-            <div className="flex flex-wrap items-center gap-2 pt-1">
-              <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
-                {summary.totalGames.toLocaleString()} games
+      <div className="flex flex-col gap-3 px-1 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+          <span className="type-kicker mr-1 text-fg/45">Tier</span>
+          {(["ALL", ...TIER_ORDER] as const).map((tier) => (
+            <button
+              key={tier}
+              type="button"
+              className="tierlist-filter-pill"
+              data-active={focusTier === tier}
+              aria-pressed={focusTier === tier}
+              onClick={() => applyFocusTier(tier)}
+            >
+              <span>{tier === "ALL" ? "All" : tier}</span>
+              <span className="text-fg/50">
+                {tier === "ALL" ? allSummary.visibleCount : allSummary.tierCounts[tier]}
               </span>
-              {summary.averageWinRate != null ? (
-                <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
-                  Avg WR {formatPercent(summary.averageWinRate, { decimals: 2 })}
-                </span>
-              ) : null}
-              {leadEntry ? (
-                <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
-                  Lead {leadChampion?.name ?? `#${leadEntry.championId}`}{" "}
-                  {formatPercent(leadEntry.winRate, { decimals: 2 })}
-                </span>
-              ) : null}
-            </div>
-          </div>
-
-          <div className="grid gap-2 xl:justify-items-end">
-            <p className="type-kicker text-muted">Sort locally</p>
-            <div className="flex flex-wrap gap-2 xl:justify-end">
-              {(["rank", "winRate", "pickRate", "games"] as const).map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  className="tierlist-filter-pill"
-                  data-active={sortCol === option}
-                  aria-pressed={sortCol === option}
-                  onClick={() => applySort(option)}
-                >
-                  <span>{sortLabel(option)}</span>
-                  {sortCol === option ? (
-                    <span className="text-primary">{sortDir === "asc" ? "\u25B2" : "\u25BC"}</span>
-                  ) : null}
-                </button>
-              ))}
-            </div>
-          </div>
+            </button>
+          ))}
         </div>
 
-        <div className="mt-4 flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="type-kicker mr-1 text-muted">Tier focus</span>
-            {(["ALL", ...TIER_ORDER] as const).map((tier) => (
-              <button
-                key={tier}
-                type="button"
-                className="tierlist-filter-pill"
-                data-active={focusTier === tier}
-                aria-pressed={focusTier === tier}
-                onClick={() => applyFocusTier(tier)}
-              >
-                <span>{tier === "ALL" ? "All tiers" : `Tier ${tier}`}</span>
-                <span className="text-fg/56">
-                  {tier === "ALL" ? allSummary.visibleCount : allSummary.tierCounts[tier]}
-                </span>
-              </button>
-            ))}
-          </div>
-
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
+          <span className="type-tabular">{summary.totalGames.toLocaleString()} games</span>
+          {summary.averageWinRate != null ? (
+            <span className="type-tabular border-l border-border/30 pl-3">
+              Avg WR {formatPercent(summary.averageWinRate, { decimals: 2 })}
+            </span>
+          ) : null}
           {isFilteredView ? (
-            <Button variant="ghost" size="sm" onClick={resetView} className="w-fit rounded-full px-4">
-              Reset board view
+            <Button variant="ghost" size="sm" onClick={resetView} className="ml-1 h-8 rounded-lg px-3">
+              Reset
             </Button>
           ) : null}
         </div>
-      </Card>
+      </div>
 
       {summary.visibleCount === 0 ? (
         <Card className="tierlist-table-shell grid gap-3 p-6">

--- a/apps/web/components/ui/LaneIcon.tsx
+++ b/apps/web/components/ui/LaneIcon.tsx
@@ -1,0 +1,110 @@
+type LaneGlyph = "ALL" | "TOP" | "JUNGLE" | "MIDDLE" | "BOTTOM" | "UTILITY";
+
+function normalizeLane(role: string | null | undefined): LaneGlyph {
+  const normalized = (role ?? "").trim().toUpperCase();
+  switch (normalized) {
+    case "TOP":
+      return "TOP";
+    case "JUNGLE":
+      return "JUNGLE";
+    case "MIDDLE":
+    case "MID":
+      return "MIDDLE";
+    case "BOTTOM":
+    case "BOT":
+    case "ADC":
+      return "BOTTOM";
+    case "UTILITY":
+    case "SUPPORT":
+      return "UTILITY";
+    default:
+      return "ALL";
+  }
+}
+
+// Official League position icons (paths from Community Dragon's
+// rcp-fe-lol-static-assets/svg/position-*.svg, viewBox 0 0 34 34). Each lane
+// pairs a dim "frame" path with a bright "active" shape; both use currentColor
+// so the icon inherits the gold accent on the active lane tab and stays
+// grayscale otherwise. Top/Jungle render the position bracket; "All" uses a
+// neutral quad glyph since Riot ships no all-roles icon.
+function LaneGlyphPaths({ lane }: { lane: LaneGlyph }) {
+  switch (lane) {
+    case "TOP":
+      return (
+        <>
+          <path
+            fill="currentColor"
+            fillOpacity={0.4}
+            fillRule="evenodd"
+            d="M21,14H14v7h7V14Zm5-3V26L11.014,26l-4,4H30V7.016Z"
+          />
+          <polygon fill="currentColor" points="4 4 4.003 28.045 9 23 9 9 23 9 28.045 4.003 4 4" />
+        </>
+      );
+    case "JUNGLE":
+      return (
+        <path
+          fill="currentColor"
+          fillRule="evenodd"
+          d="M25,3c-2.128,3.3-5.147,6.851-6.966,11.469A42.373,42.373,0,0,1,20,20a27.7,27.7,0,0,1,1-3C21,12.023,22.856,8.277,25,3ZM13,20c-1.488-4.487-4.76-6.966-9-9,3.868,3.136,4.422,7.52,5,12l3.743,3.312C14.215,27.917,16.527,30.451,17,31c4.555-9.445-3.366-20.8-8-28C11.67,9.573,13.717,13.342,13,20Zm8,5a15.271,15.271,0,0,1,0,2l4-4c0.578-4.48,1.132-8.864,5-12C24.712,13.537,22.134,18.854,21,25Z"
+        />
+      );
+    case "MIDDLE":
+      return (
+        <>
+          <path
+            fill="currentColor"
+            fillOpacity={0.4}
+            fillRule="evenodd"
+            d="M30,12.968l-4.008,4L26,26H17l-4,4H30ZM16.979,8L21,4H4V20.977L8,17,8,8h8.981Z"
+          />
+          <polygon fill="currentColor" points="25 4 4 25 4 30 9 30 30 9 30 4 25 4" />
+        </>
+      );
+    case "BOTTOM":
+      return (
+        <>
+          <path
+            fill="currentColor"
+            fillOpacity={0.4}
+            fillRule="evenodd"
+            d="M13,20h7V13H13v7ZM4,4V26.984l3.955-4L8,8,22.986,8l4-4H4Z"
+          />
+          <polygon fill="currentColor" points="29.997 5.955 25 11 25 25 11 25 5.955 29.997 30 30 29.997 5.955" />
+        </>
+      );
+    case "UTILITY":
+      return (
+        <path
+          fill="currentColor"
+          fillRule="evenodd"
+          d="M26,13c3.535,0,8-4,8-4H23l-3,3,2,7,5-2-3-4h2ZM22,5L20.827,3H13.062L12,5l5,6Zm-5,9-1-1L13,28l4,3,4-3L18,13ZM11,9H0s4.465,4,8,4h2L7,17l5,2,2-7Z"
+        />
+      );
+    case "ALL":
+    default:
+      return (
+        <>
+          <rect x="6" y="6" width="9" height="9" rx="2" fill="currentColor" fillOpacity={0.4} />
+          <rect x="19" y="6" width="9" height="9" rx="2" fill="currentColor" />
+          <rect x="6" y="19" width="9" height="9" rx="2" fill="currentColor" />
+          <rect x="19" y="19" width="9" height="9" rx="2" fill="currentColor" fillOpacity={0.4} />
+        </>
+      );
+  }
+}
+
+export function LaneIcon({
+  role,
+  className
+}: {
+  role: string | null | undefined;
+  className?: string;
+}) {
+  return (
+    <svg viewBox="0 0 34 34" aria-hidden="true" className={className}>
+      <LaneGlyphPaths lane={normalizeLane(role)} />
+    </svg>
+  );
+}


### PR DESCRIPTION
Tier list: new TierListFilterBar with Lane+Rank primary controls over quieter Region+Patch refinements, moved out of the hero to sit directly above the champion table. Real Community Dragon position icons (LaneIcon) in the lane tabs and on every champion row; the heavy board-view toolbar is slimmed to one compact strip.

Landings (/, /lol, /tft): cut meta-instructional copy. The home page is now data-forward with a best-effort live strip (patch + top LoL picks + top TFT comps) that degrades gracefully and never crashes on a Data Dragon hiccup; TFT's big-number stat cards become a compact browse row; rounded-full CTAs are now rounded-xl.

Also: patch badge scoped to the LoL column, home preview pinned to Emerald+ to match where its links lead, adaptive single/two-column strip, and screen-reader lane labels + region group semantics.

Frontend-only; no API/contract/migration changes.

## Summary

## Changes

## Verification
- [ ] `dotnet build` (or N/A)
- [ ] `pnpm web:test` (or N/A)
- [ ] `pnpm web:build` (or N/A)

## Documentation (Required)
- [ ] Docs updated for behavior/API/config changes (or N/A with reason)
  - `README.md`
  - `docs/DEVELOPMENT.md`
  - `docs/API.md`
  - `docs/ARCHITECTURE.md`

