### PR TITLE
Profile page: redesign + bans/rank-history/damage/objectives/mastery/played-with/timeline

### DIFF
--- a/Transcendence.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Data/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMatchRepository, MatchRepository>();
         services.AddScoped<ISummonerRepository, SummonerRepository>();
         services.AddScoped<IRankRepository, RankRepository>();
+        services.AddScoped<IChampionMasteryRepository, ChampionMasteryRepository>();
         services.AddScoped<IRefreshLockRepository, RefreshLockRepository>();
         services.AddScoped<IApiClientKeyRepository, ApiClientKeyRepository>();
         services.AddScoped<ILiveGameSnapshotRepository, LiveGameSnapshotRepository>();

--- a/Transcendence.Data/Models/LoL/Account/ChampionMastery.cs
+++ b/Transcendence.Data/Models/LoL/Account/ChampionMastery.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Transcendence.Data.Models.LoL.Account;
+
+/// <summary>
+/// A summoner's champion-mastery snapshot (Riot mastery-v4). One row per
+/// (summoner, champion). Refreshed by the worker on summoner refresh.
+/// </summary>
+public class ChampionMastery
+{
+    public Guid SummonerId { get; set; }
+    public int ChampionId { get; set; }
+    public int ChampionLevel { get; set; }
+    public long ChampionPoints { get; set; }
+    public long LastPlayTime { get; set; }
+    public bool ChestGranted { get; set; }
+    public int TokensEarned { get; set; }
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonIgnore] public Summoner? Summoner { get; set; }
+}

--- a/Transcendence.Data/Models/LoL/Account/Summoner.cs
+++ b/Transcendence.Data/Models/LoL/Account/Summoner.cs
@@ -24,4 +24,5 @@ public class Summoner
     public ICollection<SummonerIngestionCursor> IngestionCursors { get; } = [];
     public ICollection<Rank> Ranks { get; set; } = new List<Rank>();
     public ICollection<HistoricalRank> HistoricalRanks { get; set; } = new List<HistoricalRank>();
+    public ICollection<ChampionMastery> ChampionMasteries { get; set; } = new List<ChampionMastery>();
 }

--- a/Transcendence.Data/Models/LoL/Match/Match.cs
+++ b/Transcendence.Data/Models/LoL/Match/Match.cs
@@ -34,6 +34,7 @@ public class Match
     public List<Summoner> Summoners { get; set; } = [];
     public ICollection<MatchParticipant> Participants { get; set; } = new List<MatchParticipant>();
     public ICollection<MatchBan> Bans { get; set; } = new List<MatchBan>();
+    public ICollection<MatchTeamObjective> TeamObjectives { get; set; } = new List<MatchTeamObjective>();
     public ICollection<MatchParticipantTimelineSnapshot> TimelineSnapshots { get; set; } =
         new List<MatchParticipantTimelineSnapshot>();
     public MatchTimelineFetchState? TimelineFetchState { get; set; }

--- a/Transcendence.Data/Models/LoL/Match/MatchParticipant.cs
+++ b/Transcendence.Data/Models/LoL/Match/MatchParticipant.cs
@@ -32,6 +32,9 @@ public class MatchParticipant
     public int ChampLevel { get; set; }
     public int GoldEarned { get; set; }
     public int TotalDamageDealtToChampions { get; set; }
+    public int PhysicalDamageDealtToChampions { get; set; }
+    public int MagicDamageDealtToChampions { get; set; }
+    public int TrueDamageDealtToChampions { get; set; }
     public int VisionScore { get; set; }
     public int TotalMinionsKilled { get; set; }
     public int NeutralMinionsKilled { get; set; }

--- a/Transcendence.Data/Models/LoL/Match/MatchTeamObjective.cs
+++ b/Transcendence.Data/Models/LoL/Match/MatchTeamObjective.cs
@@ -1,0 +1,27 @@
+namespace Transcendence.Data.Models.LoL.Match;
+
+/// <summary>
+/// Per-team objective tallies for a match (one row per team: 100 / 200), from
+/// Riot match-v5 info.teams[].objectives. Populated on new ingestion only.
+/// </summary>
+public class MatchTeamObjective
+{
+    public Guid MatchId { get; set; }
+    public required Match Match { get; set; }
+    public int TeamId { get; set; }
+
+    public bool FirstBlood { get; set; }
+
+    public int BaronKills { get; set; }
+    public bool BaronFirst { get; set; }
+    public int DragonKills { get; set; }
+    public bool DragonFirst { get; set; }
+    public int RiftHeraldKills { get; set; }
+    public bool RiftHeraldFirst { get; set; }
+    public int HordeKills { get; set; }
+    public bool HordeFirst { get; set; }
+    public int TowerKills { get; set; }
+    public bool TowerFirst { get; set; }
+    public int InhibitorKills { get; set; }
+    public bool InhibitorFirst { get; set; }
+}

--- a/Transcendence.Data/Repositories/Implementations/ChampionMasteryRepository.cs
+++ b/Transcendence.Data/Repositories/Implementations/ChampionMasteryRepository.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Repositories.Interfaces;
+
+namespace Transcendence.Data.Repositories.Implementations;
+
+public class ChampionMasteryRepository(TranscendenceContext context) : IChampionMasteryRepository
+{
+    public async Task UpsertAsync(Guid summonerId, List<ChampionMastery> masteries,
+        CancellationToken cancellationToken = default)
+    {
+        var existing = await context.ChampionMasteries
+            .Where(cm => cm.SummonerId == summonerId)
+            .ToListAsync(cancellationToken);
+        var existingByChampion = existing.ToDictionary(cm => cm.ChampionId);
+        var incomingChampionIds = new HashSet<int>();
+
+        foreach (var incoming in masteries)
+        {
+            incomingChampionIds.Add(incoming.ChampionId);
+
+            if (existingByChampion.TryGetValue(incoming.ChampionId, out var current))
+            {
+                current.ChampionLevel = incoming.ChampionLevel;
+                current.ChampionPoints = incoming.ChampionPoints;
+                current.LastPlayTime = incoming.LastPlayTime;
+                current.ChestGranted = incoming.ChestGranted;
+                current.TokensEarned = incoming.TokensEarned;
+                current.UpdatedAt = DateTime.UtcNow;
+            }
+            else
+            {
+                incoming.SummonerId = summonerId;
+                incoming.UpdatedAt = DateTime.UtcNow;
+                await context.ChampionMasteries.AddAsync(incoming, cancellationToken);
+            }
+        }
+
+        // Prune masteries Riot no longer returns so the stored snapshot stays accurate.
+        var stale = existing.Where(cm => !incomingChampionIds.Contains(cm.ChampionId)).ToList();
+        if (stale.Count > 0)
+            context.ChampionMasteries.RemoveRange(stale);
+    }
+}

--- a/Transcendence.Data/Repositories/Interfaces/IChampionMasteryRepository.cs
+++ b/Transcendence.Data/Repositories/Interfaces/IChampionMasteryRepository.cs
@@ -1,0 +1,12 @@
+using Transcendence.Data.Models.LoL.Account;
+
+namespace Transcendence.Data.Repositories.Interfaces;
+
+public interface IChampionMasteryRepository
+{
+    /// <summary>
+    /// Replaces a summoner's champion-mastery snapshot with the supplied list
+    /// (insert/update by champion, prune champions no longer present). Caller saves.
+    /// </summary>
+    Task UpsertAsync(Guid summonerId, List<ChampionMastery> masteries, CancellationToken cancellationToken = default);
+}

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -23,6 +23,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<CurrentChampionLoadout> CurrentChampionLoadouts { get; set; }
     public DbSet<MatchParticipant> MatchParticipants { get; set; }
     public DbSet<MatchBan> MatchBans { get; set; }
+    public DbSet<MatchTeamObjective> MatchTeamObjectives { get; set; }
     public DbSet<MatchTimelineFetchState> MatchTimelineFetchStates { get; set; }
     public DbSet<MatchParticipantTimelineSnapshot> MatchParticipantTimelineSnapshots { get; set; }
 
@@ -437,6 +438,18 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
 
         modelBuilder.Entity<MatchBan>()
             .HasQueryFilter(mb => mb.Match.Status != FetchStatus.PermanentlyUnfetchable);
+
+        modelBuilder.Entity<MatchTeamObjective>(entity =>
+        {
+            entity.HasKey(o => new { o.MatchId, o.TeamId });
+            entity.HasOne(o => o.Match)
+                .WithMany(m => m.TeamObjectives)
+                .HasForeignKey(o => o.MatchId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<MatchTeamObjective>()
+            .HasQueryFilter(o => o.Match.Status != FetchStatus.PermanentlyUnfetchable);
 
         modelBuilder.Entity<MatchTimelineFetchState>(entity =>
         {

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -18,6 +18,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<CurrentDataParameters> CurrentDataParameters { get; set; }
     public DbSet<Rank> Ranks { get; set; }
     public DbSet<HistoricalRank> HistoricalRanks { get; set; }
+    public DbSet<ChampionMastery> ChampionMasteries { get; set; }
     public DbSet<TrackedProSummoner> TrackedProSummoners { get; set; }
     public DbSet<SummonerIngestionCursor> SummonerIngestionCursors { get; set; }
     public DbSet<CurrentChampionLoadout> CurrentChampionLoadouts { get; set; }
@@ -450,6 +451,15 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
 
         modelBuilder.Entity<MatchTeamObjective>()
             .HasQueryFilter(o => o.Match.Status != FetchStatus.PermanentlyUnfetchable);
+
+        modelBuilder.Entity<ChampionMastery>(entity =>
+        {
+            entity.HasKey(cm => new { cm.SummonerId, cm.ChampionId });
+            entity.HasOne(cm => cm.Summoner)
+                .WithMany(s => s.ChampionMasteries)
+                .HasForeignKey(cm => cm.SummonerId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
 
         modelBuilder.Entity<MatchTimelineFetchState>(entity =>
         {

--- a/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
@@ -20,6 +20,7 @@ public class SummonerStatsService(
     private const string OverviewCacheKeyPrefix = "stats:overview:";
     private const string ChampionsCacheKeyPrefix = "stats:champions:";
     private const string RolesCacheKeyPrefix = "stats:roles:";
+    private const string RankHistoryCacheKeyPrefix = "stats:rank-history:";
     private const string RecentMatchesCacheKeyPrefix = "stats:recent:";
     private const string MatchDetailCacheKeyPrefix = "match:detail:";
     private const string SummonerStatsCacheTagPrefix = "summoner-stats:";
@@ -250,6 +251,47 @@ public class SummonerStatsService(
             .ToList();
 
         return list;
+    }
+
+    public async Task<IReadOnlyList<RankHistoryEntry>> GetRankHistoryAsync(Guid summonerId, string? queueType,
+        CancellationToken ct)
+    {
+        var normalizedQueue = string.IsNullOrWhiteSpace(queueType) ? null : queueType.Trim();
+        var cacheKey = $"{RankHistoryCacheKeyPrefix}{summonerId}:{normalizedQueue ?? "-"}";
+        return await ExecuteStatsRequestAsync(
+            "Failed to load rank history.",
+            async token => await cache.GetOrCreateAsync(
+                cacheKey,
+                async cancel => await ComputeRankHistoryAsync(summonerId, normalizedQueue, cancel),
+                StatsCacheOptions,
+                tags: new[] { BuildSummonerStatsTag(summonerId) },
+                cancellationToken: token),
+            ct);
+    }
+
+    private async Task<IReadOnlyList<RankHistoryEntry>> ComputeRankHistoryAsync(Guid summonerId, string? queueType,
+        CancellationToken ct)
+    {
+        // HistoricalRank uses a shadow FK "SummonerId" (indexed) — query it directly to avoid a Summoner join.
+        var query = db.HistoricalRanks
+            .AsNoTracking()
+            .Where(hr => EF.Property<Guid?>(hr, "SummonerId") == summonerId);
+
+        if (queueType != null)
+            query = query.Where(hr => hr.QueueType == queueType);
+
+        return await query
+            .OrderBy(hr => hr.DateRecorded)
+            .ThenBy(hr => hr.Id)
+            .Select(hr => new RankHistoryEntry(
+                hr.QueueType,
+                hr.Tier,
+                hr.RankNumber,
+                hr.LeaguePoints,
+                hr.Wins,
+                hr.Losses,
+                hr.DateRecorded))
+            .ToListAsync(ct);
     }
 
     public async Task<PagedResult<RecentMatchSummary>> GetRecentMatchesAsync(
@@ -599,6 +641,7 @@ public class SummonerStatsService(
                 .ThenInclude(p => p.Items)
             .Include(m => m.Participants)
                 .ThenInclude(p => p.Runes)
+            .Include(m => m.Bans)
             .FirstOrDefaultAsync(m => m.MatchId == matchId, ct);
 
         if (match == null)
@@ -632,6 +675,14 @@ public class SummonerStatsService(
 
         var participants = match.Participants.Select(p => MapParticipant(p, runeMetadata)).ToList();
 
+        var bans = match.Bans
+            .GroupBy(b => b.TeamId)
+            .OrderBy(g => g.Key)
+            .Select(g => new TeamBansDto(
+                g.Key,
+                g.OrderBy(b => b.PickTurn).Select(b => b.ChampionId).ToList()))
+            .ToList();
+
         return new MatchDetailDto(
             match.MatchId ?? string.Empty,
             match.MatchDate,
@@ -641,7 +692,8 @@ public class SummonerStatsService(
                 ? match.QueueType
                 : QueueCatalog.ResolveQueueLabel(match.QueueId),
             string.IsNullOrWhiteSpace(match.Patch) ? null : match.Patch,
-            participants
+            participants,
+            bans
         );
     }
 

--- a/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
@@ -21,6 +21,8 @@ public class SummonerStatsService(
     private const string ChampionsCacheKeyPrefix = "stats:champions:";
     private const string RolesCacheKeyPrefix = "stats:roles:";
     private const string RankHistoryCacheKeyPrefix = "stats:rank-history:";
+    private const string PlayedWithCacheKeyPrefix = "stats:played-with:";
+    private const string MasteryCacheKeyPrefix = "stats:mastery:";
     private const string RecentMatchesCacheKeyPrefix = "stats:recent:";
     private const string MatchDetailCacheKeyPrefix = "match:detail:";
     private const string SummonerStatsCacheTagPrefix = "summoner-stats:";
@@ -291,6 +293,119 @@ public class SummonerStatsService(
                 hr.Wins,
                 hr.Losses,
                 hr.DateRecorded))
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<PlayedWithEntry>> GetPlayedWithAsync(Guid summonerId, int recentMatches,
+        int topCount, CancellationToken ct)
+    {
+        recentMatches = Math.Clamp(recentMatches <= 0 ? 100 : recentMatches, 1, 100);
+        topCount = Math.Clamp(topCount <= 0 ? 6 : topCount, 1, 10);
+        var cacheKey = $"{PlayedWithCacheKeyPrefix}{summonerId}:{recentMatches}:{topCount}";
+        return await ExecuteStatsRequestAsync(
+            "Failed to compute recently-played-with.",
+            async token => await cache.GetOrCreateAsync(
+                cacheKey,
+                async cancel => await ComputePlayedWithAsync(summonerId, recentMatches, topCount, cancel),
+                StatsCacheOptions,
+                tags: new[] { BuildSummonerStatsTag(summonerId) },
+                cancellationToken: token),
+            ct);
+    }
+
+    private async Task<IReadOnlyList<PlayedWithEntry>> ComputePlayedWithAsync(Guid summonerId, int recentMatches,
+        int topCount, CancellationToken ct)
+    {
+        // Step 1: anchor on the summoner's own participation in their most recent matches
+        // (carries my team + my result per match). Bounded by recentMatches.
+        var anchor = await db.MatchParticipants
+            .AsNoTracking()
+            .Where(mp => mp.SummonerId == summonerId)
+            .OrderByDescending(mp => mp.Match.MatchDate)
+            .Select(mp => new { mp.MatchId, mp.TeamId, mp.Win })
+            .Take(recentMatches)
+            .ToListAsync(ct);
+
+        if (anchor.Count == 0)
+            return [];
+
+        var anchorByMatch = anchor
+            .GroupBy(a => a.MatchId)
+            .ToDictionary(g => g.Key, g => g.First());
+        var matchIds = anchorByMatch.Keys.ToList();
+
+        // Step 2: co-participants in those matches (excluding self), via the indexed MatchId IN (...).
+        var coRows = await db.MatchParticipants
+            .AsNoTracking()
+            .Where(mp => matchIds.Contains(mp.MatchId) && mp.SummonerId != summonerId)
+            .Select(mp => new
+            {
+                mp.MatchId,
+                mp.SummonerId,
+                mp.TeamId,
+                mp.Summoner.GameName,
+                mp.Summoner.TagLine
+            })
+            .ToListAsync(ct);
+
+        return coRows
+            .GroupBy(r => r.SummonerId)
+            .Select(g =>
+            {
+                var first = g.First();
+                var sameTeamGames = 0;
+                var sameTeamWins = 0;
+                foreach (var row in g)
+                {
+                    if (!anchorByMatch.TryGetValue(row.MatchId, out var me))
+                        continue;
+                    if (row.TeamId == me.TeamId)
+                    {
+                        sameTeamGames++;
+                        if (me.Win) sameTeamWins++;
+                    }
+                }
+
+                return new PlayedWithEntry(g.Key, first.GameName, first.TagLine, g.Count(), sameTeamGames, sameTeamWins);
+            })
+            .Where(e => e.GamesTogether >= 2)
+            .OrderByDescending(e => e.GamesTogether)
+            .ThenByDescending(e => e.SameTeamGames)
+            .Take(topCount)
+            .ToList();
+    }
+
+    public async Task<IReadOnlyList<ChampionMasteryEntry>> GetTopMasteryAsync(Guid summonerId, int top,
+        CancellationToken ct)
+    {
+        top = Math.Clamp(top <= 0 ? 6 : top, 1, 20);
+        var cacheKey = $"{MasteryCacheKeyPrefix}{summonerId}:{top}";
+        return await ExecuteStatsRequestAsync(
+            "Failed to load champion mastery.",
+            async token => await cache.GetOrCreateAsync(
+                cacheKey,
+                async cancel => await ComputeTopMasteryAsync(summonerId, top, cancel),
+                StatsCacheOptions,
+                tags: new[] { BuildSummonerStatsTag(summonerId) },
+                cancellationToken: token),
+            ct);
+    }
+
+    private async Task<IReadOnlyList<ChampionMasteryEntry>> ComputeTopMasteryAsync(Guid summonerId, int top,
+        CancellationToken ct)
+    {
+        return await db.ChampionMasteries
+            .AsNoTracking()
+            .Where(cm => cm.SummonerId == summonerId)
+            .OrderByDescending(cm => cm.ChampionPoints)
+            .Take(top)
+            .Select(cm => new ChampionMasteryEntry(
+                cm.ChampionId,
+                cm.ChampionLevel,
+                cm.ChampionPoints,
+                cm.LastPlayTime,
+                cm.ChestGranted,
+                cm.TokensEarned))
             .ToListAsync(ct);
     }
 

--- a/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
@@ -25,6 +25,7 @@ public class SummonerStatsService(
     private const string MasteryCacheKeyPrefix = "stats:mastery:";
     private const string RecentMatchesCacheKeyPrefix = "stats:recent:";
     private const string MatchDetailCacheKeyPrefix = "match:detail:";
+    private const string MatchTimelineCacheKeyPrefix = "match:timeline:";
     private const string SummonerStatsCacheTagPrefix = "summoner-stats:";
 
     // Stats cache options: 5min total, 2min L1 (stats change on refresh)
@@ -743,6 +744,52 @@ public class SummonerStatsService(
                 MatchDetailCacheOptions,
                 cancellationToken: token),
             ct);
+    }
+
+    public async Task<MatchTimelineDto?> GetMatchTimelineAsync(string matchId, CancellationToken ct)
+    {
+        var cacheKey = $"{MatchTimelineCacheKeyPrefix}{matchId}";
+        return await ExecuteStatsRequestAsync(
+            "Failed to load match timeline.",
+            async token => await cache.GetOrCreateAsync(
+                cacheKey,
+                async cancel => await ComputeMatchTimelineAsync(matchId, cancel),
+                MatchDetailCacheOptions,
+                cancellationToken: token),
+            ct);
+    }
+
+    private async Task<MatchTimelineDto?> ComputeMatchTimelineAsync(string matchId, CancellationToken ct)
+    {
+        var match = await db.Matches
+            .AsNoTracking()
+            .Where(m => m.MatchId == matchId)
+            .Select(m => new { m.Id, m.Duration })
+            .FirstOrDefaultAsync(ct);
+
+        if (match == null)
+            return null;
+
+        var rows = await (
+            from s in db.MatchParticipantTimelineSnapshots.AsNoTracking()
+            where s.MatchId == match.Id
+            join p in db.MatchParticipants.AsNoTracking()
+                on new { s.MatchId, s.ParticipantId } equals new { p.MatchId, p.ParticipantId }
+            select new { s.MinuteMark, p.TeamId, s.Gold, s.Xp }
+        ).ToListAsync(ct);
+
+        var frames = rows
+            .GroupBy(r => r.MinuteMark)
+            .OrderBy(g => g.Key)
+            .Select(g => new TimelineFrameDto(
+                g.Key,
+                g.Where(x => x.TeamId == 100).Sum(x => x.Gold),
+                g.Where(x => x.TeamId == 200).Sum(x => x.Gold),
+                g.Where(x => x.TeamId == 100).Sum(x => x.Xp),
+                g.Where(x => x.TeamId == 200).Sum(x => x.Xp)))
+            .ToList();
+
+        return new MatchTimelineDto(matchId, match.Duration, frames);
     }
 
     private async Task<MatchDetailDto?> ComputeMatchDetailAsync(string matchId, CancellationToken ct)

--- a/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
@@ -642,6 +642,7 @@ public class SummonerStatsService(
             .Include(m => m.Participants)
                 .ThenInclude(p => p.Runes)
             .Include(m => m.Bans)
+            .Include(m => m.TeamObjectives)
             .FirstOrDefaultAsync(m => m.MatchId == matchId, ct);
 
         if (match == null)
@@ -683,6 +684,19 @@ public class SummonerStatsService(
                 g.OrderBy(b => b.PickTurn).Select(b => b.ChampionId).ToList()))
             .ToList();
 
+        var objectives = match.TeamObjectives
+            .OrderBy(o => o.TeamId)
+            .Select(o => new TeamObjectivesDto(
+                o.TeamId,
+                o.FirstBlood,
+                new ObjectiveStatDto(o.BaronKills, o.BaronFirst),
+                new ObjectiveStatDto(o.DragonKills, o.DragonFirst),
+                new ObjectiveStatDto(o.RiftHeraldKills, o.RiftHeraldFirst),
+                new ObjectiveStatDto(o.HordeKills, o.HordeFirst),
+                new ObjectiveStatDto(o.TowerKills, o.TowerFirst),
+                new ObjectiveStatDto(o.InhibitorKills, o.InhibitorFirst)))
+            .ToList();
+
         return new MatchDetailDto(
             match.MatchId ?? string.Empty,
             match.MatchDate,
@@ -693,7 +707,8 @@ public class SummonerStatsService(
                 : QueueCatalog.ResolveQueueLabel(match.QueueId),
             string.IsNullOrWhiteSpace(match.Patch) ? null : match.Patch,
             participants,
-            bans
+            bans,
+            objectives
         );
     }
 
@@ -730,6 +745,9 @@ public class SummonerStatsService(
             p.ChampLevel,
             p.GoldEarned,
             p.TotalDamageDealtToChampions,
+            p.PhysicalDamageDealtToChampions,
+            p.MagicDamageDealtToChampions,
+            p.TrueDamageDealtToChampions,
             p.VisionScore,
             p.TotalMinionsKilled,
             p.NeutralMinionsKilled,

--- a/Transcendence.Service.Core/Services/Analysis/Interfaces/ISummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Interfaces/ISummonerStatsService.cs
@@ -9,6 +9,11 @@ public interface ISummonerStatsService
     Task<IReadOnlyList<ChampionStat>> GetChampionStatsAsync(Guid summonerId, int top, CancellationToken ct);
     Task<IReadOnlyList<RoleStat>> GetRoleBreakdownAsync(Guid summonerId, CancellationToken ct);
 
+    /// <summary>
+    /// Gets recorded rank snapshots (LP/tier progression) for a summoner, oldest first.
+    /// </summary>
+    Task<IReadOnlyList<RankHistoryEntry>> GetRankHistoryAsync(Guid summonerId, string? queueType, CancellationToken ct);
+
     Task<PagedResult<RecentMatchSummary>> GetRecentMatchesAsync(
         Guid summonerId,
         int page,

--- a/Transcendence.Service.Core/Services/Analysis/Interfaces/ISummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Interfaces/ISummonerStatsService.cs
@@ -14,6 +14,16 @@ public interface ISummonerStatsService
     /// </summary>
     Task<IReadOnlyList<RankHistoryEntry>> GetRankHistoryAsync(Guid summonerId, string? queueType, CancellationToken ct);
 
+    /// <summary>
+    /// Gets the summoners this player most frequently appears in matches with (from recent matches).
+    /// </summary>
+    Task<IReadOnlyList<PlayedWithEntry>> GetPlayedWithAsync(Guid summonerId, int recentMatches, int topCount, CancellationToken ct);
+
+    /// <summary>
+    /// Gets the summoner's highest champion-mastery entries (by points), served from stored data.
+    /// </summary>
+    Task<IReadOnlyList<ChampionMasteryEntry>> GetTopMasteryAsync(Guid summonerId, int top, CancellationToken ct);
+
     Task<PagedResult<RecentMatchSummary>> GetRecentMatchesAsync(
         Guid summonerId,
         int page,

--- a/Transcendence.Service.Core/Services/Analysis/Interfaces/ISummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Interfaces/ISummonerStatsService.cs
@@ -39,4 +39,10 @@ public interface ISummonerStatsService
     /// <param name="ct">Cancellation token</param>
     /// <returns>Full match details or null if match not found</returns>
     Task<MatchDetailDto?> GetMatchDetailAsync(string matchId, CancellationToken ct);
+
+    /// <summary>
+    /// Gets the per-minute team gold/xp timeline for a match (the gold/xp-diff curve).
+    /// Null if the match is unknown; Frames empty if no timeline snapshots exist.
+    /// </summary>
+    Task<MatchTimelineDto?> GetMatchTimelineAsync(string matchId, CancellationToken ct);
 }

--- a/Transcendence.Service.Core/Services/Analysis/Models/StatsModels.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Models/StatsModels.cs
@@ -65,6 +65,24 @@ public record RankHistoryEntry(
     DateTime DateRecorded
 );
 
+public record PlayedWithEntry(
+    Guid SummonerId,
+    string? GameName,
+    string? TagLine,
+    int GamesTogether,
+    int SameTeamGames,
+    int SameTeamWins
+);
+
+public record ChampionMasteryEntry(
+    int ChampionId,
+    int ChampionLevel,
+    long ChampionPoints,
+    long LastPlayTime,
+    bool ChestGranted,
+    int TokensEarned
+);
+
 public record RecentMatchSummary(
     string MatchId,
     long MatchDate,

--- a/Transcendence.Service.Core/Services/Analysis/Models/StatsModels.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Models/StatsModels.cs
@@ -55,6 +55,16 @@ public record RoleStat(
     double WinRate
 );
 
+public record RankHistoryEntry(
+    string? QueueType,
+    string? Tier,
+    string? RankNumber,
+    int LeaguePoints,
+    int Wins,
+    int Losses,
+    DateTime DateRecorded
+);
+
 public record RecentMatchSummary(
     string MatchId,
     long MatchDate,

--- a/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
@@ -90,6 +90,7 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<ISummonerService, SummonerService>();
         services.AddScoped<IRankService, RankService>();
+        services.AddScoped<IChampionMasteryService, ChampionMasteryService>();
         services.AddScoped<IMatchService, MatchService>();
         services.AddScoped<IStaticDataService, StaticDataService>();
         services.AddScoped<IRiotMatchIdsClient, RiotMatchIdsClient>();

--- a/Transcendence.Service.Core/Services/Jobs/Configuration/TimelineIngestionOptions.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Configuration/TimelineIngestionOptions.cs
@@ -4,6 +4,11 @@ public class TimelineIngestionOptions
 {
     public bool Enabled { get; set; } = true;
     public int MinuteMark { get; set; } = 15;
+    /// <summary>
+    /// Cadence (in minutes) for the multi-frame timeline curve. Snapshots are captured at
+    /// each multiple of this value up to game length, plus the analytics <see cref="MinuteMark"/>.
+    /// </summary>
+    public int FrameIntervalMinutes { get; set; } = 2;
     public int MaxRetryAttempts { get; set; } = 4;
     public int BackfillBatchSize { get; set; } = 100;
     public int BackfillMaxEnqueuesPerRun { get; set; } = 50;

--- a/Transcendence.Service.Core/Services/Jobs/MatchTimelineIngestionJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/MatchTimelineIngestionJob.cs
@@ -94,22 +94,31 @@ public class MatchTimelineIngestionJob(
             if (timeline?.Info?.Frames == null || timeline.Info.Frames.Length == 0)
                 throw new InvalidOperationException("Timeline response did not include frames.");
 
-            var minuteMark = Math.Max(1, jobOptions.MinuteMark);
-            var targetTimestampMs = minuteMark * 60 * 1000;
-            var selectedFrame = SelectFrameForMinuteMark(timeline.Info.Frames, targetTimestampMs);
-
-            if (selectedFrame == null || selectedFrame.ParticipantFrames == null)
-                throw new InvalidOperationException("Timeline frame for minute mark could not be resolved.");
-
             BackfillParticipantIdsFromTimeline(match.Participants, timeline.Info.Participants);
 
-            var qualityFlags = BuildQualityFlags(match, selectedFrame.Timestamp, targetTimestampMs);
-            var snapshots = BuildSnapshots(match, selectedFrame, minuteMark, qualityFlags);
-            if (snapshots.Count == 0)
-                throw new InvalidOperationException("No participant snapshots could be derived from timeline frame.");
+            // Capture a multi-frame curve: a regular cadence up to game length, plus the
+            // analytics anchor mark (kept so champion-analytics gold/xp-diff@N stays intact).
+            var anchorMark = Math.Max(1, jobOptions.MinuteMark);
+            var minuteMarks = BuildMinuteMarks(match.Duration, Math.Max(1, jobOptions.FrameIntervalMinutes), anchorMark);
 
+            var snapshots = new List<MatchParticipantTimelineSnapshot>();
+            foreach (var mark in minuteMarks)
+            {
+                var targetTimestampMs = mark * 60 * 1000;
+                var selectedFrame = SelectFrameForMinuteMark(timeline.Info.Frames, targetTimestampMs);
+                if (selectedFrame?.ParticipantFrames == null)
+                    continue;
+
+                var qualityFlags = BuildQualityFlags(match, selectedFrame.Timestamp, targetTimestampMs);
+                snapshots.AddRange(BuildSnapshots(match, selectedFrame, mark, qualityFlags));
+            }
+
+            if (snapshots.Count == 0)
+                throw new InvalidOperationException("No participant snapshots could be derived from timeline frames.");
+
+            // Replace the whole snapshot set for this match so re-ingestion is idempotent.
             var existingSnapshots = await db.MatchParticipantTimelineSnapshots
-                .Where(x => x.MatchId == match.Id && x.MinuteMark == minuteMark)
+                .Where(x => x.MatchId == match.Id)
                 .ToListAsync(ct);
             if (existingSnapshots.Count > 0)
                 db.MatchParticipantTimelineSnapshots.RemoveRange(existingSnapshots);
@@ -147,6 +156,19 @@ public class MatchTimelineIngestionJob(
                     TimeSpan.FromSeconds(delaySeconds));
             }
         }
+    }
+
+    public static IReadOnlyList<int> BuildMinuteMarks(int durationSeconds, int intervalMinutes, int anchorMark)
+    {
+        var durationMinutes = Math.Max(1, durationSeconds / 60);
+        var interval = Math.Max(1, intervalMinutes);
+        var marks = new SortedSet<int>();
+        for (var mark = interval; mark <= durationMinutes; mark += interval)
+            marks.Add(mark);
+        // The analytics anchor is always captured, even for games shorter than the anchor
+        // (it resolves to the final frame, exactly as the single-frame ingestion did).
+        marks.Add(Math.Max(1, anchorMark));
+        return marks.ToList();
     }
 
     private static FramesTimeLine? SelectFrameForMinuteMark(FramesTimeLine[] frames, int targetTimestampMs)

--- a/Transcendence.Service.Core/Services/Jobs/SummonerRefreshJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/SummonerRefreshJob.cs
@@ -21,6 +21,8 @@ public class SummonerRefreshJob(
     ISummonerRepository summonerRepository,
     IMatchRepository matchRepository,
     IMatchService matchService,
+    IChampionMasteryService championMasteryService,
+    IChampionMasteryRepository championMasteryRepository,
     TranscendenceContext db,
     IRefreshLockRepository refreshLockRepository,
     ILogger<SummonerRefreshJob> logger,
@@ -57,6 +59,9 @@ public class SummonerRefreshJob(
             var summoner = await summonerService.GetSummonerByRiotIdAsync(gameName, tagLine, platformRoute, ct);
             await summonerRepository.AddOrUpdateSummonerAsync(summoner, ct);
             await db.SaveChangesAsync(ct);
+
+            // Enrich with champion mastery (fail-soft — never block a refresh on it).
+            await TryRefreshChampionMasteryAsync(summoner, platformRoute, gameName, tagLine, ct);
 
             var regional = platformRoute.ToRegional();
             var pageSize = Math.Max(1, options.MatchIdsPageSize);
@@ -861,6 +866,31 @@ public class SummonerRefreshJob(
         }
 
         return persisted;
+    }
+
+    private async Task TryRefreshChampionMasteryAsync(Summoner summoner, PlatformRoute platformRoute,
+        string gameName, string tagLine, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(summoner.Puuid))
+            return;
+
+        try
+        {
+            var masteries = await championMasteryService.GetMasteriesAsync(summoner.Puuid, platformRoute, ct);
+            await championMasteryRepository.UpsertAsync(summoner.Id, masteries, ct);
+            await db.SaveChangesAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Mastery is enrichment; never let its failure fail a refresh.
+            logger.LogWarning(ex,
+                "[Refresh] Champion mastery refresh failed for {GameName}#{Tag} on {Platform}; continuing refresh.",
+                gameName, tagLine, platformRoute);
+        }
     }
 
     private async Task InvalidateStatsCacheAsync(Guid summonerId, CancellationToken ct)

--- a/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
@@ -41,6 +41,24 @@ public record TeamObjectivesDto(
 public record ObjectiveStatDto(int Kills, bool First);
 
 /// <summary>
+/// Per-minute team gold/xp totals for a match, for the gold/xp-diff curve.
+/// Empty Frames when the match has no (or too few) timeline snapshots.
+/// </summary>
+public record MatchTimelineDto(
+    string MatchId,
+    int Duration,
+    IReadOnlyList<TimelineFrameDto> Frames
+);
+
+public record TimelineFrameDto(
+    int MinuteMark,
+    int BlueGold,
+    int RedGold,
+    int BlueXp,
+    int RedXp
+);
+
+/// <summary>
 /// Complete participant data for a match including all stats, items, runes, and spells.
 /// </summary>
 public record ParticipantDetailDto(

--- a/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
@@ -11,7 +11,8 @@ public record MatchDetailDto(
     string QueueType,
     string? Patch,
     IReadOnlyList<ParticipantDetailDto> Participants,
-    IReadOnlyList<TeamBansDto> Bans
+    IReadOnlyList<TeamBansDto> Bans,
+    IReadOnlyList<TeamObjectivesDto> Objectives
 );
 
 /// <summary>
@@ -21,6 +22,23 @@ public record TeamBansDto(
     int TeamId,
     IReadOnlyList<int> BannedChampionIds
 );
+
+/// <summary>
+/// Objective tallies for one team (kills + who got it first). Populated on new
+/// ingestion only — absent/zero for matches ingested before Phase 3.
+/// </summary>
+public record TeamObjectivesDto(
+    int TeamId,
+    bool FirstBlood,
+    ObjectiveStatDto Baron,
+    ObjectiveStatDto Dragon,
+    ObjectiveStatDto RiftHerald,
+    ObjectiveStatDto Horde,
+    ObjectiveStatDto Tower,
+    ObjectiveStatDto Inhibitor
+);
+
+public record ObjectiveStatDto(int Kills, bool First);
 
 /// <summary>
 /// Complete participant data for a match including all stats, items, runes, and spells.
@@ -39,6 +57,9 @@ public record ParticipantDetailDto(
     int ChampLevel,
     int GoldEarned,
     int TotalDamageDealtToChampions,
+    int PhysicalDamageDealtToChampions,
+    int MagicDamageDealtToChampions,
+    int TrueDamageDealtToChampions,
     int VisionScore,
     int TotalMinionsKilled,
     int NeutralMinionsKilled,

--- a/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
@@ -10,7 +10,16 @@ public record MatchDetailDto(
     int QueueId,
     string QueueType,
     string? Patch,
-    IReadOnlyList<ParticipantDetailDto> Participants
+    IReadOnlyList<ParticipantDetailDto> Participants,
+    IReadOnlyList<TeamBansDto> Bans
+);
+
+/// <summary>
+/// Champions banned by one team, in pick-turn order.
+/// </summary>
+public record TeamBansDto(
+    int TeamId,
+    IReadOnlyList<int> BannedChampionIds
 );
 
 /// <summary>

--- a/Transcendence.Service.Core/Services/RiotApi/DTOs/SummonerProfileResponse.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/DTOs/SummonerProfileResponse.cs
@@ -19,6 +19,12 @@ public class SummonerProfileResponse
     // Top champions by games played
     public List<ProfileChampionStat>? TopChampions { get; set; }
 
+    // Summoners this player most frequently appears in matches with
+    public List<FrequentlyPlayedWithStat>? FrequentlyPlayedWith { get; set; }
+
+    // Highest champion mastery (by points)
+    public List<ChampionMasteryStat>? TopMastery { get; set; }
+
     // Data freshness
     public DataAgeMetadata ProfileAge { get; set; } = new();
     public DataAgeMetadata RankAge { get; set; } = new();
@@ -69,4 +75,31 @@ public class ProfileChampionStat
     public int Losses { get; set; }
     public double WinRate { get; set; }
     public double KdaRatio { get; set; }
+}
+
+/// <summary>
+/// A summoner frequently appearing in the profile owner's matches.
+/// </summary>
+public class FrequentlyPlayedWithStat
+{
+    public Guid SummonerId { get; set; }
+    public string GameName { get; set; } = string.Empty;
+    public string TagLine { get; set; } = string.Empty;
+    public int GamesTogether { get; set; }
+    public int SameTeamGames { get; set; }
+    public int SameTeamWins { get; set; }
+}
+
+/// <summary>
+/// A champion-mastery entry for the profile response.
+/// </summary>
+public class ChampionMasteryStat
+{
+    public int ChampionId { get; set; }
+    public string ChampionName { get; set; } = string.Empty;
+    public int ChampionLevel { get; set; }
+    public long ChampionPoints { get; set; }
+    public long LastPlayTime { get; set; }
+    public bool ChestGranted { get; set; }
+    public int TokensEarned { get; set; }
 }

--- a/Transcendence.Service.Core/Services/RiotApi/DTOs/SummonerProfileResponse.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/DTOs/SummonerProfileResponse.cs
@@ -19,9 +19,6 @@ public class SummonerProfileResponse
     // Top champions by games played
     public List<ProfileChampionStat>? TopChampions { get; set; }
 
-    // Recent match summaries (last 10)
-    public List<ProfileRecentMatch>? RecentMatches { get; set; }
-
     // Data freshness
     public DataAgeMetadata ProfileAge { get; set; } = new();
     public DataAgeMetadata RankAge { get; set; } = new();
@@ -72,21 +69,4 @@ public class ProfileChampionStat
     public int Losses { get; set; }
     public double WinRate { get; set; }
     public double KdaRatio { get; set; }
-}
-
-/// <summary>
-/// Recent match summary for the profile response.
-/// </summary>
-public class ProfileRecentMatch
-{
-    public string MatchId { get; set; } = string.Empty;
-    public long MatchDate { get; set; }
-    public string QueueType { get; set; } = string.Empty;
-    public bool Win { get; set; }
-    public int ChampionId { get; set; }
-    public string ChampionName { get; set; } = string.Empty;
-    public int Kills { get; set; }
-    public int Deaths { get; set; }
-    public int Assists { get; set; }
-    public double CsPerMin { get; set; }
 }

--- a/Transcendence.Service.Core/Services/RiotApi/Implementations/ChampionMasteryService.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/Implementations/ChampionMasteryService.cs
@@ -1,0 +1,27 @@
+using Camille.Enums;
+using Camille.RiotGames;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Service.Core.Services.RiotApi.Interfaces;
+
+namespace Transcendence.Service.Core.Services.RiotApi.Implementations;
+
+public class ChampionMasteryService(LeagueRiotApiContext riotApiContext) : IChampionMasteryService
+{
+    public async Task<List<ChampionMastery>> GetMasteriesAsync(string summonerPuuid, PlatformRoute platformRoute,
+        CancellationToken cancellationToken = default)
+    {
+        var entries = await riotApiContext.Api.ChampionMasteryV4()
+            .GetAllChampionMasteriesByPUUIDAsync(platformRoute, summonerPuuid, cancellationToken);
+
+        // Normalize to entities without binding to a Summoner; the repository attaches the FK.
+        return entries.Select(e => new ChampionMastery
+        {
+            ChampionId = (int)e.ChampionId,
+            ChampionLevel = e.ChampionLevel,
+            ChampionPoints = e.ChampionPoints,
+            LastPlayTime = e.LastPlayTime,
+            ChestGranted = e.ChestGranted ?? false,
+            TokensEarned = e.TokensEarned
+        }).ToList();
+    }
+}

--- a/Transcendence.Service.Core/Services/RiotApi/Implementations/MatchService.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/Implementations/MatchService.cs
@@ -56,6 +56,7 @@ public class MatchService(
         };
         ApplyQueueMetadata(match, (int)info.QueueId);
         PopulateMatchBans(match, info);
+        PopulateTeamObjectives(match, info);
 
         // Ensure static data for this match patch exists
         await staticDataService.EnsureStaticDataForPatchAsync(match.Patch, cancellationToken);
@@ -128,6 +129,10 @@ public class MatchService(
                 ChampLevel = p.ChampLevel,
                 GoldEarned = p.GoldEarned,
                 TotalDamageDealtToChampions = p.TotalDamageDealtToChampions,
+                // keep the damage split in sync across all 3 participant-mapping blocks
+                PhysicalDamageDealtToChampions = p.PhysicalDamageDealtToChampions,
+                MagicDamageDealtToChampions = p.MagicDamageDealtToChampions,
+                TrueDamageDealtToChampions = p.TrueDamageDealtToChampions,
                 VisionScore = p.VisionScore,
                 TotalMinionsKilled = p.TotalMinionsKilled,
                 NeutralMinionsKilled = p.NeutralMinionsKilled,
@@ -193,6 +198,7 @@ public class MatchService(
         };
         ApplyQueueMetadata(match, (int)info.QueueId);
         PopulateMatchBans(match, info);
+        PopulateTeamObjectives(match, info);
 
         await staticDataService.EnsureStaticDataForPatchAsync(match.Patch, cancellationToken);
 
@@ -299,6 +305,10 @@ public class MatchService(
                 ChampLevel = p.ChampLevel,
                 GoldEarned = p.GoldEarned,
                 TotalDamageDealtToChampions = p.TotalDamageDealtToChampions,
+                // keep the damage split in sync across all 3 participant-mapping blocks
+                PhysicalDamageDealtToChampions = p.PhysicalDamageDealtToChampions,
+                MagicDamageDealtToChampions = p.MagicDamageDealtToChampions,
+                TrueDamageDealtToChampions = p.TrueDamageDealtToChampions,
                 VisionScore = p.VisionScore,
                 TotalMinionsKilled = p.TotalMinionsKilled,
                 NeutralMinionsKilled = p.NeutralMinionsKilled,
@@ -380,6 +390,7 @@ public class MatchService(
             match.PlatformRegion = platformRoute.ToString();
             ApplyQueueMetadata(match, (int)info.QueueId);
             PopulateMatchBans(match, info);
+            PopulateTeamObjectives(match, info);
 
             // Ensure static data for this match patch exists
             await staticDataService.EnsureStaticDataForPatchAsync(match.Patch, cancellationToken);
@@ -450,6 +461,10 @@ public class MatchService(
                     ChampLevel = p.ChampLevel,
                     GoldEarned = p.GoldEarned,
                     TotalDamageDealtToChampions = p.TotalDamageDealtToChampions,
+                    // keep the damage split in sync across all 3 participant-mapping blocks
+                    PhysicalDamageDealtToChampions = p.PhysicalDamageDealtToChampions,
+                    MagicDamageDealtToChampions = p.MagicDamageDealtToChampions,
+                    TrueDamageDealtToChampions = p.TrueDamageDealtToChampions,
                     VisionScore = p.VisionScore,
                     TotalMinionsKilled = p.TotalMinionsKilled,
                     NeutralMinionsKilled = p.NeutralMinionsKilled,
@@ -768,6 +783,37 @@ public class MatchService(
                     ChampionId = (int)ban.ChampionId
                 });
             }
+        }
+    }
+
+    private static void PopulateTeamObjectives(DataMatch match, Info info)
+    {
+        match.TeamObjectives.Clear();
+        var teams = info.Teams?.ToList() ?? [];
+        foreach (var team in teams)
+        {
+            var objectives = team.Objectives;
+            if (objectives == null)
+                continue;
+
+            match.TeamObjectives.Add(new MatchTeamObjective
+            {
+                Match = match,
+                TeamId = (int)team.TeamId,
+                FirstBlood = objectives.Champion?.First ?? false,
+                BaronKills = objectives.Baron?.Kills ?? 0,
+                BaronFirst = objectives.Baron?.First ?? false,
+                DragonKills = objectives.Dragon?.Kills ?? 0,
+                DragonFirst = objectives.Dragon?.First ?? false,
+                RiftHeraldKills = objectives.RiftHerald?.Kills ?? 0,
+                RiftHeraldFirst = objectives.RiftHerald?.First ?? false,
+                HordeKills = objectives.Horde?.Kills ?? 0,
+                HordeFirst = objectives.Horde?.First ?? false,
+                TowerKills = objectives.Tower?.Kills ?? 0,
+                TowerFirst = objectives.Tower?.First ?? false,
+                InhibitorKills = objectives.Inhibitor?.Kills ?? 0,
+                InhibitorFirst = objectives.Inhibitor?.First ?? false
+            });
         }
     }
 

--- a/Transcendence.Service.Core/Services/RiotApi/Interfaces/IChampionMasteryService.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/Interfaces/IChampionMasteryService.cs
@@ -1,0 +1,10 @@
+using Camille.Enums;
+using Transcendence.Data.Models.LoL.Account;
+
+namespace Transcendence.Service.Core.Services.RiotApi.Interfaces;
+
+public interface IChampionMasteryService
+{
+    Task<List<ChampionMastery>> GetMasteriesAsync(string summonerPuuid, PlatformRoute platformRoute,
+        CancellationToken cancellationToken = default);
+}

--- a/Transcendence.Service/Migrations/20260608040403_AddMatchDamageBreakdownAndTeamObjectives.Designer.cs
+++ b/Transcendence.Service/Migrations/20260608040403_AddMatchDamageBreakdownAndTeamObjectives.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260608040403_AddMatchDamageBreakdownAndTeamObjectives")]
+    partial class AddMatchDamageBreakdownAndTeamObjectives
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260608040403_AddMatchDamageBreakdownAndTeamObjectives.cs
+++ b/Transcendence.Service/Migrations/20260608040403_AddMatchDamageBreakdownAndTeamObjectives.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMatchDamageBreakdownAndTeamObjectives : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MagicDamageDealtToChampions",
+                table: "MatchParticipants",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PhysicalDamageDealtToChampions",
+                table: "MatchParticipants",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TrueDamageDealtToChampions",
+                table: "MatchParticipants",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "MatchTeamObjectives",
+                columns: table => new
+                {
+                    MatchId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TeamId = table.Column<int>(type: "integer", nullable: false),
+                    FirstBlood = table.Column<bool>(type: "boolean", nullable: false),
+                    BaronKills = table.Column<int>(type: "integer", nullable: false),
+                    BaronFirst = table.Column<bool>(type: "boolean", nullable: false),
+                    DragonKills = table.Column<int>(type: "integer", nullable: false),
+                    DragonFirst = table.Column<bool>(type: "boolean", nullable: false),
+                    RiftHeraldKills = table.Column<int>(type: "integer", nullable: false),
+                    RiftHeraldFirst = table.Column<bool>(type: "boolean", nullable: false),
+                    HordeKills = table.Column<int>(type: "integer", nullable: false),
+                    HordeFirst = table.Column<bool>(type: "boolean", nullable: false),
+                    TowerKills = table.Column<int>(type: "integer", nullable: false),
+                    TowerFirst = table.Column<bool>(type: "boolean", nullable: false),
+                    InhibitorKills = table.Column<int>(type: "integer", nullable: false),
+                    InhibitorFirst = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MatchTeamObjectives", x => new { x.MatchId, x.TeamId });
+                    table.ForeignKey(
+                        name: "FK_MatchTeamObjectives_Matches_MatchId",
+                        column: x => x.MatchId,
+                        principalTable: "Matches",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MatchTeamObjectives");
+
+            migrationBuilder.DropColumn(
+                name: "MagicDamageDealtToChampions",
+                table: "MatchParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "PhysicalDamageDealtToChampions",
+                table: "MatchParticipants");
+
+            migrationBuilder.DropColumn(
+                name: "TrueDamageDealtToChampions",
+                table: "MatchParticipants");
+        }
+    }
+}

--- a/Transcendence.Service/Migrations/20260608042747_AddChampionMasteryTracking.Designer.cs
+++ b/Transcendence.Service/Migrations/20260608042747_AddChampionMasteryTracking.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260608042747_AddChampionMasteryTracking")]
+    partial class AddChampionMasteryTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260608042747_AddChampionMasteryTracking.cs
+++ b/Transcendence.Service/Migrations/20260608042747_AddChampionMasteryTracking.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChampionMasteryTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChampionMasteries",
+                columns: table => new
+                {
+                    SummonerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ChampionId = table.Column<int>(type: "integer", nullable: false),
+                    ChampionLevel = table.Column<int>(type: "integer", nullable: false),
+                    ChampionPoints = table.Column<long>(type: "bigint", nullable: false),
+                    LastPlayTime = table.Column<long>(type: "bigint", nullable: false),
+                    ChestGranted = table.Column<bool>(type: "boolean", nullable: false),
+                    TokensEarned = table.Column<int>(type: "integer", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChampionMasteries", x => new { x.SummonerId, x.ChampionId });
+                    table.ForeignKey(
+                        name: "FK_ChampionMasteries_Summoners_SummonerId",
+                        column: x => x.SummonerId,
+                        principalTable: "Summoners",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChampionMasteries");
+        }
+    }
+}

--- a/Transcendence.WebAPI/Controllers/SummonerStatsController.cs
+++ b/Transcendence.WebAPI/Controllers/SummonerStatsController.cs
@@ -83,6 +83,28 @@ public class SummonerStatsController(ISummonerStatsService statsService) : Contr
     }
 
     /// <summary>
+    ///     Gets recorded rank snapshots (LP/tier progression) for a summoner, oldest first.
+    /// </summary>
+    [HttpGet("stats/rank-history")]
+    [ProducesResponseType(typeof(List<RankHistoryEntryDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetRankHistory([FromRoute] Guid summonerId,
+        [FromQuery] string? queueType = null, CancellationToken ct = default)
+    {
+        var result = await statsService.GetRankHistoryAsync(summonerId, queueType, ct);
+        var dto = result.Select(r => new RankHistoryEntryDto(
+            r.QueueType,
+            r.Tier,
+            r.RankNumber,
+            r.LeaguePoints,
+            r.Wins,
+            r.Losses,
+            r.DateRecorded
+        )).ToList();
+        return Ok(dto);
+    }
+
+    /// <summary>
     ///     Gets recent matches for a summoner with pagination.
     /// </summary>
     [HttpGet("matches/recent")]

--- a/Transcendence.WebAPI/Controllers/SummonerStatsController.cs
+++ b/Transcendence.WebAPI/Controllers/SummonerStatsController.cs
@@ -178,4 +178,23 @@ public class SummonerStatsController(ISummonerStatsService statsService) : Contr
 
         return Ok(result);
     }
+
+    /// <summary>
+    ///     Gets the per-minute team gold/xp timeline for a match (the gold/xp-diff curve).
+    /// </summary>
+    [HttpGet("matches/{matchId}/timeline")]
+    [ProducesResponseType(typeof(MatchTimelineDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> GetMatchTimeline(
+        [FromRoute] Guid summonerId,
+        [FromRoute] string matchId,
+        CancellationToken ct = default)
+    {
+        var result = await statsService.GetMatchTimelineAsync(matchId, ct);
+        if (result == null)
+            return NotFound();
+
+        return Ok(result);
+    }
 }

--- a/Transcendence.WebAPI/Controllers/SummonersController.cs
+++ b/Transcendence.WebAPI/Controllers/SummonersController.cs
@@ -116,6 +116,8 @@ public class SummonersController(
             var overview = await statsService.GetSummonerOverviewAsync(summoner.Id, 20, ct);
             var champions = await statsService.GetChampionStatsAsync(summoner.Id, 5, ct);
             var recent = await statsService.GetRecentMatchesAsync(summoner.Id, 1, 10, null, null, ct);
+            var playedWith = await statsService.GetPlayedWithAsync(summoner.Id, 100, 6, ct);
+            var mastery = await statsService.GetTopMasteryAsync(summoner.Id, 6, ct);
 
             // Calculate StatsAge from most recent match
             var mostRecentMatchDate = recent.Items.Count > 0 ? recent.Items[0].MatchDate : (long?)null;
@@ -173,6 +175,27 @@ public class SummonersController(
                     Losses = c.Losses,
                     WinRate = c.WinRate,
                     KdaRatio = c.KdaRatio
+                }).ToList(),
+
+                FrequentlyPlayedWith = playedWith.Select(p => new FrequentlyPlayedWithStat
+                {
+                    SummonerId = p.SummonerId,
+                    GameName = p.GameName ?? string.Empty,
+                    TagLine = p.TagLine ?? string.Empty,
+                    GamesTogether = p.GamesTogether,
+                    SameTeamGames = p.SameTeamGames,
+                    SameTeamWins = p.SameTeamWins
+                }).ToList(),
+
+                TopMastery = mastery.Select(m => new ChampionMasteryStat
+                {
+                    ChampionId = m.ChampionId,
+                    ChampionName = ResolveChampionName(m.ChampionId),
+                    ChampionLevel = m.ChampionLevel,
+                    ChampionPoints = m.ChampionPoints,
+                    LastPlayTime = m.LastPlayTime,
+                    ChestGranted = m.ChestGranted,
+                    TokensEarned = m.TokensEarned
                 }).ToList(),
 
                 ProfileAge = new DataAgeMetadata

--- a/Transcendence.WebAPI/Controllers/SummonersController.cs
+++ b/Transcendence.WebAPI/Controllers/SummonersController.cs
@@ -175,21 +175,6 @@ public class SummonersController(
                     KdaRatio = c.KdaRatio
                 }).ToList(),
 
-                // Recent 10 matches
-                RecentMatches = recent.Items.Select(m => new ProfileRecentMatch
-                {
-                    MatchId = m.MatchId,
-                    MatchDate = m.MatchDate,
-                    QueueType = m.QueueType,
-                    Win = m.Win,
-                    ChampionId = m.ChampionId,
-                    ChampionName = ResolveChampionName(m.ChampionId),
-                    Kills = m.Kills,
-                    Deaths = m.Deaths,
-                    Assists = m.Assists,
-                    CsPerMin = m.CsPerMin
-                }).ToList(),
-
                 ProfileAge = new DataAgeMetadata
                 {
                     FetchedAt = summoner.UpdatedAt

--- a/Transcendence.WebAPI/Models/Stats/SummonerStatsDtos.cs
+++ b/Transcendence.WebAPI/Models/Stats/SummonerStatsDtos.cs
@@ -51,6 +51,16 @@ public record RoleStatDto(
     double WinRate
 );
 
+public record RankHistoryEntryDto(
+    string? QueueType,
+    string? Tier,
+    string? RankNumber,
+    int LeaguePoints,
+    int Wins,
+    int Losses,
+    DateTime DateRecorded
+);
+
 public record RecentMatchSummaryDto(
     string MatchId,
     long MatchDate,

--- a/apps/web/app/api/static/runes/route.ts
+++ b/apps/web/app/api/static/runes/route.ts
@@ -4,10 +4,10 @@ import { fetchRunesReforged } from "@/lib/staticData";
 
 export async function GET() {
   try {
-    const { version, runeById, styleById, runeSortById } = await fetchRunesReforged();
+    const { version, runeById, styleById, runeSortById, trees } = await fetchRunesReforged();
 
     return NextResponse.json(
-      { version, runeById, styleById, runeSortById },
+      { version, runeById, styleById, runeSortById, trees },
       {
         headers: {
           "cache-control": "public, s-maxage=86400, stale-while-revalidate=86400"

--- a/apps/web/components/RuneTreeDisplay.tsx
+++ b/apps/web/components/RuneTreeDisplay.tsx
@@ -57,16 +57,18 @@ function StyleHeader({
   styleId,
   styleById,
   label,
-  size
+  size,
+  dense = false
 }: {
   styleId: number;
   styleById: Record<string, RuneMeta>;
   label: string;
   size: number;
+  dense?: boolean;
 }) {
   const style = styleById[String(styleId)];
   return (
-    <div className="mb-2 flex items-center gap-2">
+    <div className={cn("flex items-center gap-2", dense ? "mb-1.5" : "mb-2")}>
       {style ? (
         <Image
           src={runeIconUrl(style.icon)}
@@ -98,7 +100,10 @@ export function RuneTreeDisplay({
   trees,
   runeById,
   styleById,
-  iconSize = 26,
+  iconSize,
+  density = "default",
+  gridClassName,
+  panelClassName,
   className
 }: {
   primaryStyleId: number;
@@ -110,6 +115,12 @@ export function RuneTreeDisplay({
   runeById: Record<string, RuneMeta>;
   styleById: Record<string, RuneMeta>;
   iconSize?: number;
+  /** "compact" shrinks icons/padding and drops the inner panel chrome for tight contexts (match scoreboard). */
+  density?: "default" | "compact";
+  /** Override the outer grid (e.g. single column inside a participant card). */
+  gridClassName?: string;
+  /** Override the inner tree/shard panel surface (e.g. borderless when nested in an already-bordered shell). */
+  panelClassName?: string;
   className?: string;
 }) {
   const primaryTree = trees.find((tree) => tree.id === primaryStyleId);
@@ -122,20 +133,28 @@ export function RuneTreeDisplay({
     return <p className="type-caption text-muted">Runes unavailable.</p>;
   }
 
-  const keystoneSize = iconSize + 6;
+  const compact = density === "compact";
+  const resolvedIcon = iconSize ?? (compact ? 22 : 26);
+  const keystoneSize = resolvedIcon + 6;
+  const shardSize = Math.max(12, resolvedIcon - (compact ? 6 : 4));
+  const slotGap = compact ? "gap-1" : "gap-2.5";
+  const keystonePad = compact ? "gap-1.5 border-b border-border/30 pb-1.5" : "gap-2 border-b border-border/30 pb-2.5";
+  const colGap = compact ? "gap-2" : "gap-3";
+  const panelCls = panelClassName ?? (compact ? "rounded-control p-2" : "surface-subtle rounded-control p-3");
+  const gridCls = gridClassName ?? "grid w-full gap-4 sm:grid-cols-2";
 
   return (
-    <div className={cn("grid w-full gap-4 sm:grid-cols-2", className)}>
+    <div className={cn(gridCls, className)}>
       {primaryTree ? (
-        <div className="surface-subtle rounded-control p-3">
-          <StyleHeader styleId={primaryStyleId} styleById={styleById} label="Primary" size={iconSize} />
-          <div className="grid gap-2.5">
+        <div className={panelCls}>
+          <StyleHeader styleId={primaryStyleId} styleById={styleById} label="Primary" size={resolvedIcon} dense={compact} />
+          <div className={cn("grid", slotGap)}>
             {primaryTree.slots.map((slot, slotIdx) => (
               <div
                 key={`p-slot-${slotIdx}`}
                 className={cn(
                   "flex items-center justify-between gap-1.5",
-                  slotIdx === 0 && "gap-2 border-b border-border/30 pb-2.5"
+                  slotIdx === 0 && keystonePad
                 )}
               >
                 {slot.runes.map((rune) => (
@@ -146,7 +165,7 @@ export function RuneTreeDisplay({
                     fallbackIcon={rune.icon}
                     runeById={runeById}
                     selected={primarySet.has(rune.id)}
-                    size={slotIdx === 0 ? keystoneSize : iconSize}
+                    size={slotIdx === 0 ? keystoneSize : resolvedIcon}
                   />
                 ))}
               </div>
@@ -155,11 +174,11 @@ export function RuneTreeDisplay({
         </div>
       ) : null}
 
-      <div className="grid gap-3">
+      <div className={cn("grid", colGap)}>
         {secondaryTree ? (
-          <div className="surface-subtle rounded-control p-3">
-            <StyleHeader styleId={subStyleId} styleById={styleById} label="Secondary" size={iconSize} />
-            <div className="grid gap-2.5">
+          <div className={panelCls}>
+            <StyleHeader styleId={subStyleId} styleById={styleById} label="Secondary" size={resolvedIcon} dense={compact} />
+            <div className={cn("grid", slotGap)}>
               {secondaryTree.slots.slice(1).map((slot, slotIdx) => (
                 <div key={`s-slot-${slotIdx}`} className="flex items-center justify-between gap-1.5">
                   {slot.runes.map((rune) => (
@@ -170,7 +189,7 @@ export function RuneTreeDisplay({
                       fallbackIcon={rune.icon}
                       runeById={runeById}
                       selected={subSet.has(rune.id)}
-                      size={iconSize}
+                      size={resolvedIcon}
                     />
                   ))}
                 </div>
@@ -179,9 +198,9 @@ export function RuneTreeDisplay({
           </div>
         ) : null}
 
-        <div className="surface-subtle rounded-control p-3">
+        <div className={panelCls}>
           <span className="type-overline text-muted">Shards</span>
-          <div className="mt-2 grid gap-1.5">
+          <div className={cn("grid", compact ? "mt-1.5 gap-1" : "mt-2 gap-1.5")}>
             {STAT_SHARD_ROWS.map((row, rowIdx) => {
               const selectedForRow = statShards[rowIdx];
               return (
@@ -194,7 +213,7 @@ export function RuneTreeDisplay({
                       fallbackIcon=""
                       runeById={runeById}
                       selected={shardId === selectedForRow}
-                      size={iconSize - 4}
+                      size={shardSize}
                       shape="circle"
                     />
                   ))}

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -21,6 +21,7 @@ import {
   type MatchSummary,
   type PagedResultDto,
   type QueueOption,
+  type RankHistoryEntry,
   type RankInfo,
   type RuneStatic,
   type SpellStatic,
@@ -32,7 +33,8 @@ import { computeNextPollDelayMs } from "@/lib/polling";
 import { formatQueueLabel } from "@/lib/queues";
 import {
   buildLolPublicSummonerByIdPath,
-  buildLolPublicSummonerByRiotIdPath
+  buildLolPublicSummonerByRiotIdPath,
+  buildLolPublicSummonerRankHistoryPath
 } from "@/lib/lolPublicApi";
 
 export type { SummonerProfileResponse } from "@/components/lol-profile/shared";
@@ -97,6 +99,7 @@ export function SummonerProfileClient({
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [details, setDetails] = useState<Record<string, MatchDetail | null>>({});
   const [detailBusy, setDetailBusy] = useState<Record<string, boolean>>({});
+  const [rankHistory, setRankHistory] = useState<RankHistoryEntry[] | null>(null);
 
   const queueOptions = useMemo<QueueOption[]>(() => {
     const optionMap = new Map<string, QueueOption>();
@@ -340,6 +343,27 @@ export function SummonerProfileClient({
     };
   }, [page, profile?.summonerId]);
 
+  useEffect(() => {
+    const summonerId = profile?.summonerId;
+    if (!summonerId) return;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch(buildLolPublicSummonerRankHistoryPath(summonerId), { cache: "no-store" });
+        if (!res.ok || cancelled) return;
+        const json = (await res.json().catch(() => null)) as RankHistoryEntry[] | null;
+        if (!cancelled && Array.isArray(json)) setRankHistory(json);
+      } catch {
+        // Rank progression is optional decoration — ignore fetch errors.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [profile?.summonerId]);
+
   async function queueRefresh() {
     setBusy(true);
     setError(null);
@@ -439,6 +463,7 @@ export function SummonerProfileClient({
             championStatic={championStatic}
             rankedEntries={rankedEntries}
             unrankedQueues={unrankedQueues}
+            rankHistory={rankHistory}
             region={region}
             gameName={gameName}
             tagLine={tagLine}

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -8,9 +8,6 @@ import { MatchHistorySection } from "@/components/lol-profile/MatchHistorySectio
 import { ProfileHeroCard } from "@/components/lol-profile/ProfileHeroCard";
 import { ProfileSidebar } from "@/components/lol-profile/ProfileSidebar";
 import {
-  buildAlignedParticipantRows,
-  buildRuneRowKey,
-  hasRunes,
   matchKdaRatio,
   normalizeInitialQueue,
   normalizeInitialSort,
@@ -20,7 +17,6 @@ import {
   type ChampionStatic,
   type ItemStatic,
   type MatchDetail,
-  type MatchParticipant,
   type MatchSortOption,
   type MatchSummary,
   type PagedResultDto,
@@ -41,15 +37,9 @@ import {
 
 export type { SummonerProfileResponse } from "@/components/lol-profile/shared";
 
-// Stable hash of a riot id so the hero splash picks the same skin on every render
-// (avoids SSR/hydration drift that Math.random() would cause).
-function hashRiotId(value: string): number {
-  let hash = 0;
-  for (let i = 0; i < value.length; i++) {
-    hash = (hash * 31 + value.charCodeAt(i)) | 0;
-  }
-  return Math.abs(hash);
-}
+// Stop polling the 202→200 refresh loop after this many attempts (~2-3 min with the
+// 1-10s backoff) so a stuck worker degrades to a retry prompt instead of an endless spinner.
+const MAX_POLL_ATTEMPTS = 24;
 
 export function SummonerProfileClient({
   region,
@@ -91,6 +81,7 @@ export function SummonerProfileClient({
   const [busy, setBusy] = useState(false);
   const [polling, setPolling] = useState(initialStatus === 202);
   const [pollDelayMs, setPollDelayMs] = useState(2000);
+  const [pollAttempts, setPollAttempts] = useState(0);
   const [championStatic, setChampionStatic] = useState<ChampionStatic | null>(null);
   const [itemStatic, setItemStatic] = useState<ItemStatic | null>(null);
   const [spellStatic, setSpellStatic] = useState<SpellStatic | null>(null);
@@ -106,8 +97,6 @@ export function SummonerProfileClient({
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [details, setDetails] = useState<Record<string, MatchDetail | null>>({});
   const [detailBusy, setDetailBusy] = useState<Record<string, boolean>>({});
-  const [expandedRunes, setExpandedRunes] = useState<Record<string, boolean>>({});
-  const [heroSkinNum, setHeroSkinNum] = useState(0);
 
   const queueOptions = useMemo<QueueOption[]>(() => {
     const optionMap = new Map<string, QueueOption>();
@@ -283,21 +272,30 @@ export function SummonerProfileClient({
     }
 
     setAccepted(null);
+    setPolling(false);
     setError(pickApiError(res.status, json));
   }, [gameName, region, tagLine]);
 
   useEffect(() => {
     if (!polling) return;
+    if (pollAttempts >= MAX_POLL_ATTEMPTS) {
+      setPolling(false);
+      setAccepted({
+        message: "This update is taking longer than expected — it'll keep processing in the background. Tap Update Now to check again."
+      });
+      return;
+    }
     const timeout = setTimeout(async () => {
       try {
         await fetchProfileOnce();
       } finally {
+        setPollAttempts((n) => n + 1);
         setPollDelayMs((delay) => computeNextPollDelayMs(delay));
       }
     }, pollDelayMs);
 
     return () => clearTimeout(timeout);
-  }, [fetchProfileOnce, pollDelayMs, polling]);
+  }, [fetchProfileOnce, pollAttempts, pollDelayMs, polling]);
 
   useEffect(() => {
     const summonerId = profile?.summonerId;
@@ -357,6 +355,7 @@ export function SummonerProfileClient({
         return;
       }
       setAccepted(json ?? { message: "Update started." });
+      setPollAttempts(0);
       setPolling(true);
       setPollDelayMs(computeNextPollDelayMs(2000, json?.retryAfterSeconds));
     } catch (e) {
@@ -389,30 +388,6 @@ export function SummonerProfileClient({
     }
   }
 
-  function toggleRuneRow(runeRowKey: string) {
-    setExpandedRunes((state) => ({
-      ...state,
-      [runeRowKey]: !state[runeRowKey]
-    }));
-  }
-
-  function toggleAllRunesForMatch(matchId: string, participants: MatchParticipant[], expanded: boolean) {
-    const updates: Record<string, boolean> = {};
-    const rows = buildAlignedParticipantRows(participants ?? []);
-
-    rows.forEach((row, rowIndex) => {
-      if (row.blue && hasRunes(row.blue.runes)) {
-        updates[buildRuneRowKey(matchId, 100, rowIndex, row.blue)] = expanded;
-      }
-      if (row.red && hasRunes(row.red.runes)) {
-        updates[buildRuneRowKey(matchId, 200, rowIndex, row.red)] = expanded;
-      }
-    });
-
-    if (Object.keys(updates).length === 0) return;
-    setExpandedRunes((state) => ({ ...state, ...updates }));
-  }
-
   const rankedEntries = useMemo(() => {
     const entries: Array<{ label: string; rank: RankInfo }> = [];
     if (profile?.soloRank) entries.push({ label: "Solo/Duo", rank: profile.soloRank });
@@ -428,53 +403,6 @@ export function SummonerProfileClient({
   }, [profile?.flexRank, profile?.soloRank]);
 
   const dataAge = profile?.profileAge?.ageDescription ?? "updated recently";
-  const featuredChampion = (profile?.topChampions ?? [])[0];
-  const featuredChampionName = featuredChampion
-    ? championStatic?.champions[String(featuredChampion.championId)]?.name ?? featuredChampion.championName
-    : null;
-  const featuredSlug = featuredChampion
-    ? championStatic?.champions[String(featuredChampion.championId)]?.id ?? null
-    : null;
-  const staticVersion = championStatic?.version ?? null;
-
-  // Pick a (stable) random skin splash for the most-played champion as the hero backdrop.
-  useEffect(() => {
-    setHeroSkinNum(0);
-    if (!featuredSlug || !staticVersion) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(
-          `https://ddragon.leagueoflegends.com/cdn/${staticVersion}/data/en_US/champion/${featuredSlug}.json`
-        );
-        if (!res.ok || cancelled) return;
-        const data = (await res.json()) as {
-          data?: Record<string, { skins?: Array<{ num: number }> }>;
-        };
-        const skins = data?.data?.[featuredSlug]?.skins ?? [];
-        if (skins.length === 0 || cancelled) return;
-        const picked = skins[hashRiotId(`${gameName}#${tagLine}`) % skins.length]?.num ?? 0;
-        if (picked === 0 || cancelled) return;
-        // Some skin `num`s have no splash art on the (versionless) CDN, which
-        // would leave the backdrop blank. Only upgrade from the base splash
-        // once the chosen skin's art actually loads; otherwise keep `_0`.
-        const probe = new window.Image();
-        probe.onload = () => {
-          if (!cancelled) setHeroSkinNum(picked);
-        };
-        probe.src = `https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${featuredSlug}_${picked}.jpg`;
-      } catch {
-        // Keep the base splash on any failure.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [featuredSlug, staticVersion, gameName, tagLine]);
-
-  const heroBackgroundUrl = featuredSlug
-    ? `https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${featuredSlug}_${heroSkinNum}.jpg`
-    : null;
   const sortOptions: Array<{ value: MatchSortOption; label: string }> = [
     { value: "DATE_DESC", label: "Most Recent" },
     { value: "KDA_DESC", label: "Best KDA" },
@@ -482,24 +410,20 @@ export function SummonerProfileClient({
   ];
 
   return (
-    <div className="grid gap-8">
+    <div className="grid grid-cols-1 gap-8">
       <ProfileHeroCard
         title={title}
         region={region}
         gameName={gameName}
         tagLine={tagLine}
         profile={profile}
-        backgroundUrl={heroBackgroundUrl}
         championStatic={championStatic}
-        history={history}
         dataAge={dataAge}
         rankedEntries={rankedEntries}
         quickStats={quickStats}
         recentForm={recentForm}
         accepted={accepted}
         error={error}
-        featuredChampion={featuredChampion}
-        featuredChampionName={featuredChampionName}
         busy={busy}
         onRefresh={queueRefresh}
       />
@@ -509,7 +433,7 @@ export function SummonerProfileClient({
           <Skeleton className="h-16 w-full" />
         </Card>
       ) : (
-        <div className="grid gap-6 xl:grid-cols-[minmax(280px,0.32fr)_minmax(0,1fr)] xl:items-start">
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(280px,0.32fr)_minmax(0,1fr)] xl:items-start">
           <ProfileSidebar
             profile={profile}
             championStatic={championStatic}
@@ -537,7 +461,6 @@ export function SummonerProfileClient({
             expandedMatchId={expandedMatchId}
             details={details}
             detailBusy={detailBusy}
-            expandedRunes={expandedRunes}
             championStatic={championStatic}
             itemStatic={itemStatic}
             spellStatic={spellStatic}
@@ -556,8 +479,6 @@ export function SummonerProfileClient({
               setPage(1);
             }}
             onToggleExpanded={toggleExpanded}
-            onToggleRuneRow={toggleRuneRow}
-            onToggleAllRunesForMatch={toggleAllRunesForMatch}
             onPreviousPage={() => setPage((current) => Math.max(1, current - 1))}
             onNextPage={() => setPage((current) => current + 1)}
           />

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -472,6 +472,7 @@ export function SummonerProfileClient({
             region={region}
             gameName={gameName}
             tagLine={tagLine}
+            summonerId={profile.summonerId ?? ""}
             page={page}
             queue={queue}
             championFilter={championFilter}

--- a/apps/web/components/lol-profile/GoldDiffChart.tsx
+++ b/apps/web/components/lol-profile/GoldDiffChart.tsx
@@ -1,0 +1,63 @@
+import { cn } from "@/lib/cn";
+import type { TimelineFrame } from "@/components/lol-profile/shared";
+
+// Gold lead over time: blue team's gold advantage (blueGold - redGold) plotted
+// against a 0 baseline — area above is the blue team's lead, below is the red
+// team's. Color encodes which team is ahead (team-blue / team-red), no gold.
+export function GoldDiffChart({ frames, className }: { frames: TimelineFrame[]; className?: string }) {
+  if (frames.length < 2) return null;
+
+  const W = 320;
+  const H = 76;
+  const pad = 6;
+
+  const points = frames.map((f) => ({ minute: f.minuteMark, diff: f.blueGold - f.redGold }));
+  const maxAbs = Math.max(1, ...points.map((p) => Math.abs(p.diff)));
+  const minMinute = points[0].minute;
+  const maxMinute = points[points.length - 1].minute;
+  const minuteSpan = Math.max(1, maxMinute - minMinute);
+  const mid = H / 2;
+
+  const x = (minute: number) => pad + ((minute - minMinute) / minuteSpan) * (W - 2 * pad);
+  const y = (diff: number) => mid - (diff / maxAbs) * (mid - pad);
+
+  const line = points.map((p) => `${x(p.minute).toFixed(1)},${y(p.diff).toFixed(1)}`).join(" ");
+  const area =
+    `M ${x(points[0].minute).toFixed(1)},${mid.toFixed(1)} ` +
+    points.map((p) => `L ${x(p.minute).toFixed(1)},${y(p.diff).toFixed(1)}`).join(" ") +
+    ` L ${x(points[points.length - 1].minute).toFixed(1)},${mid.toFixed(1)} Z`;
+
+  const finalDiff = points[points.length - 1].diff;
+  const ahead = finalDiff >= 0;
+  const lineColor = ahead ? "var(--color-team-blue)" : "var(--color-team-red)";
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      className={cn("h-[76px] w-full", className)}
+      role="img"
+      aria-label={`Gold lead curve; ${ahead ? "blue" : "red"} team ahead by ${Math.abs(finalDiff).toLocaleString()} at the end`}
+    >
+      <defs>
+        <linearGradient id="golddiff-grad" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--color-team-blue)" stopOpacity="0.32" />
+          <stop offset="50%" stopColor="var(--color-team-blue)" stopOpacity="0.04" />
+          <stop offset="50%" stopColor="var(--color-team-red)" stopOpacity="0.04" />
+          <stop offset="100%" stopColor="var(--color-team-red)" stopOpacity="0.32" />
+        </linearGradient>
+      </defs>
+      <line
+        x1={pad}
+        y1={mid}
+        x2={W - pad}
+        y2={mid}
+        stroke="var(--color-border-strong)"
+        strokeWidth="1"
+        strokeDasharray="3 3"
+      />
+      <path d={area} fill="url(#golddiff-grad)" />
+      <polyline points={line} fill="none" stroke={lineColor} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -49,6 +49,7 @@ type MatchHistorySectionProps = {
   region: string;
   gameName: string;
   tagLine: string;
+  summonerId: string;
   page: number;
   queue: string;
   championFilter: string;
@@ -85,6 +86,7 @@ function MatchHistoryCard({
   region,
   gameName,
   tagLine,
+  summonerId,
   championStatic,
   itemStatic,
   spellStatic,
@@ -99,6 +101,7 @@ function MatchHistoryCard({
   region: string;
   gameName: string;
   tagLine: string;
+  summonerId: string;
   championStatic: ChampionStatic | null;
   itemStatic: ItemStatic | null;
   spellStatic: SpellStatic | null;
@@ -328,6 +331,7 @@ function MatchHistoryCard({
               {detail ? (
                 <MatchScoreboard
                   detail={detail}
+                  summonerId={summonerId}
                   region={region}
                   gameName={gameName}
                   tagLine={tagLine}
@@ -349,6 +353,7 @@ export function MatchHistorySection({
   region,
   gameName,
   tagLine,
+  summonerId,
   page,
   queue,
   championFilter,
@@ -448,6 +453,7 @@ export function MatchHistorySection({
               region={region}
               gameName={gameName}
               tagLine={tagLine}
+              summonerId={summonerId}
               championStatic={championStatic}
               itemStatic={itemStatic}
               spellStatic={spellStatic}

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -8,7 +8,8 @@ import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Select } from "@/components/ui/Select";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { RuneSetupDisplay } from "@/components/RuneSetupDisplay";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { MatchScoreboard } from "@/components/lol-profile/MatchScoreboard";
 import {
   formatDateTimeMs,
   formatDurationSeconds,
@@ -25,17 +26,12 @@ import {
 } from "@/lib/staticData";
 
 import {
-  buildAlignedParticipantRows,
-  buildRuneRowKey,
-  hasRunes,
-  isCurrentProfilePlayer,
   matchKdaRatio,
   normalizeInitialSort,
-  participantDisplayName,
+  sortRuneSelections,
   type ChampionStatic,
   type ItemStatic,
   type MatchDetail,
-  type MatchParticipant,
   type MatchSortOption,
   type MatchSummary,
   type PagedResultDto,
@@ -67,7 +63,6 @@ type MatchHistorySectionProps = {
   expandedMatchId: string | null;
   details: Record<string, MatchDetail | null>;
   detailBusy: Record<string, boolean>;
-  expandedRunes: Record<string, boolean>;
   championStatic: ChampionStatic | null;
   itemStatic: ItemStatic | null;
   spellStatic: SpellStatic | null;
@@ -77,338 +72,9 @@ type MatchHistorySectionProps = {
   onChampionFilterChange(value: string): void;
   onSortChange(value: MatchSortOption): void;
   onToggleExpanded(matchId: string): void | Promise<void>;
-  onToggleRuneRow(runeRowKey: string): void;
-  onToggleAllRunesForMatch(matchId: string, participants: MatchParticipant[], expanded: boolean): void;
   onPreviousPage(): void;
   onNextPage(): void;
 };
-
-function sortPrimarySelections(selectionIds: number[], runeStatic: RuneStatic | null) {
-  return selectionIds.slice().sort((a, b) => {
-    const aSort = runeStatic?.runeSortById[String(a)] ?? Number.MAX_SAFE_INTEGER;
-    const bSort = runeStatic?.runeSortById[String(b)] ?? Number.MAX_SAFE_INTEGER;
-    return aSort - bSort;
-  });
-}
-
-function MatchParticipantCard({
-  participant,
-  matchId,
-  teamId,
-  roleKey,
-  rowIndex,
-  region,
-  gameName,
-  tagLine,
-  championStatic,
-  itemStatic,
-  spellStatic,
-  runeStatic,
-  expandedRunes,
-  onToggleRuneRow
-}: {
-  participant: MatchParticipant | null;
-  matchId: string;
-  teamId: 100 | 200;
-  roleKey: string;
-  rowIndex: number;
-  region: string;
-  gameName: string;
-  tagLine: string;
-  championStatic: ChampionStatic | null;
-  itemStatic: ItemStatic | null;
-  spellStatic: SpellStatic | null;
-  runeStatic: RuneStatic | null;
-  expandedRunes: Record<string, boolean>;
-  onToggleRuneRow(runeRowKey: string): void;
-}) {
-  if (!participant) {
-    return (
-      <div className="rounded-control border border-dashed border-border/35 bg-surface/35 px-3 py-3 text-xs text-muted">
-        {roleDisplayLabel(roleKey)} unavailable
-      </div>
-    );
-  }
-
-  const isCurrent = isCurrentProfilePlayer(participant, gameName, tagLine);
-  const champion = championStatic?.champions[String(participant.championId)];
-  const itemIds = (participant.items ?? []).slice(0, 7);
-  const cs = (participant.totalMinionsKilled + participant.neutralMinionsKilled).toLocaleString();
-  const runeRowKey = buildRuneRowKey(matchId, teamId, rowIndex, participant);
-  const runesExpanded = expandedRunes[runeRowKey] === true;
-  const orderedPrimarySelections = sortPrimarySelections(
-    participant.runes?.primarySelections ?? [],
-    runeStatic
-  );
-  const hasRunesData = hasRunes(participant.runes);
-  const primaryRuneId = orderedPrimarySelections[0] ?? 0;
-  const primaryRuneMeta = runeStatic?.runeById[String(primaryRuneId)];
-  const canExpandRunes = Boolean(runeStatic && hasRunesData);
-
-  return (
-    <div
-      className={`rounded-control border px-3 py-3 ${
-        isCurrent ? "border-primary/45 bg-primary/10 shadow-card" : "surface-subtle"
-      }`}
-    >
-      <div className="grid items-center gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-        <div className="flex items-center gap-3">
-          {champion && championStatic ? (
-            <Image
-              src={championIconUrl(championStatic.version, champion.id)}
-              alt={champion.name}
-              width={34}
-              height={34}
-              className="rounded-lg border border-border/50"
-            />
-          ) : (
-            <div className="h-[34px] w-[34px] rounded-lg border border-border/50 bg-surface/70" />
-          )}
-          <div className="min-w-0 flex-1">
-            {participant.gameName && participant.tagLine && !isCurrent ? (
-              <Link
-                href={`/lol/summoners/${region}/${encodeRiotIdPath({ gameName: participant.gameName, tagLine: participant.tagLine })}`}
-                className="block truncate text-sm font-medium text-fg/95 transition-colors hover:text-primary hover:underline"
-              >
-                {participantDisplayName(participant.gameName, participant.tagLine)}
-              </Link>
-            ) : (
-              <p className="truncate text-sm font-medium text-fg/95">
-                {participantDisplayName(participant.gameName, participant.tagLine)}
-              </p>
-            )}
-            <div className="type-caption mt-1 flex flex-wrap items-center gap-2 text-muted">
-              <span>{participant.kills}/{participant.deaths}/{participant.assists}</span>
-              <span>{cs} CS</span>
-              <span>{participant.goldEarned.toLocaleString()}g</span>
-              <span>{participant.totalDamageDealtToChampions.toLocaleString()} dmg</span>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-1.5 lg:justify-end">
-          {[participant.summonerSpell1Id, participant.summonerSpell2Id].map((spellId, spellIdx) => {
-            const spellMeta = spellStatic?.spells[String(spellId)];
-            return spellMeta && spellStatic ? (
-              <Image
-                key={`${spellId}-${spellIdx}`}
-                src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
-                alt={spellMeta.name}
-                title={spellMeta.name}
-                width={18}
-                height={18}
-                className="rounded-md border border-border/40"
-              />
-            ) : (
-              <div
-                key={`${spellId}-${spellIdx}`}
-                className="h-[18px] w-[18px] rounded-md border border-border/40 bg-surface/60"
-              />
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex flex-wrap items-center gap-1">
-          {itemIds.map((itemId, itemIdx) => {
-            if (!itemId) {
-              return (
-                <div
-                  key={`empty-${itemIdx}`}
-                  className="h-5 w-5 rounded-md border border-border/35 bg-surface/60"
-                />
-              );
-            }
-
-            const itemMeta = itemStatic?.items[String(itemId)];
-            return itemStatic ? (
-              <Image
-                key={`${itemId}-${itemIdx}`}
-                src={itemIconUrl(itemStatic.version, itemId)}
-                alt={itemMeta?.name ?? `Item ${itemId}`}
-                title={itemMeta?.name ?? `Item ${itemId}`}
-                width={20}
-                height={20}
-                className="rounded-md border border-border/35"
-              />
-            ) : (
-              <div
-                key={`${itemId}-${itemIdx}`}
-                className="h-5 w-5 rounded-md border border-border/35 bg-surface/60"
-              />
-            );
-          })}
-        </div>
-
-        <button
-          type="button"
-          onClick={() => onToggleRuneRow(runeRowKey)}
-          disabled={!canExpandRunes}
-          className={`type-caption inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
-            canExpandRunes
-              ? "border-border/50 bg-surface-2/55 text-fg/85 hover:bg-surface-2/72"
-              : "border-border/25 bg-surface/25 text-muted"
-          }`}
-          aria-expanded={runesExpanded}
-          aria-label={runesExpanded ? "Hide runes" : "Show runes"}
-        >
-          {primaryRuneMeta ? (
-            <Image
-              src={runeIconUrl(primaryRuneMeta.icon)}
-              alt={primaryRuneMeta.name}
-              title={primaryRuneMeta.name}
-              width={20}
-              height={20}
-              className="rounded-full border border-border/35 bg-surface-2/70 p-0.5"
-            />
-          ) : (
-            <span className="h-5 w-5 rounded-full border border-border/35 bg-surface-2/70" />
-          )}
-          <span>{canExpandRunes ? (runesExpanded ? "Hide Runes" : "Show Runes") : "Runes Unavailable"}</span>
-        </button>
-      </div>
-
-      {runeStatic && canExpandRunes && runesExpanded ? (
-        <RuneSetupDisplay
-          primaryStyleId={participant.runes?.primaryStyleId ?? 0}
-          subStyleId={participant.runes?.subStyleId ?? 0}
-          primarySelections={participant.runes?.primarySelections ?? []}
-          subSelections={participant.runes?.subSelections ?? []}
-          statShards={participant.runes?.statShards ?? []}
-          runeById={runeStatic.runeById}
-          styleById={runeStatic.styleById}
-          runeSortById={runeStatic.runeSortById}
-          iconSize={20}
-          density="compact"
-          className="mt-3"
-        />
-      ) : null}
-    </div>
-  );
-}
-
-function MatchDetailPanel({
-  match,
-  detail,
-  region,
-  gameName,
-  tagLine,
-  championStatic,
-  itemStatic,
-  spellStatic,
-  runeStatic,
-  expandedRunes,
-  onToggleRuneRow,
-  onToggleAllRunesForMatch
-}: {
-  match: MatchSummary;
-  detail: MatchDetail;
-  region: string;
-  gameName: string;
-  tagLine: string;
-  championStatic: ChampionStatic | null;
-  itemStatic: ItemStatic | null;
-  spellStatic: SpellStatic | null;
-  runeStatic: RuneStatic | null;
-  expandedRunes: Record<string, boolean>;
-  onToggleRuneRow(runeRowKey: string): void;
-  onToggleAllRunesForMatch(matchId: string, participants: MatchParticipant[], expanded: boolean): void;
-}) {
-  const alignedRows = buildAlignedParticipantRows(detail.participants ?? []);
-  const runeRowKeys: string[] = [];
-
-  alignedRows.forEach((row, rowIndex) => {
-    if (row.blue && hasRunes(row.blue.runes)) {
-      runeRowKeys.push(buildRuneRowKey(match.matchId, 100, rowIndex, row.blue));
-    }
-    if (row.red && hasRunes(row.red.runes)) {
-      runeRowKeys.push(buildRuneRowKey(match.matchId, 200, rowIndex, row.red));
-    }
-  });
-
-  const allRunesExpanded =
-    runeRowKeys.length > 0 && runeRowKeys.every((runeRowKey) => expandedRunes[runeRowKey] === true);
-  const canToggleAllRunes = Boolean(runeStatic && runeRowKeys.length > 0);
-
-  return (
-    <div className="match-detail-shell p-3 md:p-4">
-      <div className="mb-4 flex items-center justify-between gap-2">
-        <div>
-          <p className="type-kicker text-muted">Matchup details</p>
-          <p className="mt-1 text-xs text-fg/62">
-            Compare both teams with runes, spells, and item paths side by side.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => onToggleAllRunesForMatch(match.matchId, detail.participants ?? [], !allRunesExpanded)}
-          disabled={!canToggleAllRunes}
-          className={`type-caption inline-flex items-center gap-1 rounded-full border px-2.5 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
-            canToggleAllRunes
-              ? "border-border/55 bg-surface-2/55 text-fg/85 hover:bg-surface-2/72"
-              : "border-border/25 bg-surface/25 text-muted"
-          }`}
-        >
-          {allRunesExpanded ? "Collapse all runes" : "Expand all runes"}
-        </button>
-      </div>
-
-      <div className="mb-3 grid grid-cols-2 gap-2">
-        <p className="rounded-full border border-team-blue/18 bg-team-blue/10 px-3 py-1 text-xs font-semibold text-team-blue">
-          Blue Team
-        </p>
-        <p className="rounded-full border border-team-red/18 bg-team-red/10 px-3 py-1 text-xs font-semibold text-team-red">
-          Red Team
-        </p>
-      </div>
-
-      <div className="grid gap-3">
-        {alignedRows.map((row, rowIndex) => (
-          <div key={`${match.matchId}-${row.roleKey}-${rowIndex}`} className="grid gap-2">
-            <p className="type-overline px-1 text-muted">
-              {roleDisplayLabel(row.roleKey)}
-            </p>
-            <div className="grid gap-2 sm:grid-cols-2">
-              <MatchParticipantCard
-                participant={row.blue}
-                matchId={match.matchId}
-                teamId={100}
-                roleKey={row.roleKey}
-                rowIndex={rowIndex}
-                region={region}
-                gameName={gameName}
-                tagLine={tagLine}
-                championStatic={championStatic}
-                itemStatic={itemStatic}
-                spellStatic={spellStatic}
-                runeStatic={runeStatic}
-                expandedRunes={expandedRunes}
-                onToggleRuneRow={onToggleRuneRow}
-              />
-              <MatchParticipantCard
-                participant={row.red}
-                matchId={match.matchId}
-                teamId={200}
-                roleKey={row.roleKey}
-                rowIndex={rowIndex}
-                region={region}
-                gameName={gameName}
-                tagLine={tagLine}
-                championStatic={championStatic}
-                itemStatic={itemStatic}
-                spellStatic={spellStatic}
-                runeStatic={runeStatic}
-                expandedRunes={expandedRunes}
-                onToggleRuneRow={onToggleRuneRow}
-              />
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 function MatchHistoryCard({
   match,
@@ -423,10 +89,7 @@ function MatchHistoryCard({
   itemStatic,
   spellStatic,
   runeStatic,
-  expandedRunes,
-  onToggleExpanded,
-  onToggleRuneRow,
-  onToggleAllRunesForMatch
+  onToggleExpanded
 }: {
   match: MatchSummary;
   expanded: boolean;
@@ -440,20 +103,13 @@ function MatchHistoryCard({
   itemStatic: ItemStatic | null;
   spellStatic: SpellStatic | null;
   runeStatic: RuneStatic | null;
-  expandedRunes: Record<string, boolean>;
   onToggleExpanded(matchId: string): void | Promise<void>;
-  onToggleRuneRow(runeRowKey: string): void;
-  onToggleAllRunesForMatch(matchId: string, participants: MatchParticipant[], expanded: boolean): void;
 }) {
   const queueLabel = formatQueueLabel(match.queueType, match.queueId);
   const champion = championStatic?.champions[String(match.championId)];
   const championName = champion?.name ?? `Champion ${match.championId}`;
   const roleLabel = match.teamPosition ? roleDisplayLabel(match.teamPosition) : "Unknown";
-  const orderedPrimarySelections = sortPrimarySelections(
-    match.runesDetail?.primarySelections ?? [],
-    runeStatic
-  );
-  const primaryRuneId = orderedPrimarySelections[0] ?? 0;
+  const primaryRuneId = sortRuneSelections(match.runesDetail?.primarySelections ?? [], runeStatic?.runeSortById)[0] ?? 0;
   const primaryRuneMeta = runeStatic?.runeById[String(primaryRuneId)];
   const subStyleMeta = runeStatic?.styleById[String(match.runesDetail?.subStyleId ?? 0)];
   const spellIds = [match.summonerSpell1Id, match.summonerSpell2Id];
@@ -462,8 +118,7 @@ function MatchHistoryCard({
   const matchPanelId = `match-panel-${match.matchId}`;
 
   return (
-    <motion.div
-      layout={!prefersReducedMotion}
+    <div
       className={`match-card-shell ${
         match.win ? "match-card-shell--win border-success/28" : "match-card-shell--loss border-danger/28"
       } rounded-panel border`}
@@ -657,17 +312,21 @@ function MatchHistoryCard({
             initial={prefersReducedMotion ? undefined : { height: 0, opacity: 0 }}
             animate={prefersReducedMotion ? undefined : { height: "auto", opacity: 1 }}
             exit={prefersReducedMotion ? undefined : { height: 0, opacity: 0 }}
+            transition={
+              prefersReducedMotion
+                ? undefined
+                : { height: { duration: 0.28, ease: [0.25, 1, 0.5, 1] }, opacity: { duration: 0.18 } }
+            }
             className="overflow-hidden"
             style={prefersReducedMotion ? { height: "auto", opacity: 1 } : undefined}
           >
-            <div className="mt-4 border-t border-white/8 pt-4">
+            <div className="mt-4 border-t border-border/55 px-4 pt-4 md:px-5">
               {detailBusy ? <Skeleton className="h-12 w-full" /> : null}
               {!detailBusy && !detail ? (
                 <p className="text-sm text-fg/75">Detailed rows are unavailable for this match.</p>
               ) : null}
               {detail ? (
-                <MatchDetailPanel
-                  match={match}
+                <MatchScoreboard
                   detail={detail}
                   region={region}
                   gameName={gameName}
@@ -676,16 +335,13 @@ function MatchHistoryCard({
                   itemStatic={itemStatic}
                   spellStatic={spellStatic}
                   runeStatic={runeStatic}
-                  expandedRunes={expandedRunes}
-                  onToggleRuneRow={onToggleRuneRow}
-                  onToggleAllRunesForMatch={onToggleAllRunesForMatch}
                 />
               ) : null}
             </div>
           </motion.div>
         ) : null}
       </AnimatePresence>
-    </motion.div>
+    </div>
   );
 }
 
@@ -707,7 +363,6 @@ export function MatchHistorySection({
   expandedMatchId,
   details,
   detailBusy,
-  expandedRunes,
   championStatic,
   itemStatic,
   spellStatic,
@@ -717,70 +372,18 @@ export function MatchHistorySection({
   onChampionFilterChange,
   onSortChange,
   onToggleExpanded,
-  onToggleRuneRow,
-  onToggleAllRunesForMatch,
   onPreviousPage,
   onNextPage
 }: MatchHistorySectionProps) {
   return (
-    <section className="grid gap-5">
+    <section className="flex flex-col gap-5">
       <Card className="profile-section-card rounded-panel p-5 md:p-6">
-        <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(310px,auto)] xl:items-start">
-          <div className="grid gap-4">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-end justify-between gap-3">
             <div>
-              <p className="type-kicker text-muted">Match history</p>
-              <h2 className="type-panel-title mt-2">
-                Recent results with clearer scan paths
-              </h2>
-              <p className="mt-2 max-w-2xl text-sm text-fg/70">
-                Filter by queue or champion, then open any game for side-by-side lane and team detail.
-              </p>
+              <p className="type-overline text-muted">Match history</p>
+              <h2 className="type-panel-title mt-1">Matches</h2>
             </div>
-
-            <div className="flex flex-wrap gap-x-4 gap-y-2">
-              {queueOptions.map((option) => (
-                <button
-                  key={option.value}
-                  className="control-tab type-ui focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
-                  onClick={() => onQueueChange(option.value)}
-                  aria-pressed={option.value === queue}
-                  data-active={option.value === queue}
-                >
-                  {option.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="surface-card grid gap-3 rounded-card p-4">
-            <div>
-              <label htmlFor="match-champion-filter" className="sr-only">
-                Filter matches by champion
-              </label>
-              <Input
-                id="match-champion-filter"
-                list="match-champion-options"
-                placeholder="Filter champion (name or ID)"
-                value={championFilter}
-                onChange={(event) => onChampionFilterChange(event.currentTarget.value)}
-                className="h-10 min-w-[220px] bg-surface-2/55 text-sm shadow-inset"
-                spellCheck={false}
-              />
-              <datalist id="match-champion-options">
-                {championOptions.map((option) => (
-                  <option key={`champion-filter-${option.id}`} value={option.label} />
-                ))}
-              </datalist>
-            </div>
-
-            <Select
-              value={sort}
-              onValueChange={(v) => onSortChange(normalizeInitialSort(v))}
-              ariaLabel="Sort matches"
-              options={sortOptions}
-              className="w-full"
-            />
-
             <div className="flex flex-wrap items-center gap-2">
               <Badge className="surface-chip text-fg/72">
                 Page {history?.page ?? page}/{history?.totalPages ?? 1}
@@ -791,12 +394,49 @@ export function MatchHistorySection({
               <Badge className="surface-chip text-fg/72">{visibleMatches.length} shown</Badge>
             </div>
           </div>
+
+          <div className="flex flex-wrap items-center gap-2 border-t border-border/70 pt-3">
+            <div className="max-w-full overflow-x-auto">
+              <SegmentedControl
+                options={queueOptions}
+                value={queue}
+                onValueChange={onQueueChange}
+                ariaLabel="Filter matches by queue"
+              />
+            </div>
+            <div className="ml-auto flex flex-wrap items-center gap-2">
+              <label htmlFor="match-champion-filter" className="sr-only">
+                Filter matches by champion
+              </label>
+              <Input
+                id="match-champion-filter"
+                list="match-champion-options"
+                placeholder="Filter champion"
+                value={championFilter}
+                onChange={(event) => onChampionFilterChange(event.currentTarget.value)}
+                className="h-9 w-[180px] bg-surface-2/55 text-sm shadow-inset"
+                spellCheck={false}
+              />
+              <datalist id="match-champion-options">
+                {championOptions.map((option) => (
+                  <option key={`champion-filter-${option.id}`} value={option.label} />
+                ))}
+              </datalist>
+              <Select
+                value={sort}
+                onValueChange={(v) => onSortChange(normalizeInitialSort(v))}
+                ariaLabel="Sort matches"
+                options={sortOptions}
+                className="w-[160px]"
+              />
+            </div>
+          </div>
         </div>
 
         {historyError ? <p className="mt-4 text-sm text-danger">{historyError}</p> : null}
         {historyBusy && !history ? <Skeleton className="mt-4 h-16 w-full" /> : null}
 
-        <div className="mt-5 grid gap-4">
+        <div className="mt-5 flex flex-col gap-4">
           {visibleMatches.map((match) => (
             <MatchHistoryCard
               key={match.matchId}
@@ -812,10 +452,7 @@ export function MatchHistorySection({
               itemStatic={itemStatic}
               spellStatic={spellStatic}
               runeStatic={runeStatic}
-              expandedRunes={expandedRunes}
               onToggleExpanded={onToggleExpanded}
-              onToggleRuneRow={onToggleRuneRow}
-              onToggleAllRunesForMatch={onToggleAllRunesForMatch}
             />
           ))}
 

--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+import { ParticipantRuneCard } from "@/components/lol-profile/ParticipantRuneCard";
+import { ScoreboardTeamTable } from "@/components/lol-profile/ScoreboardTeamTable";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { roleDisplayLabel } from "@/lib/roles";
+import { championIconUrl } from "@/lib/staticData";
+
+import {
+  buildAlignedParticipantRows,
+  matchKdaRatio,
+  participantDisplayName,
+  type ChampionStatic,
+  type ItemStatic,
+  type MatchDetail,
+  type MatchParticipant,
+  type RuneStatic,
+  type SpellStatic
+} from "@/components/lol-profile/shared";
+
+type ScoreboardTab = "overview" | "runes";
+
+const TABS = [
+  { value: "overview" as const, label: "Overview" },
+  { value: "runes" as const, label: "Runes" }
+];
+
+function RuneTabCell({
+  participant,
+  roleKey,
+  championStatic,
+  runeStatic
+}: {
+  participant: MatchParticipant | null;
+  roleKey: string;
+  championStatic: ChampionStatic | null;
+  runeStatic: RuneStatic | null;
+}) {
+  if (!participant) {
+    return (
+      <div className="rounded-control border border-dashed border-border/35 bg-surface/35 px-3 py-3 type-caption text-muted">
+        {roleDisplayLabel(roleKey)} unavailable
+      </div>
+    );
+  }
+
+  const champion = championStatic?.champions[String(participant.championId)];
+
+  return (
+    <div className="surface-subtle grid content-start gap-2 rounded-control p-3">
+      <div className="flex items-center gap-2">
+        {champion && championStatic ? (
+          <Image
+            src={championIconUrl(championStatic.version, champion.id)}
+            alt={champion.name}
+            width={28}
+            height={28}
+            className="rounded-lg border border-border/55"
+          />
+        ) : (
+          <div className="h-7 w-7 rounded-lg border border-border/55 bg-surface/70" />
+        )}
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-fg/95">
+            {participantDisplayName(participant.gameName, participant.tagLine)}
+          </p>
+          <p className="type-caption text-muted tabular-nums">
+            {participant.kills}/{participant.deaths}/{participant.assists} · {matchKdaRatio(participant).toFixed(2)} KDA
+          </p>
+        </div>
+      </div>
+      <ParticipantRuneCard participant={participant} runeStatic={runeStatic} />
+    </div>
+  );
+}
+
+// Compact, tabbed post-game view that replaces the old 10-tall-cards detail panel.
+// Overview = two dense team scoreboards (op.gg-style); Runes = role-aligned rune
+// pages for side-by-side comparison. Runes also surface via a hover tooltip on each
+// scoreboard row's keystone, so a single player can be inspected without leaving Overview.
+export function MatchScoreboard({
+  detail,
+  region,
+  gameName,
+  tagLine,
+  championStatic,
+  itemStatic,
+  spellStatic,
+  runeStatic
+}: {
+  detail: MatchDetail;
+  region: string;
+  gameName: string;
+  tagLine: string;
+  championStatic: ChampionStatic | null;
+  itemStatic: ItemStatic | null;
+  spellStatic: SpellStatic | null;
+  runeStatic: RuneStatic | null;
+}) {
+  const [tab, setTab] = useState<ScoreboardTab>("overview");
+  const participants = detail.participants ?? [];
+  const blue = participants.filter((p) => p.teamId === 100);
+  const red = participants.filter((p) => p.teamId === 200);
+  const alignedRows = buildAlignedParticipantRows(participants);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SegmentedControl<ScoreboardTab>
+        options={TABS}
+        value={tab}
+        onValueChange={setTab}
+        ariaLabel="Match detail view"
+        className="w-fit"
+      />
+
+      {tab === "overview" ? (
+        <div className="flex flex-col gap-3">
+          <ScoreboardTeamTable
+            participants={blue}
+            teamId={100}
+            durationSeconds={detail.duration}
+            region={region}
+            gameName={gameName}
+            tagLine={tagLine}
+            championStatic={championStatic}
+            itemStatic={itemStatic}
+            spellStatic={spellStatic}
+            runeStatic={runeStatic}
+          />
+          <ScoreboardTeamTable
+            participants={red}
+            teamId={200}
+            durationSeconds={detail.duration}
+            region={region}
+            gameName={gameName}
+            tagLine={tagLine}
+            championStatic={championStatic}
+            itemStatic={itemStatic}
+            spellStatic={spellStatic}
+            runeStatic={runeStatic}
+          />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {alignedRows.map((row, rowIndex) => (
+            <div key={`${row.roleKey}-${rowIndex}`} className="flex flex-col gap-2">
+              <p className="type-overline px-1 text-muted">{roleDisplayLabel(row.roleKey)}</p>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <RuneTabCell participant={row.blue} roleKey={row.roleKey} championStatic={championStatic} runeStatic={runeStatic} />
+                <RuneTabCell participant={row.red} roleKey={row.roleKey} championStatic={championStatic} runeStatic={runeStatic} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -143,6 +143,8 @@ export function MatchScoreboard({
   const red = participants.filter((p) => p.teamId === 200);
   const blueBans = detail.bans?.find((b) => b.teamId === 100)?.bannedChampionIds ?? [];
   const redBans = detail.bans?.find((b) => b.teamId === 200)?.bannedChampionIds ?? [];
+  // Normalize damage bars to the whole lobby's top dealer so the carry reads across both teams.
+  const matchMaxDamage = Math.max(1, ...participants.map((p) => p.totalDamageDealtToChampions));
   const alignedRows = buildAlignedParticipantRows(participants);
 
   return (
@@ -164,6 +166,7 @@ export function MatchScoreboard({
             participants={blue}
             teamId={100}
             durationSeconds={detail.duration}
+            maxDamage={matchMaxDamage}
             bans={blueBans}
             region={region}
             gameName={gameName}
@@ -177,6 +180,7 @@ export function MatchScoreboard({
             participants={red}
             teamId={200}
             durationSeconds={detail.duration}
+            maxDamage={matchMaxDamage}
             bans={redBans}
             region={region}
             gameName={gameName}

--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -17,6 +17,7 @@ import {
   type ItemStatic,
   type MatchDetail,
   type MatchParticipant,
+  type MatchTeamObjectives,
   type RuneStatic,
   type SpellStatic
 } from "@/components/lol-profile/shared";
@@ -77,6 +78,42 @@ function RuneTabCell({
   );
 }
 
+function TeamObjectivesSummary({ team, side }: { team: MatchTeamObjectives | undefined; side: "blue" | "red" }) {
+  const items = team
+    ? [
+        team.dragon.kills > 0 ? `${team.dragon.kills} Dragon` : null,
+        team.baron.kills > 0 ? `${team.baron.kills} Baron` : null,
+        team.riftHerald.kills > 0 ? `${team.riftHerald.kills} Herald` : null,
+        team.horde.kills > 0 ? `${team.horde.kills} Grubs` : null,
+        `${team.tower.kills} Towers`,
+        team.inhibitor.kills > 0 ? `${team.inhibitor.kills} Inhib` : null
+      ].filter(Boolean)
+    : [];
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <span className={`type-overline font-semibold ${side === "blue" ? "text-team-blue" : "text-team-red"}`}>
+        {side === "blue" ? "Blue" : "Red"}
+      </span>
+      {team?.firstBlood ? (
+        <span className="surface-chip type-caption rounded-full px-2 py-0.5 text-fg/80">First Blood</span>
+      ) : null}
+      <span className="type-caption text-fg/72 tabular-nums">{items.length > 0 ? items.join(" · ") : "—"}</span>
+    </div>
+  );
+}
+
+function ObjectivesStrip({ objectives }: { objectives: MatchTeamObjectives[] }) {
+  const blue = objectives.find((o) => o.teamId === 100);
+  const red = objectives.find((o) => o.teamId === 200);
+  return (
+    <div className="surface-subtle flex flex-wrap items-center justify-between gap-x-6 gap-y-2 rounded-control px-3 py-2">
+      <TeamObjectivesSummary team={blue} side="blue" />
+      <TeamObjectivesSummary team={red} side="red" />
+    </div>
+  );
+}
+
 // Compact, tabbed post-game view that replaces the old 10-tall-cards detail panel.
 // Overview = two dense team scoreboards (op.gg-style); Runes = role-aligned rune
 // pages for side-by-side comparison. Runes also surface via a hover tooltip on each
@@ -120,6 +157,9 @@ export function MatchScoreboard({
 
       {tab === "overview" ? (
         <div className="flex flex-col gap-3">
+          {detail.objectives && detail.objectives.length > 0 ? (
+            <ObjectivesStrip objectives={detail.objectives} />
+          ) : null}
           <ScoreboardTeamTable
             participants={blue}
             teamId={100}

--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 
 import { ParticipantRuneCard } from "@/components/lol-profile/ParticipantRuneCard";
 import { ScoreboardTeamTable } from "@/components/lol-profile/ScoreboardTeamTable";
+import { GoldDiffChart } from "@/components/lol-profile/GoldDiffChart";
 import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl } from "@/lib/staticData";
+import { buildLolPublicSummonerMatchTimelinePath } from "@/lib/lolPublicApi";
 
 import {
   buildAlignedParticipantRows,
@@ -18,6 +20,7 @@ import {
   type MatchDetail,
   type MatchParticipant,
   type MatchTeamObjectives,
+  type MatchTimeline,
   type RuneStatic,
   type SpellStatic
 } from "@/components/lol-profile/shared";
@@ -120,6 +123,7 @@ function ObjectivesStrip({ objectives }: { objectives: MatchTeamObjectives[] }) 
 // scoreboard row's keystone, so a single player can be inspected without leaving Overview.
 export function MatchScoreboard({
   detail,
+  summonerId,
   region,
   gameName,
   tagLine,
@@ -129,6 +133,7 @@ export function MatchScoreboard({
   runeStatic
 }: {
   detail: MatchDetail;
+  summonerId: string;
   region: string;
   gameName: string;
   tagLine: string;
@@ -138,6 +143,28 @@ export function MatchScoreboard({
   runeStatic: RuneStatic | null;
 }) {
   const [tab, setTab] = useState<ScoreboardTab>("overview");
+  const [timeline, setTimeline] = useState<MatchTimeline | null>(null);
+
+  // Lazy-load the gold/xp-diff curve once the scoreboard mounts (i.e. the match is expanded).
+  // Optional decoration — only present for matches with ingested timeline frames.
+  useEffect(() => {
+    if (!summonerId || !detail.matchId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(buildLolPublicSummonerMatchTimelinePath(summonerId, detail.matchId), { cache: "no-store" });
+        if (!res.ok || cancelled) return;
+        const json = (await res.json().catch(() => null)) as MatchTimeline | null;
+        if (!cancelled && json && Array.isArray(json.frames)) setTimeline(json);
+      } catch {
+        // Timeline curve is optional — ignore fetch errors.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [summonerId, detail.matchId]);
+
   const participants = detail.participants ?? [];
   const blue = participants.filter((p) => p.teamId === 100);
   const red = participants.filter((p) => p.teamId === 200);
@@ -161,6 +188,12 @@ export function MatchScoreboard({
         <div className="flex flex-col gap-3">
           {detail.objectives && detail.objectives.length > 0 ? (
             <ObjectivesStrip objectives={detail.objectives} />
+          ) : null}
+          {timeline && timeline.frames.length >= 2 ? (
+            <div className="surface-subtle grid gap-1.5 rounded-control px-3 py-2.5">
+              <p className="type-overline text-muted">Gold lead</p>
+              <GoldDiffChart frames={timeline.frames} />
+            </div>
           ) : null}
           <ScoreboardTeamTable
             participants={blue}

--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -104,6 +104,8 @@ export function MatchScoreboard({
   const participants = detail.participants ?? [];
   const blue = participants.filter((p) => p.teamId === 100);
   const red = participants.filter((p) => p.teamId === 200);
+  const blueBans = detail.bans?.find((b) => b.teamId === 100)?.bannedChampionIds ?? [];
+  const redBans = detail.bans?.find((b) => b.teamId === 200)?.bannedChampionIds ?? [];
   const alignedRows = buildAlignedParticipantRows(participants);
 
   return (
@@ -122,6 +124,7 @@ export function MatchScoreboard({
             participants={blue}
             teamId={100}
             durationSeconds={detail.duration}
+            bans={blueBans}
             region={region}
             gameName={gameName}
             tagLine={tagLine}
@@ -134,6 +137,7 @@ export function MatchScoreboard({
             participants={red}
             teamId={200}
             durationSeconds={detail.duration}
+            bans={redBans}
             region={region}
             gameName={gameName}
             tagLine={tagLine}

--- a/apps/web/components/lol-profile/ParticipantRuneCard.tsx
+++ b/apps/web/components/lol-profile/ParticipantRuneCard.tsx
@@ -1,0 +1,40 @@
+import { RuneTreeDisplay } from "@/components/RuneTreeDisplay";
+import { hasRunes, type MatchParticipant, type RuneStatic } from "@/components/lol-profile/shared";
+import { cn } from "@/lib/cn";
+
+// Single source of the participant.runes → RuneTreeDisplay mapping. Shared by the
+// scoreboard's Runes tab (side-by-side compare) and the keystone hover tooltip, so
+// the rune page renders identically wherever it surfaces. Compact + single-column
+// so it fits a narrow cell or a tooltip without the lopsided-card problem the old
+// per-card "Show Runes" toggle caused.
+export function ParticipantRuneCard({
+  participant,
+  runeStatic,
+  className
+}: {
+  participant: MatchParticipant;
+  runeStatic: RuneStatic | null;
+  className?: string;
+}) {
+  if (!runeStatic || !hasRunes(participant.runes)) {
+    return <p className={cn("type-caption text-muted", className)}>Runes unavailable.</p>;
+  }
+
+  const runes = participant.runes;
+
+  return (
+    <RuneTreeDisplay
+      primaryStyleId={runes.primaryStyleId ?? 0}
+      subStyleId={runes.subStyleId ?? 0}
+      primarySelections={runes.primarySelections ?? []}
+      subSelections={runes.subSelections ?? []}
+      statShards={runes.statShards ?? []}
+      trees={runeStatic.trees ?? []}
+      runeById={runeStatic.runeById}
+      styleById={runeStatic.styleById}
+      density="compact"
+      gridClassName="grid w-full gap-2"
+      className={className}
+    />
+  );
+}

--- a/apps/web/components/lol-profile/ProfileHeroCard.tsx
+++ b/apps/web/components/lol-profile/ProfileHeroCard.tsx
@@ -1,9 +1,8 @@
 import Image from "next/image";
 
 import { FavoriteButton } from "@/components/FavoriteButton";
-import { Badge } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
-import { Card } from "@/components/ui/Card";
+import { Toolbar } from "@/components/ui/Toolbar";
 import { formatPercent } from "@/lib/format";
 import { profileIconUrl } from "@/lib/staticData";
 
@@ -13,11 +12,8 @@ import {
   type AcceptedResponse,
   type ApiErrorResponse,
   type ChampionStatic,
-  type PagedResultDto,
-  type ProfileChampionStat,
   type RankInfo,
-  type SummonerProfileResponse,
-  type MatchSummary
+  type SummonerProfileResponse
 } from "@/components/lol-profile/shared";
 import { rankTierDisplayLabel } from "@/lib/ranks";
 
@@ -32,23 +28,23 @@ type RankedEntry = {
   rank: RankInfo;
 };
 
+// Flat, answer-first header (the "Ladder" Toolbar primitive) — no splash art, no
+// frosted-glass metric panel. Identity + rank-at-a-glance + the primary action live
+// on one compact line; the full ranked breakdown is progressive-disclosed in the
+// sidebar, so rank appears exactly once here.
 export function ProfileHeroCard({
   title,
   region,
   gameName,
   tagLine,
   profile,
-  backgroundUrl,
   championStatic,
-  history,
   dataAge,
   rankedEntries,
   quickStats,
   recentForm,
   accepted,
   error,
-  featuredChampion,
-  featuredChampionName,
   busy,
   onRefresh
 }: {
@@ -57,176 +53,92 @@ export function ProfileHeroCard({
   gameName: string;
   tagLine: string;
   profile: SummonerProfileResponse | null;
-  backgroundUrl?: string | null;
   championStatic: ChampionStatic | null;
-  history: PagedResultDto<MatchSummary> | null;
   dataAge: string;
   rankedEntries: RankedEntry[];
   quickStats: QuickStats | null;
   recentForm: boolean[];
   accepted: AcceptedResponse | null;
   error: ApiErrorResponse | null;
-  featuredChampion?: ProfileChampionStat;
-  featuredChampionName: string | null;
   busy: boolean;
   onRefresh: () => void;
 }) {
   const primaryRank = rankedEntries[0]?.rank;
+  const rankText = primaryRank
+    ? `${rankTierDisplayLabel(primaryRank.tier)} ${primaryRank.division}`
+    : "Unranked";
 
   return (
-    <Card className="profile-hero-card relative overflow-hidden rounded-hero p-5 md:p-8">
-      {backgroundUrl ? (
-        <>
-          {/* Most-played champion splash — immersive backdrop. The art sits on
-              its own layer so the scrim above can stay full-strength for text
-              legibility without dimming the image into invisibility. */}
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0 bg-cover opacity-55"
-            style={{
-              backgroundImage: `url(${backgroundUrl})`,
-              backgroundPosition: "center 22%"
-            }}
-          />
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0"
-            style={{
-              background:
-                "linear-gradient(to right, var(--t-bg) 4%, color-mix(in oklch, var(--t-bg), transparent 35%) 48%, color-mix(in oklch, var(--t-bg), transparent 62%) 100%)"
-            }}
-          />
-        </>
-      ) : null}
-      <div className="relative grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(300px,0.78fr)] xl:items-end">
-        <div className="grid gap-5">
-          <div className="flex min-w-0 flex-col gap-5 sm:flex-row sm:items-center">
+    <div className="flex flex-col gap-3">
+      <Toolbar
+        eyebrow="League profile"
+        title={
+          <span className="flex items-center gap-3">
             {profile && championStatic ? (
               <Image
                 src={profileIconUrl(championStatic.version, profile.profileIconId)}
                 alt={`${title} icon`}
-                width={88}
-                height={88}
-                className="rounded-panel border border-border/80 shadow-media"
+                width={48}
+                height={48}
+                className="rounded-xl border border-border/70 shadow-soft"
               />
             ) : (
-              <div className="h-[88px] w-[88px] rounded-panel border border-border/70 bg-surface/70" />
+              <span className="h-12 w-12 rounded-xl border border-border/60 bg-surface/70" />
             )}
-            <div className="min-w-0">
-              <p className="type-kicker text-muted">League profile</p>
-              <h1 className="type-hero-title mt-2 truncate">
-                {title}
-              </h1>
-              <p className="mt-2 type-ui text-fg/78">
-                {profile ? `Level ${profile.summonerLevel} · ${dataAge}` : region.toUpperCase()}
-              </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                <span className="profile-stat-pill">
-                  <span className="type-kicker text-muted">Region</span>
-                  <span className="type-ui text-fg">{region.toUpperCase()}</span>
-                </span>
-                <span className="profile-stat-pill">
-                  <span className="type-kicker text-muted">Ranked</span>
-                  <span className={`type-ui ${rankColorClass(primaryRank?.tier)}`}>
-                    {primaryRank
-                      ? `${rankTierDisplayLabel(primaryRank.tier)} ${primaryRank.division}`
-                      : "Unranked"}
-                  </span>
-                </span>
-                {quickStats ? (
-                  <span className="profile-stat-pill">
-                    <span className="type-kicker text-muted">Recent WR</span>
-                    <span className="type-ui text-fg">{formatPercent(quickStats.winRate)}</span>
-                  </span>
-                ) : null}
-              </div>
-            </div>
-          </div>
-
-          {recentForm.length > 0 ? (
-            <div className="grid gap-2">
-              <div className="flex items-center justify-between gap-3">
-                <p className="type-kicker text-fg/68">Recent Form</p>
-                <p className="text-xs text-fg/55">Latest {recentForm.length} games</p>
-              </div>
-              <div className="flex flex-wrap items-center gap-1.5" aria-label="Recent match outcomes (latest first)">
+            <span className="truncate">{title}</span>
+          </span>
+        }
+        meta={
+          <>
+            <span>Level {profile?.summonerLevel ?? "—"}</span>
+            <span>{region.toUpperCase()}</span>
+            <span className={rankColorClass(primaryRank?.tier)}>
+              {rankText}
+              {primaryRank ? ` · ${primaryRank.leaguePoints} LP` : ""}
+            </span>
+            {quickStats ? <span className="text-fg/80">{formatPercent(quickStats.winRate)} WR</span> : null}
+          </>
+        }
+        actions={
+          <>
+            <Button variant="outline" onClick={onRefresh} disabled={busy}>
+              {busy ? "Starting…" : "Update Now"}
+            </Button>
+            <FavoriteButton region={region} gameName={gameName} tagLine={tagLine} />
+          </>
+        }
+        filters={
+          recentForm.length > 0 ? (
+            <>
+              <span className="type-overline text-muted">Recent form</span>
+              <div className="flex flex-wrap items-center gap-1" aria-label="Recent match outcomes (latest first)">
                 {recentForm.map((win, idx) => (
                   <span
                     key={`${win ? "w" : "l"}-${idx}`}
-                    className={`h-3 w-9 rounded-full transition-transform duration-200 ${
-                      win ? "bg-success/75" : "bg-danger/70"
-                    }`}
+                    className={`h-2.5 w-7 rounded-full ${win ? "bg-success/75" : "bg-danger/70"}`}
                     aria-label={win ? "Win" : "Loss"}
                     title={win ? "Win" : "Loss"}
                   />
                 ))}
               </div>
-            </div>
-          ) : null}
+              <span className="type-caption ml-auto text-muted">
+                Last {recentForm.length} · {dataAge}
+              </span>
+            </>
+          ) : undefined
+        }
+      />
 
-          {accepted?.message ? (
-            <p className="rounded-card border border-info/30 bg-info/10 px-4 py-3 text-sm text-fg/84">
-              {friendlyAcceptedMessage(accepted.message)}
-            </p>
-          ) : null}
-          {error?.message ? (
-            <p className="rounded-card border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
-              {error.message}
-            </p>
-          ) : null}
-        </div>
-
-        <div className="relative grid gap-3 rounded-panel border border-border bg-surface/80 p-4 shadow-card">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="type-kicker text-muted">Snapshot</p>
-              <p className="mt-1 text-sm text-fg/66">Fast read on current ranked form.</p>
-            </div>
-            <Badge className="surface-chip text-fg/72">
-              {history ? `${history.totalCount.toLocaleString()} tracked` : "Awaiting history"}
-            </Badge>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
-            <div className="profile-metric-tile">
-              <p className="type-kicker text-muted">Ranked</p>
-              <p className={`mt-2 text-xl font-semibold ${rankColorClass(primaryRank?.tier)}`}>
-                {primaryRank
-                  ? `${rankTierDisplayLabel(primaryRank.tier)} ${primaryRank.division}`
-                  : "Unranked"}
-              </p>
-              <p className="mt-1 text-sm text-fg/66">
-                {primaryRank ? `${primaryRank.leaguePoints} LP` : "No ranked ladder games yet"}
-              </p>
-            </div>
-            <div className="profile-metric-tile">
-              <p className="type-kicker text-muted">Recent sample</p>
-              <p className="mt-2 text-xl font-semibold text-fg">
-                {quickStats ? formatPercent(quickStats.winRate) : "Pending"}
-              </p>
-              <p className="mt-1 text-sm text-fg/66">
-                {quickStats
-                  ? `${quickStats.total} games · ${quickStats.avgKda.toFixed(2)} avg KDA`
-                  : "Waiting for recent matches"}
-              </p>
-            </div>
-            <div className="profile-metric-tile">
-              <p className="type-kicker text-muted">Champion focus</p>
-              <p className="mt-2 text-xl font-semibold text-fg">{featuredChampionName ?? "Loading"}</p>
-              <p className="mt-1 text-sm text-fg/66">
-                {featuredChampion
-                  ? `${featuredChampion.games} games · ${formatPercent(featuredChampion.winRate)} win rate`
-                  : "Top champion pool updating"}
-              </p>
-            </div>
-          </div>
-          <div className="flex flex-wrap items-center gap-2 pt-1">
-            <Button variant="outline" onClick={onRefresh} disabled={busy}>
-              {busy ? "Starting..." : "Update Now"}
-            </Button>
-            <FavoriteButton region={region} gameName={gameName} tagLine={tagLine} />
-          </div>
-        </div>
-      </div>
-    </Card>
+      {accepted?.message ? (
+        <p className="rounded-card border border-info/30 bg-info/10 px-4 py-3 text-sm text-fg/84">
+          {friendlyAcceptedMessage(accepted.message)}
+        </p>
+      ) : null}
+      {error?.message ? (
+        <p className="rounded-card border border-danger/30 bg-danger/10 px-4 py-3 text-sm text-danger">
+          {error.message}
+        </p>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -19,12 +19,6 @@ import {
   type SummonerProfileResponse
 } from "@/components/lol-profile/shared";
 
-function formatMasteryPoints(points: number): string {
-  if (points >= 1_000_000) return `${(points / 1_000_000).toFixed(1)}M`;
-  if (points >= 1_000) return `${Math.round(points / 1_000)}K`;
-  return String(points);
-}
-
 type RankedEntry = {
   label: string;
   rank: RankInfo;
@@ -173,11 +167,11 @@ export function ProfileSidebar({
                     <p className="truncate text-sm font-medium text-fg group-hover:text-primary">
                       {champion?.name ?? `Champion ${m.championId}`}
                     </p>
-                    <p className="type-caption text-muted tabular-nums">{formatMasteryPoints(m.championPoints)} pts</p>
+                    <p className="type-caption text-muted tabular-nums">{m.championPoints.toLocaleString()} pts</p>
                   </div>
                   <span
-                    className={`type-overline rounded-full border px-2 py-0.5 ${
-                      highMastery ? "border-primary/45 bg-primary/10 text-primary" : "border-border/50 text-fg/75"
+                    className={`type-overline rounded-full border px-2 py-0.5 tabular-nums ${
+                      highMastery ? "border-border-strong bg-surface-2 font-semibold text-fg" : "border-border/50 text-muted"
                     }`}
                   >
                     M{m.championLevel}
@@ -230,7 +224,8 @@ export function ProfileSidebar({
           </div>
           <div className="mt-4 grid gap-2">
             {profile.frequentlyPlayedWith!.map((mate) => {
-              const wr = mate.sameTeamGames > 0 ? (mate.sameTeamWins / mate.sameTeamGames) * 100 : null;
+              // Only show a same-team win-rate once the sample is meaningful (avoids "100% · 1 game" noise).
+              const wr = mate.sameTeamGames >= 2 ? (mate.sameTeamWins / mate.sameTeamGames) * 100 : null;
               return (
                 <Link
                   key={mate.summonerId}

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -82,14 +82,17 @@ export function ProfileSidebar({
                   className="surface-subtle grid gap-3 rounded-card px-3 py-3 sm:grid-cols-[96px_minmax(0,1fr)] sm:items-center"
                 >
                   {emblem ? (
-                    <div className="flex h-24 w-24 items-center justify-center rounded-control border border-border/45 bg-surface/65 p-1.5">
+                    // The communitydragon ranked emblem sits in a large mostly-transparent
+                    // canvas (~22% content, centered), so we crop the padding by scaling the
+                    // centered crest up inside an overflow-hidden frame.
+                    <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-control border border-border/45 bg-surface/65">
                       <Image
                         src={emblem}
                         alt={`${rankTierDisplayLabel(rank.tier)} emblem`}
-                        width={96}
-                        height={96}
-                        sizes="96px"
-                        className="h-full w-full select-none object-contain"
+                        width={256}
+                        height={256}
+                        sizes="256px"
+                        className="h-full w-full origin-center scale-[3.3] select-none object-contain"
                       />
                     </div>
                   ) : (

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -6,8 +6,10 @@ import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
 import { DataBar } from "@/components/ui/DataBar";
 import { Sparkline } from "@/components/ui/Sparkline";
+import { championIconUrl } from "@/lib/staticData";
 import { formatPercent, winRateColorClass } from "@/lib/format";
 import { rankEmblemUrl, rankTierDisplayLabel, rankToLadderPoints } from "@/lib/ranks";
+import { encodeRiotIdPath } from "@/lib/riotid";
 
 import {
   rankColorClass,
@@ -16,6 +18,12 @@ import {
   type RankInfo,
   type SummonerProfileResponse
 } from "@/components/lol-profile/shared";
+
+function formatMasteryPoints(points: number): string {
+  if (points >= 1_000_000) return `${(points / 1_000_000).toFixed(1)}M`;
+  if (points >= 1_000) return `${Math.round(points / 1_000)}K`;
+  return String(points);
+}
 
 type RankedEntry = {
   label: string;
@@ -134,6 +142,53 @@ export function ProfileSidebar({
         ) : null}
       </Card>
 
+      {(profile.topMastery?.length ?? 0) > 0 ? (
+        <Card className="profile-section-card p-5">
+          <div>
+            <p className="type-kicker text-muted">Mastery</p>
+            <h2 className="mt-2 type-section">Top mastery</h2>
+          </div>
+          <div className="mt-4 grid gap-2">
+            {profile.topMastery!.map((m) => {
+              const champion = championStatic?.champions[String(m.championId)];
+              const highMastery = m.championLevel >= 7;
+              return (
+                <Link
+                  key={m.championId}
+                  href={`/lol/champions/${m.championId}`}
+                  className="surface-subtle group flex items-center gap-3 rounded-control px-3 py-2.5 transition hover:border-border-strong hover:bg-surface-2/60"
+                >
+                  {champion && championStatic ? (
+                    <Image
+                      src={championIconUrl(championStatic.version, champion.id)}
+                      alt={champion.name}
+                      width={32}
+                      height={32}
+                      className="rounded-lg border border-border/50"
+                    />
+                  ) : (
+                    <div className="h-8 w-8 rounded-lg border border-border/50 bg-surface/70" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-fg group-hover:text-primary">
+                      {champion?.name ?? `Champion ${m.championId}`}
+                    </p>
+                    <p className="type-caption text-muted tabular-nums">{formatMasteryPoints(m.championPoints)} pts</p>
+                  </div>
+                  <span
+                    className={`type-overline rounded-full border px-2 py-0.5 ${
+                      highMastery ? "border-primary/45 bg-primary/10 text-primary" : "border-border/50 text-fg/75"
+                    }`}
+                  >
+                    M{m.championLevel}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </Card>
+      ) : null}
+
       <Card className="profile-section-card p-5">
         <div>
           <p className="type-kicker text-muted">Champion pool</p>
@@ -166,6 +221,39 @@ export function ProfileSidebar({
           })}
         </div>
       </Card>
+
+      {(profile.frequentlyPlayedWith?.length ?? 0) > 0 ? (
+        <Card className="profile-section-card p-5">
+          <div>
+            <p className="type-kicker text-muted">Duo signals</p>
+            <h2 className="mt-2 type-section">Played with</h2>
+          </div>
+          <div className="mt-4 grid gap-2">
+            {profile.frequentlyPlayedWith!.map((mate) => {
+              const wr = mate.sameTeamGames > 0 ? (mate.sameTeamWins / mate.sameTeamGames) * 100 : null;
+              return (
+                <Link
+                  key={mate.summonerId}
+                  href={`/lol/summoners/${region}/${encodeRiotIdPath({ gameName: mate.gameName, tagLine: mate.tagLine })}`}
+                  className="surface-subtle group grid gap-1.5 rounded-control px-3 py-2.5 transition hover:border-border-strong hover:bg-surface-2/60"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="min-w-0 truncate text-sm font-medium text-fg group-hover:text-primary">
+                      {mate.gameName}
+                      <span className="text-muted">#{mate.tagLine}</span>
+                    </p>
+                    {wr != null ? <DataBar value={wr} /> : null}
+                  </div>
+                  <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
+                    <span>{mate.gamesTogether} games together</span>
+                    {mate.sameTeamGames > 0 ? <span>{mate.sameTeamGames} as duo</span> : null}
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </Card>
+      ) : null}
 
       <LiveGameCard region={region} gameName={gameName} tagLine={tagLine} />
     </aside>

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -5,12 +5,14 @@ import { LiveGameCard } from "@/components/LiveGameCard";
 import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
 import { DataBar } from "@/components/ui/DataBar";
+import { Sparkline } from "@/components/ui/Sparkline";
 import { formatPercent, winRateColorClass } from "@/lib/format";
-import { rankEmblemUrl, rankTierDisplayLabel } from "@/lib/ranks";
+import { rankEmblemUrl, rankTierDisplayLabel, rankToLadderPoints } from "@/lib/ranks";
 
 import {
   rankColorClass,
   type ChampionStatic,
+  type RankHistoryEntry,
   type RankInfo,
   type SummonerProfileResponse
 } from "@/components/lol-profile/shared";
@@ -25,6 +27,7 @@ export function ProfileSidebar({
   championStatic,
   rankedEntries,
   unrankedQueues,
+  rankHistory,
   region,
   gameName,
   tagLine
@@ -33,10 +36,21 @@ export function ProfileSidebar({
   championStatic: ChampionStatic | null;
   rankedEntries: RankedEntry[];
   unrankedQueues: string[];
+  rankHistory: RankHistoryEntry[] | null;
   region: string;
   gameName: string;
   tagLine: string;
 }) {
+  // Solo/Duo LP progression: recorded snapshots (oldest→newest) + the current rank
+  // appended as the latest point. Sparkline self-hides below 2 points.
+  const soloRank = rankedEntries.find((entry) => entry.label === "Solo/Duo")?.rank;
+  const soloSeries = [
+    ...(rankHistory ?? [])
+      .filter((entry) => (entry.queueType ?? "").toUpperCase().includes("SOLO"))
+      .map((entry) => rankToLadderPoints(entry.tier, entry.rankNumber, entry.leaguePoints)),
+    soloRank ? rankToLadderPoints(soloRank.tier, soloRank.division, soloRank.leaguePoints) : null
+  ].filter((value): value is number => value != null);
+
   return (
     <aside className="grid content-start gap-5 xl:sticky xl:top-24">
       <Card className="profile-section-card p-5">
@@ -99,6 +113,16 @@ export function ProfileSidebar({
             })}
           </div>
         )}
+        {soloSeries.length >= 2 ? (
+          <div className="surface-subtle mt-4 flex items-center justify-between gap-3 rounded-card px-3 py-2.5">
+            <div>
+              <p className="type-overline text-muted">Solo/Duo progression</p>
+              <p className="type-caption text-fg/65">{soloSeries.length} snapshots</p>
+            </div>
+            <Sparkline values={soloSeries} width={104} height={30} />
+          </div>
+        ) : null}
+
         {unrankedQueues.length > 0 ? (
           <div className="mt-3 grid gap-1">
             {unrankedQueues.map((label) => (

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -43,7 +43,7 @@ export function ProfileSidebar({
         <div className="flex items-start justify-between gap-3">
           <div>
             <p className="type-kicker text-muted">Ranked snapshot</p>
-            <h2 className="mt-2 type-section">Queues and ladder movement</h2>
+            <h2 className="mt-2 type-section">Solo/Duo &amp; Flex</h2>
           </div>
           <Badge className="surface-chip text-fg/72">
             {profile.rankAge?.ageDescription ?? "updated recently"}
@@ -113,7 +113,7 @@ export function ProfileSidebar({
       <Card className="profile-section-card p-5">
         <div>
           <p className="type-kicker text-muted">Champion pool</p>
-          <h2 className="mt-2 type-section">Top picks in recent tracked games</h2>
+          <h2 className="mt-2 type-section">Most played</h2>
         </div>
         <div className="mt-4 grid gap-3">
           {(profile.topChampions ?? []).slice(0, 6).map((championStat, index) => {

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -97,6 +97,7 @@ function RuneTrigger({
 function ScoreboardRow({
   participant,
   durationSeconds,
+  teamMaxDamage,
   region,
   gameName,
   tagLine,
@@ -107,6 +108,7 @@ function ScoreboardRow({
 }: {
   participant: MatchParticipant;
   durationSeconds: number;
+  teamMaxDamage: number;
   region: string;
   gameName: string;
   tagLine: string;
@@ -119,6 +121,12 @@ function ScoreboardRow({
   const champion = championStatic?.champions[String(participant.championId)];
   const cs = participant.totalMinionsKilled + participant.neutralMinionsKilled;
   const csPerMin = durationSeconds > 0 ? cs / (durationSeconds / 60) : 0;
+  const totalDmg = participant.totalDamageDealtToChampions;
+  const physDmg = participant.physicalDamageDealtToChampions ?? 0;
+  const magicDmg = participant.magicDamageDealtToChampions ?? 0;
+  const trueDmg = participant.trueDamageDealtToChampions ?? 0;
+  const splitSum = physDmg + magicDmg + trueDmg;
+  const damageFillPct = teamMaxDamage > 0 ? Math.min(100, (totalDmg / teamMaxDamage) * 100) : 0;
   const itemSlots = Array.from({ length: 7 }, (_, idx) => participant.items?.[idx] ?? 0);
   const displayName = participantDisplayName(participant.gameName, participant.tagLine);
   const canLink = Boolean(participant.gameName && participant.tagLine && !isCurrent);
@@ -199,8 +207,28 @@ function ScoreboardRow({
         <p className="type-caption text-muted tabular-nums">{csPerMin.toFixed(1)}/min</p>
       </Td>
 
-      <Td align="right" className="whitespace-nowrap text-sm tabular-nums text-fg/88">
-        {participant.totalDamageDealtToChampions.toLocaleString()}
+      <Td align="right" className="whitespace-nowrap">
+        <span className="text-sm tabular-nums text-fg/88">{totalDmg.toLocaleString()}</span>
+        {splitSum > 0 ? (
+          <Tooltip
+            side="left"
+            content={
+              <div className="grid gap-0.5 tabular-nums">
+                <span><span className="text-loss">■</span> Physical {physDmg.toLocaleString()}</span>
+                <span><span className="text-team-blue">■</span> Magic {magicDmg.toLocaleString()}</span>
+                <span><span className="text-fg">■</span> True {trueDmg.toLocaleString()}</span>
+              </div>
+            }
+          >
+            <div className="ml-auto mt-1 h-1.5 w-16 overflow-hidden rounded-full bg-surface-2/70">
+              <div className="flex h-full" style={{ width: `${damageFillPct}%` }}>
+                <span className="h-full" style={{ width: `${(physDmg / splitSum) * 100}%`, backgroundColor: "var(--color-loss)" }} />
+                <span className="h-full" style={{ width: `${(magicDmg / splitSum) * 100}%`, backgroundColor: "var(--color-team-blue)" }} />
+                <span className="h-full" style={{ width: `${(trueDmg / splitSum) * 100}%`, backgroundColor: "var(--color-fg)" }} />
+              </div>
+            </div>
+          </Tooltip>
+        ) : null}
       </Td>
 
       <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
@@ -271,6 +299,7 @@ export function ScoreboardTeamTable({
   const win = participants[0]?.win ?? false;
   const totalKills = participants.reduce((sum, p) => sum + p.kills, 0);
   const totalGold = participants.reduce((sum, p) => sum + p.goldEarned, 0);
+  const teamMaxDamage = Math.max(1, ...participants.map((p) => p.totalDamageDealtToChampions));
   const isBlue = teamId === 100;
 
   return (
@@ -331,6 +360,7 @@ export function ScoreboardTeamTable({
                 key={`${participant.puuid ?? participant.championId}-${idx}`}
                 participant={participant}
                 durationSeconds={durationSeconds}
+                teamMaxDamage={teamMaxDamage}
                 region={region}
                 gameName={gameName}
                 tagLine={tagLine}

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -97,7 +97,7 @@ function RuneTrigger({
 function ScoreboardRow({
   participant,
   durationSeconds,
-  teamMaxDamage,
+  maxDamage,
   region,
   gameName,
   tagLine,
@@ -108,7 +108,7 @@ function ScoreboardRow({
 }: {
   participant: MatchParticipant;
   durationSeconds: number;
-  teamMaxDamage: number;
+  maxDamage: number;
   region: string;
   gameName: string;
   tagLine: string;
@@ -126,7 +126,7 @@ function ScoreboardRow({
   const magicDmg = participant.magicDamageDealtToChampions ?? 0;
   const trueDmg = participant.trueDamageDealtToChampions ?? 0;
   const splitSum = physDmg + magicDmg + trueDmg;
-  const damageFillPct = teamMaxDamage > 0 ? Math.min(100, (totalDmg / teamMaxDamage) * 100) : 0;
+  const damageFillPct = maxDamage > 0 ? Math.min(100, (totalDmg / maxDamage) * 100) : 0;
   const itemSlots = Array.from({ length: 7 }, (_, idx) => participant.items?.[idx] ?? 0);
   const displayName = participantDisplayName(participant.gameName, participant.tagLine);
   const canLink = Boolean(participant.gameName && participant.tagLine && !isCurrent);
@@ -272,6 +272,7 @@ export function ScoreboardTeamTable({
   participants,
   teamId,
   durationSeconds,
+  maxDamage,
   bans,
   region,
   gameName,
@@ -284,6 +285,7 @@ export function ScoreboardTeamTable({
   participants: MatchParticipant[];
   teamId: 100 | 200;
   durationSeconds: number;
+  maxDamage: number;
   bans: number[];
   region: string;
   gameName: string;
@@ -299,7 +301,6 @@ export function ScoreboardTeamTable({
   const win = participants[0]?.win ?? false;
   const totalKills = participants.reduce((sum, p) => sum + p.kills, 0);
   const totalGold = participants.reduce((sum, p) => sum + p.goldEarned, 0);
-  const teamMaxDamage = Math.max(1, ...participants.map((p) => p.totalDamageDealtToChampions));
   const isBlue = teamId === 100;
 
   return (
@@ -360,7 +361,7 @@ export function ScoreboardTeamTable({
                 key={`${participant.puuid ?? participant.championId}-${idx}`}
                 participant={participant}
                 durationSeconds={durationSeconds}
-                teamMaxDamage={teamMaxDamage}
+                maxDamage={maxDamage}
                 region={region}
                 gameName={gameName}
                 tagLine={tagLine}

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -1,0 +1,324 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { ParticipantRuneCard } from "@/components/lol-profile/ParticipantRuneCard";
+import { TableScroll, Table, Th, Td } from "@/components/ui/Table";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { cn } from "@/lib/cn";
+import { encodeRiotIdPath } from "@/lib/riotid";
+import { roleDisplayLabel } from "@/lib/roles";
+import {
+  championIconUrl,
+  itemIconUrl,
+  runeIconUrl,
+  summonerSpellIconUrl
+} from "@/lib/staticData";
+
+import {
+  isCurrentProfilePlayer,
+  matchKdaRatio,
+  normalizeRoleKey,
+  participantDisplayName,
+  primaryKeystoneId,
+  type ChampionStatic,
+  type ItemStatic,
+  type MatchParticipant,
+  type RuneStatic,
+  type SpellStatic
+} from "@/components/lol-profile/shared";
+
+const ROLE_ORDER: Record<string, number> = { TOP: 0, JUNGLE: 1, MIDDLE: 2, BOTTOM: 3, UTILITY: 4 };
+
+function formatGold(gold: number): string {
+  return gold >= 1000 ? `${(gold / 1000).toFixed(1)}k` : String(gold);
+}
+
+function RuneTrigger({
+  participant,
+  runeStatic
+}: {
+  participant: MatchParticipant;
+  runeStatic: RuneStatic | null;
+}) {
+  const keystoneId = primaryKeystoneId(participant.runes, runeStatic);
+  const keystone = runeStatic?.runeById[String(keystoneId)];
+  const subStyle = runeStatic?.styleById[String(participant.runes?.subStyleId ?? 0)];
+
+  const icons = (
+    <span className="flex flex-col items-center gap-0.5">
+      {keystone ? (
+        <Image
+          src={runeIconUrl(keystone.icon)}
+          alt={keystone.name}
+          width={18}
+          height={18}
+          className="rounded-full border border-border/40 bg-surface-2/70"
+        />
+      ) : (
+        <span className="h-[18px] w-[18px] rounded-full border border-border/40 bg-surface-2/70" />
+      )}
+      {subStyle ? (
+        <Image
+          src={runeIconUrl(subStyle.icon)}
+          alt={subStyle.name}
+          width={14}
+          height={14}
+          className="rounded-full"
+        />
+      ) : (
+        <span className="h-[14px] w-[14px] rounded-full bg-surface-2/70" />
+      )}
+    </span>
+  );
+
+  if (!runeStatic) return icons;
+
+  return (
+    <Tooltip
+      side="right"
+      className="max-w-none p-2"
+      content={
+        <div className="w-[244px]">
+          <ParticipantRuneCard participant={participant} runeStatic={runeStatic} />
+        </div>
+      }
+    >
+      <button
+        type="button"
+        aria-label={`Runes for ${participantDisplayName(participant.gameName, participant.tagLine)}`}
+        className="rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
+      >
+        {icons}
+      </button>
+    </Tooltip>
+  );
+}
+
+function ScoreboardRow({
+  participant,
+  durationSeconds,
+  region,
+  gameName,
+  tagLine,
+  championStatic,
+  itemStatic,
+  spellStatic,
+  runeStatic
+}: {
+  participant: MatchParticipant;
+  durationSeconds: number;
+  region: string;
+  gameName: string;
+  tagLine: string;
+  championStatic: ChampionStatic | null;
+  itemStatic: ItemStatic | null;
+  spellStatic: SpellStatic | null;
+  runeStatic: RuneStatic | null;
+}) {
+  const isCurrent = isCurrentProfilePlayer(participant, gameName, tagLine);
+  const champion = championStatic?.champions[String(participant.championId)];
+  const cs = participant.totalMinionsKilled + participant.neutralMinionsKilled;
+  const csPerMin = durationSeconds > 0 ? cs / (durationSeconds / 60) : 0;
+  const itemSlots = Array.from({ length: 7 }, (_, idx) => participant.items?.[idx] ?? 0);
+  const displayName = participantDisplayName(participant.gameName, participant.tagLine);
+  const canLink = Boolean(participant.gameName && participant.tagLine && !isCurrent);
+
+  return (
+    <tr className={cn("border-t border-border/45", isCurrent && "bg-primary/10")}>
+      <Td className="min-w-[200px]">
+        <div className="flex items-center gap-2">
+          <div className="relative shrink-0">
+            {champion && championStatic ? (
+              <Image
+                src={championIconUrl(championStatic.version, champion.id)}
+                alt={champion.name}
+                width={34}
+                height={34}
+                className="rounded-lg border border-border/55"
+              />
+            ) : (
+              <div className="h-[34px] w-[34px] rounded-lg border border-border/55 bg-surface/70" />
+            )}
+            {participant.champLevel ? (
+              <span className="absolute -bottom-1 -right-1 rounded-full border border-border/60 bg-surface px-1 text-[0.625rem] font-semibold leading-tight text-fg/85">
+                {participant.champLevel}
+              </span>
+            ) : null}
+          </div>
+
+          <span className="flex shrink-0 flex-col gap-0.5" aria-label="Summoner spells">
+            {[participant.summonerSpell1Id, participant.summonerSpell2Id].map((spellId, spellIdx) => {
+              const spellMeta = spellStatic?.spells[String(spellId)];
+              return spellMeta && spellStatic ? (
+                <Image
+                  key={`${spellId}-${spellIdx}`}
+                  src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
+                  alt={spellMeta.name}
+                  title={spellMeta.name}
+                  width={16}
+                  height={16}
+                  className="rounded border border-border/40"
+                />
+              ) : (
+                <span key={`${spellId}-${spellIdx}`} className="h-4 w-4 rounded border border-border/40 bg-surface/60" />
+              );
+            })}
+          </span>
+
+          <RuneTrigger participant={participant} runeStatic={runeStatic} />
+
+          <div className="min-w-0">
+            {canLink ? (
+              <Link
+                href={`/lol/summoners/${region}/${encodeRiotIdPath({ gameName: participant.gameName as string, tagLine: participant.tagLine as string })}`}
+                className="block truncate text-sm font-medium text-fg/95 transition-colors hover:text-primary hover:underline"
+              >
+                {displayName}
+              </Link>
+            ) : (
+              <p className={cn("truncate text-sm font-medium", isCurrent ? "text-primary" : "text-fg/95")}>
+                {displayName}
+              </p>
+            )}
+            <p className="type-caption text-muted">{roleDisplayLabel(normalizeRoleKey(participant.teamPosition))}</p>
+          </div>
+        </div>
+      </Td>
+
+      <Td align="right" className="whitespace-nowrap">
+        <span className="text-sm tabular-nums text-fg/92">
+          {participant.kills}<span className="text-muted"> / </span>
+          <span className="text-loss">{participant.deaths}</span>
+          <span className="text-muted"> / </span>{participant.assists}
+        </span>
+        <p className="type-caption text-muted tabular-nums">{matchKdaRatio(participant).toFixed(2)} KDA</p>
+      </Td>
+
+      <Td align="right" className="whitespace-nowrap">
+        <span className="text-sm tabular-nums text-fg/88">{cs}</span>
+        <p className="type-caption text-muted tabular-nums">{csPerMin.toFixed(1)}/min</p>
+      </Td>
+
+      <Td align="right" className="whitespace-nowrap text-sm tabular-nums text-fg/88">
+        {participant.totalDamageDealtToChampions.toLocaleString()}
+      </Td>
+
+      <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
+        {participant.visionScore}
+      </Td>
+
+      <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
+        {formatGold(participant.goldEarned)}
+      </Td>
+
+      <Td>
+        <div className="flex flex-wrap items-center gap-1">
+          {itemSlots.map((itemId, itemIdx) => {
+            if (!itemId) {
+              return (
+                <span key={`empty-${itemIdx}`} className="h-[22px] w-[22px] rounded border border-border/35 bg-surface/55" />
+              );
+            }
+            const itemMeta = itemStatic?.items[String(itemId)];
+            return itemStatic ? (
+              <Image
+                key={`${itemId}-${itemIdx}`}
+                src={itemIconUrl(itemStatic.version, itemId)}
+                alt={itemMeta?.name ?? `Item ${itemId}`}
+                title={itemMeta?.name ?? `Item ${itemId}`}
+                width={22}
+                height={22}
+                className="rounded border border-border/35"
+              />
+            ) : (
+              <span key={`${itemId}-${itemIdx}`} className="h-[22px] w-[22px] rounded border border-border/35 bg-surface/55" />
+            );
+          })}
+        </div>
+      </Td>
+    </tr>
+  );
+}
+
+export function ScoreboardTeamTable({
+  participants,
+  teamId,
+  durationSeconds,
+  region,
+  gameName,
+  tagLine,
+  championStatic,
+  itemStatic,
+  spellStatic,
+  runeStatic
+}: {
+  participants: MatchParticipant[];
+  teamId: 100 | 200;
+  durationSeconds: number;
+  region: string;
+  gameName: string;
+  tagLine: string;
+  championStatic: ChampionStatic | null;
+  itemStatic: ItemStatic | null;
+  spellStatic: SpellStatic | null;
+  runeStatic: RuneStatic | null;
+}) {
+  const ordered = participants
+    .slice()
+    .sort((a, b) => (ROLE_ORDER[normalizeRoleKey(a.teamPosition)] ?? 9) - (ROLE_ORDER[normalizeRoleKey(b.teamPosition)] ?? 9));
+  const win = participants[0]?.win ?? false;
+  const totalKills = participants.reduce((sum, p) => sum + p.kills, 0);
+  const totalGold = participants.reduce((sum, p) => sum + p.goldEarned, 0);
+  const isBlue = teamId === 100;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-2 px-3">
+        <div className="flex items-center gap-2">
+          <span className={cn("type-overline font-semibold", isBlue ? "text-team-blue" : "text-team-red")}>
+            {isBlue ? "Blue Team" : "Red Team"}
+          </span>
+          <span className={cn("type-caption font-semibold", win ? "text-win" : "text-loss")}>
+            {win ? "Victory" : "Defeat"}
+          </span>
+        </div>
+        <div className="type-caption flex items-center gap-3 text-muted tabular-nums">
+          <span>{totalKills} kills</span>
+          <span>{formatGold(totalGold)} gold</span>
+        </div>
+      </div>
+
+      <TableScroll className="match-detail-shell">
+        <Table className="min-w-[600px]">
+          <thead>
+            <tr>
+              <Th>{isBlue ? "Blue Team" : "Red Team"}</Th>
+              <Th align="right">KDA</Th>
+              <Th align="right">CS</Th>
+              <Th align="right">Damage</Th>
+              <Th align="right" className="hidden sm:table-cell">Vision</Th>
+              <Th align="right" className="hidden sm:table-cell">Gold</Th>
+              <Th>Items</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {ordered.map((participant, idx) => (
+              <ScoreboardRow
+                key={`${participant.puuid ?? participant.championId}-${idx}`}
+                participant={participant}
+                durationSeconds={durationSeconds}
+                region={region}
+                gameName={gameName}
+                tagLine={tagLine}
+                championStatic={championStatic}
+                itemStatic={itemStatic}
+                spellStatic={spellStatic}
+                runeStatic={runeStatic}
+              />
+            ))}
+          </tbody>
+        </Table>
+      </TableScroll>
+    </div>
+  );
+}

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -244,6 +244,7 @@ export function ScoreboardTeamTable({
   participants,
   teamId,
   durationSeconds,
+  bans,
   region,
   gameName,
   tagLine,
@@ -255,6 +256,7 @@ export function ScoreboardTeamTable({
   participants: MatchParticipant[];
   teamId: 100 | 200;
   durationSeconds: number;
+  bans: number[];
   region: string;
   gameName: string;
   tagLine: string;
@@ -282,9 +284,31 @@ export function ScoreboardTeamTable({
             {win ? "Victory" : "Defeat"}
           </span>
         </div>
-        <div className="type-caption flex items-center gap-3 text-muted tabular-nums">
-          <span>{totalKills} kills</span>
-          <span>{formatGold(totalGold)} gold</span>
+        <div className="flex items-center gap-3">
+          {bans.length > 0 ? (
+            <div className="flex items-center gap-1" aria-label="Bans" title="Champion bans">
+              {bans.map((championId, idx) => {
+                const champion = championStatic?.champions[String(championId)];
+                return champion && championStatic ? (
+                  <Image
+                    key={`ban-${championId}-${idx}`}
+                    src={championIconUrl(championStatic.version, champion.id)}
+                    alt={`Banned: ${champion.name}`}
+                    title={`Banned: ${champion.name}`}
+                    width={16}
+                    height={16}
+                    className="rounded border border-border/40 opacity-60 grayscale"
+                  />
+                ) : (
+                  <span key={`ban-${championId}-${idx}`} className="h-4 w-4 rounded border border-border/40 bg-surface/60" />
+                );
+              })}
+            </div>
+          ) : null}
+          <div className="type-caption flex items-center gap-3 text-muted tabular-nums">
+            <span>{totalKills} kills</span>
+            <span>{formatGold(totalGold)} gold</span>
+          </div>
         </div>
       </div>
 

--- a/apps/web/components/lol-profile/shared.ts
+++ b/apps/web/components/lol-profile/shared.ts
@@ -40,6 +40,25 @@ export type ProfileChampionStat = {
   kdaRatio: number;
 };
 
+export type PlayedWithEntry = {
+  summonerId: string;
+  gameName: string;
+  tagLine: string;
+  gamesTogether: number;
+  sameTeamGames: number;
+  sameTeamWins: number;
+};
+
+export type ChampionMasteryEntry = {
+  championId: number;
+  championName: string;
+  championLevel: number;
+  championPoints: number;
+  lastPlayTime: number;
+  chestGranted: boolean;
+  tokensEarned: number;
+};
+
 export type SummonerProfileResponse = {
   summonerId?: string;
   puuid: string;
@@ -51,6 +70,8 @@ export type SummonerProfileResponse = {
   flexRank?: RankInfo | null;
   overviewStats?: ProfileOverviewStats | null;
   topChampions?: ProfileChampionStat[] | null;
+  frequentlyPlayedWith?: PlayedWithEntry[] | null;
+  topMastery?: ChampionMasteryEntry[] | null;
   profileAge: DataAgeMetadata;
   rankAge: DataAgeMetadata;
   statsAge?: DataAgeMetadata | null;

--- a/apps/web/components/lol-profile/shared.ts
+++ b/apps/web/components/lol-profile/shared.ts
@@ -200,6 +200,20 @@ export type MatchTeamObjectives = {
   inhibitor: ObjectiveStat;
 };
 
+export type TimelineFrame = {
+  minuteMark: number;
+  blueGold: number;
+  redGold: number;
+  blueXp: number;
+  redXp: number;
+};
+
+export type MatchTimeline = {
+  matchId: string;
+  duration: number;
+  frames: TimelineFrame[];
+};
+
 export type RankHistoryEntry = {
   queueType: string | null;
   tier: string | null;

--- a/apps/web/components/lol-profile/shared.ts
+++ b/apps/web/components/lol-profile/shared.ts
@@ -159,6 +159,17 @@ export type MatchDetail = {
     items: number[];
     runes: MatchRuneDetail;
   }>;
+  bans?: Array<{ teamId: number; bannedChampionIds: number[] }>;
+};
+
+export type RankHistoryEntry = {
+  queueType: string | null;
+  tier: string | null;
+  rankNumber: string | null;
+  leaguePoints: number;
+  wins: number;
+  losses: number;
+  dateRecorded: string;
 };
 
 export type QueueOption = {

--- a/apps/web/components/lol-profile/shared.ts
+++ b/apps/web/components/lol-profile/shared.ts
@@ -151,6 +151,9 @@ export type MatchDetail = {
     champLevel?: number;
     goldEarned: number;
     totalDamageDealtToChampions: number;
+    physicalDamageDealtToChampions?: number;
+    magicDamageDealtToChampions?: number;
+    trueDamageDealtToChampions?: number;
     visionScore: number;
     totalMinionsKilled: number;
     neutralMinionsKilled: number;
@@ -160,6 +163,20 @@ export type MatchDetail = {
     runes: MatchRuneDetail;
   }>;
   bans?: Array<{ teamId: number; bannedChampionIds: number[] }>;
+  objectives?: MatchTeamObjectives[];
+};
+
+export type ObjectiveStat = { kills: number; first: boolean };
+
+export type MatchTeamObjectives = {
+  teamId: number;
+  firstBlood: boolean;
+  baron: ObjectiveStat;
+  dragon: ObjectiveStat;
+  riftHerald: ObjectiveStat;
+  horde: ObjectiveStat;
+  tower: ObjectiveStat;
+  inhibitor: ObjectiveStat;
 };
 
 export type RankHistoryEntry = {

--- a/apps/web/components/lol-profile/shared.ts
+++ b/apps/web/components/lol-profile/shared.ts
@@ -1,5 +1,6 @@
 import { formatQueueLabel } from "@/lib/queues";
 import { rankTierColorClass } from "@/lib/ranks";
+import type { RuneTree } from "@/lib/staticData";
 
 export type DataAgeMetadata = {
   fetchedAt?: string;
@@ -88,6 +89,8 @@ export type RuneStatic = {
   runeById: Record<string, { name: string; icon: string }>;
   styleById: Record<string, { name: string; icon: string }>;
   runeSortById: Record<string, number>;
+  /** Full structured trees (style → slots → runes) for rendering a complete rune page. */
+  trees: RuneTree[];
 };
 
 export type MatchRuneDetail = {
@@ -145,8 +148,10 @@ export type MatchDetail = {
     kills: number;
     deaths: number;
     assists: number;
+    champLevel?: number;
     goldEarned: number;
     totalDamageDealtToChampions: number;
+    visionScore: number;
     totalMinionsKilled: number;
     neutralMinionsKilled: number;
     summonerSpell1Id: number;
@@ -254,6 +259,25 @@ export type AlignedParticipantRow = {
   blue: MatchParticipant | null;
   red: MatchParticipant | null;
 };
+
+export function sortRuneSelections(
+  selectionIds: number[],
+  runeSortById: Record<string, number> | undefined
+): number[] {
+  return selectionIds.slice().sort((a, b) => {
+    const aSort = runeSortById?.[String(a)] ?? Number.MAX_SAFE_INTEGER;
+    const bSort = runeSortById?.[String(b)] ?? Number.MAX_SAFE_INTEGER;
+    return aSort - bSort;
+  });
+}
+
+/** The keystone is the lowest-slot primary selection — i.e. first after sorting by rune slot order. */
+export function primaryKeystoneId(
+  runes: MatchRuneDetail | null | undefined,
+  runeStatic: { runeSortById: Record<string, number> } | null
+): number {
+  return sortRuneSelections(runes?.primarySelections ?? [], runeStatic?.runeSortById)[0] ?? 0;
+}
 
 export function hasRunes(runes?: MatchRuneDetail | null): boolean {
   if (!runes) return false;

--- a/apps/web/components/ui/Toolbar.tsx
+++ b/apps/web/components/ui/Toolbar.tsx
@@ -21,9 +21,11 @@ export function Toolbar({
   className?: string;
 }) {
   return (
-    <div className={cn("toolbar grid gap-3 px-4 py-3.5 sm:px-5", className)}>
+    <div className={cn("toolbar flex flex-col gap-3 px-4 py-3.5 sm:px-5", className)}>
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-        <div className="min-w-0 flex-1">
+        {/* basis-full on small screens forces the title onto its own line so the
+            actions wrap below instead of overflowing; flex-1 from sm: up. */}
+        <div className="min-w-0 grow basis-full sm:basis-0">
           {eyebrow ? <p className="type-overline text-muted">{eyebrow}</p> : null}
           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
             <h1 className="type-page-title text-fg">{title}</h1>
@@ -34,7 +36,7 @@ export function Toolbar({
             ) : null}
           </div>
         </div>
-        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+        {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}
       </div>
       {filters ? (
         <div className="flex flex-wrap items-center gap-2 border-t border-border/70 pt-3">

--- a/apps/web/lib/lolPublicApi.ts
+++ b/apps/web/lib/lolPublicApi.ts
@@ -14,6 +14,11 @@ export function buildLolPublicSummonerByIdPath(summonerId: string) {
   return `${LOL_PUBLIC_SUMMONERS_PREFIX}/${encodeURIComponent(summonerId)}`;
 }
 
+export function buildLolPublicSummonerRankHistoryPath(summonerId: string, queueType?: string) {
+  const base = `${buildLolPublicSummonerByIdPath(summonerId)}/stats/rank-history`;
+  return queueType ? `${base}?queueType=${encodeURIComponent(queueType)}` : base;
+}
+
 export function buildLolPublicSummonerSearchPath(
   region: string,
   query: string,

--- a/apps/web/lib/lolPublicApi.ts
+++ b/apps/web/lib/lolPublicApi.ts
@@ -19,6 +19,10 @@ export function buildLolPublicSummonerRankHistoryPath(summonerId: string, queueT
   return queueType ? `${base}?queueType=${encodeURIComponent(queueType)}` : base;
 }
 
+export function buildLolPublicSummonerMatchTimelinePath(summonerId: string, matchId: string) {
+  return `${buildLolPublicSummonerByIdPath(summonerId)}/matches/${encodeURIComponent(matchId)}/timeline`;
+}
+
 export function buildLolPublicSummonerSearchPath(
   region: string,
   query: string,

--- a/apps/web/lib/ranks.ts
+++ b/apps/web/lib/ranks.ts
@@ -83,6 +83,50 @@ export function rankTierColorClass(tier: string | null | undefined): string {
   return RANK_COLOR_CLASS[tier.toUpperCase()] ?? "text-muted";
 }
 
+const TIER_LADDER_ORDER = [
+  "IRON",
+  "BRONZE",
+  "SILVER",
+  "GOLD",
+  "PLATINUM",
+  "EMERALD",
+  "DIAMOND",
+  "MASTER",
+  "GRANDMASTER",
+  "CHALLENGER"
+];
+
+const DIVISION_RANK: Record<string, number> = {
+  IV: 0,
+  III: 1,
+  II: 2,
+  I: 3,
+  "4": 0,
+  "3": 1,
+  "2": 2,
+  "1": 3
+};
+
+/**
+ * Collapse a tier + division + LP into a single monotonic "ladder points" value
+ * so rank progression can be plotted on a Sparkline (higher = better). Apex
+ * tiers (Master+) have no divisions, so LP stacks directly on the tier band.
+ * Returns null for an unknown/unranked tier.
+ */
+export function rankToLadderPoints(
+  tier: string | null | undefined,
+  division: string | null | undefined,
+  leaguePoints: number
+): number | null {
+  if (!tier) return null;
+  const tierIndex = TIER_LADDER_ORDER.indexOf(tier.toUpperCase());
+  if (tierIndex < 0) return null;
+
+  const isApex = tierIndex >= TIER_LADDER_ORDER.indexOf("MASTER");
+  const divisionPoints = isApex ? 0 : (DIVISION_RANK[(division ?? "").toUpperCase()] ?? 0) * 100;
+  return tierIndex * 400 + divisionPoints + leaguePoints;
+}
+
 export function rankEmblemUrl(tier: string | null | undefined): string | null {
   if (!tier) return null;
   const normalized = normalizeRankToken(tier);

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -3852,6 +3852,102 @@
         }
       }
     },
+    "/api/lol/summoners/{summonerId}/stats/rank-history": {
+      "get": {
+        "tags": [
+          "SummonerStats"
+        ],
+        "parameters": [
+          {
+            "name": "summonerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "queueType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RankHistoryEntryDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RankHistoryEntryDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RankHistoryEntryDto"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/lol/summoners/{summonerId}/matches/recent": {
       "get": {
         "tags": [
@@ -6924,6 +7020,13 @@
               "$ref": "#/components/schemas/ParticipantDetailDto"
             },
             "nullable": true
+          },
+          "bans": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TeamBansDto"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -7731,47 +7834,36 @@
         },
         "additionalProperties": false
       },
-      "ProfileRecentMatch": {
+      "RankHistoryEntryDto": {
         "type": "object",
         "properties": {
-          "matchId": {
-            "type": "string",
-            "nullable": true
-          },
-          "matchDate": {
-            "type": "integer",
-            "format": "int64"
-          },
           "queueType": {
             "type": "string",
             "nullable": true
           },
-          "win": {
-            "type": "boolean"
-          },
-          "championId": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "championName": {
+          "tier": {
             "type": "string",
             "nullable": true
           },
-          "kills": {
+          "rankNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "leaguePoints": {
             "type": "integer",
             "format": "int32"
           },
-          "deaths": {
+          "wins": {
             "type": "integer",
             "format": "int32"
           },
-          "assists": {
+          "losses": {
             "type": "integer",
             "format": "int32"
           },
-          "csPerMin": {
-            "type": "number",
-            "format": "double"
+          "dateRecorded": {
+            "type": "string",
+            "format": "date-time"
           }
         },
         "additionalProperties": false
@@ -8131,13 +8223,6 @@
             },
             "nullable": true
           },
-          "recentMatches": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ProfileRecentMatch"
-            },
-            "nullable": true
-          },
           "profileAge": {
             "$ref": "#/components/schemas/DataAgeMetadata"
           },
@@ -8233,6 +8318,24 @@
             "type": "array",
             "items": {
               "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TeamBansDto": {
+        "type": "object",
+        "properties": {
+          "teamId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bannedChampionIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
             },
             "nullable": true
           }

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -6476,6 +6476,39 @@
         },
         "additionalProperties": false
       },
+      "ChampionMasteryStat": {
+        "type": "object",
+        "properties": {
+          "championId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "championName": {
+            "type": "string",
+            "nullable": true
+          },
+          "championLevel": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "championPoints": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "lastPlayTime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "chestGranted": {
+            "type": "boolean"
+          },
+          "tokensEarned": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
       "ChampionMatchupsResponse": {
         "type": "object",
         "properties": {
@@ -6807,6 +6840,36 @@
           "createdAtUtc": {
             "type": "string",
             "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FrequentlyPlayedWithStat": {
+        "type": "object",
+        "properties": {
+          "summonerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "gameName": {
+            "type": "string",
+            "nullable": true
+          },
+          "tagLine": {
+            "type": "string",
+            "nullable": true
+          },
+          "gamesTogether": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sameTeamGames": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sameTeamWins": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -8252,6 +8315,20 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ProfileChampionStat"
+            },
+            "nullable": true
+          },
+          "frequentlyPlayedWith": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FrequentlyPlayedWithStat"
+            },
+            "nullable": true
+          },
+          "topMastery": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ChampionMasteryStat"
             },
             "nullable": true
           },

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -4172,6 +4172,114 @@
         }
       }
     },
+    "/api/lol/summoners/{summonerId}/matches/{matchId}/timeline": {
+      "get": {
+        "tags": [
+          "SummonerStats"
+        ],
+        "parameters": [
+          {
+            "name": "summonerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "matchId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchTimelineDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchTimelineDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchTimelineDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/tft/analytics/regions": {
       "get": {
         "tags": [
@@ -7157,6 +7265,27 @@
         },
         "additionalProperties": false
       },
+      "MatchTimelineDto": {
+        "type": "object",
+        "properties": {
+          "matchId": {
+            "type": "string",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "frames": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimelineFrameDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "MatchupEntryDto": {
         "type": "object",
         "properties": {
@@ -8788,6 +8917,32 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "TimelineFrameDto": {
+        "type": "object",
+        "properties": {
+          "minuteMark": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "blueGold": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "redGold": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "blueXp": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "redXp": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
       },
       "TrackedProSummonerDto": {
         "type": "object",

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -7027,6 +7027,13 @@
               "$ref": "#/components/schemas/TeamBansDto"
             },
             "nullable": true
+          },
+          "objectives": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TeamObjectivesDto"
+            },
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -7403,6 +7410,19 @@
         },
         "additionalProperties": false
       },
+      "ObjectiveStatDto": {
+        "type": "object",
+        "properties": {
+          "kills": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "first": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "ParticipantDetailDto": {
         "type": "object",
         "properties": {
@@ -7454,6 +7474,18 @@
             "format": "int32"
           },
           "totalDamageDealtToChampions": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "physicalDamageDealtToChampions": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "magicDamageDealtToChampions": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trueDamageDealtToChampions": {
             "type": "integer",
             "format": "int32"
           },
@@ -8338,6 +8370,37 @@
               "format": "int32"
             },
             "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TeamObjectivesDto": {
+        "type": "object",
+        "properties": {
+          "teamId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "firstBlood": {
+            "type": "boolean"
+          },
+          "baron": {
+            "$ref": "#/components/schemas/ObjectiveStatDto"
+          },
+          "dragon": {
+            "$ref": "#/components/schemas/ObjectiveStatDto"
+          },
+          "riftHerald": {
+            "$ref": "#/components/schemas/ObjectiveStatDto"
+          },
+          "horde": {
+            "$ref": "#/components/schemas/ObjectiveStatDto"
+          },
+          "tower": {
+            "$ref": "#/components/schemas/ObjectiveStatDto"
+          },
+          "inhibitor": {
+            "$ref": "#/components/schemas/ObjectiveStatDto"
           }
         },
         "additionalProperties": false

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -3376,6 +3376,79 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/lol/summoners/{summonerId}/matches/{matchId}/timeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    summonerId: string;
+                    matchId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["MatchTimelineDto"];
+                        "application/json": components["schemas"]["MatchTimelineDto"];
+                        "text/json": components["schemas"]["MatchTimelineDto"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["ProblemDetails"];
+                        "application/json": components["schemas"]["ProblemDetails"];
+                        "text/json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Too Many Requests */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["ProblemDetails"];
+                        "application/json": components["schemas"]["ProblemDetails"];
+                        "text/json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Internal Server Error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["ProblemDetails"];
+                        "application/json": components["schemas"]["ProblemDetails"];
+                        "text/json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tft/analytics/regions": {
         parameters: {
             query?: never;
@@ -4999,6 +5072,12 @@ export interface components {
             /** Format: int32 */
             keystoneId?: number;
         };
+        MatchTimelineDto: {
+            matchId?: string | null;
+            /** Format: int32 */
+            duration?: number;
+            frames?: components["schemas"]["TimelineFrameDto"][] | null;
+        };
         MatchupEntryDto: {
             /** Format: int32 */
             opponentChampionId?: number;
@@ -5576,6 +5655,18 @@ export interface components {
          * @enum {integer}
          */
         TierMovement: 0 | 1 | 2 | 3;
+        TimelineFrameDto: {
+            /** Format: int32 */
+            minuteMark?: number;
+            /** Format: int32 */
+            blueGold?: number;
+            /** Format: int32 */
+            redGold?: number;
+            /** Format: int32 */
+            blueXp?: number;
+            /** Format: int32 */
+            redXp?: number;
+        };
         TrackedProSummonerDto: {
             /** Format: uuid */
             id?: string;

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -3174,6 +3174,69 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/lol/summoners/{summonerId}/stats/rank-history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    queueType?: string;
+                };
+                header?: never;
+                path: {
+                    summonerId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["RankHistoryEntryDto"][];
+                        "application/json": components["schemas"]["RankHistoryEntryDto"][];
+                        "text/json": components["schemas"]["RankHistoryEntryDto"][];
+                    };
+                };
+                /** @description Too Many Requests */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["ProblemDetails"];
+                        "application/json": components["schemas"]["ProblemDetails"];
+                        "text/json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Internal Server Error */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["ProblemDetails"];
+                        "application/json": components["schemas"]["ProblemDetails"];
+                        "text/json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/lol/summoners/{summonerId}/matches/recent": {
         parameters: {
             query?: never;
@@ -4890,6 +4953,7 @@ export interface components {
             queueType?: string | null;
             patch?: string | null;
             participants?: components["schemas"]["ParticipantDetailDto"][] | null;
+            bans?: components["schemas"]["TeamBansDto"][] | null;
         };
         MatchRuneDetailDto: {
             /** Format: int32 */
@@ -5164,23 +5228,18 @@ export interface components {
             /** Format: double */
             avgDamageToChamps?: number;
         };
-        ProfileRecentMatch: {
-            matchId?: string | null;
-            /** Format: int64 */
-            matchDate?: number;
+        RankHistoryEntryDto: {
             queueType?: string | null;
-            win?: boolean;
+            tier?: string | null;
+            rankNumber?: string | null;
             /** Format: int32 */
-            championId?: number;
-            championName?: string | null;
+            leaguePoints?: number;
             /** Format: int32 */
-            kills?: number;
+            wins?: number;
             /** Format: int32 */
-            deaths?: number;
-            /** Format: int32 */
-            assists?: number;
-            /** Format: double */
-            csPerMin?: number;
+            losses?: number;
+            /** Format: date-time */
+            dateRecorded?: string;
         };
         RankInfo: {
             tier?: string | null;
@@ -5324,7 +5383,6 @@ export interface components {
             flexRank?: components["schemas"]["RankInfo"];
             overviewStats?: components["schemas"]["ProfileOverviewStats"];
             topChampions?: components["schemas"]["ProfileChampionStat"][] | null;
-            recentMatches?: components["schemas"]["ProfileRecentMatch"][] | null;
             profileAge?: components["schemas"]["DataAgeMetadata"];
             rankAge?: components["schemas"]["DataAgeMetadata"];
             statsAge?: components["schemas"]["DataAgeMetadata"];
@@ -5355,6 +5413,11 @@ export interface components {
             estimatedWinProbability?: number;
             strengths?: string[] | null;
             weaknesses?: string[] | null;
+        };
+        TeamBansDto: {
+            /** Format: int32 */
+            teamId?: number;
+            bannedChampionIds?: number[] | null;
         };
         TftRankDto: {
             queueType?: string | null;

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4768,6 +4768,20 @@ export interface components {
             builds?: components["schemas"]["ChampionBuildDto"][] | null;
             sample?: components["schemas"]["AnalyticsSampleMetadata"];
         };
+        ChampionMasteryStat: {
+            /** Format: int32 */
+            championId?: number;
+            championName?: string | null;
+            /** Format: int32 */
+            championLevel?: number;
+            /** Format: int64 */
+            championPoints?: number;
+            /** Format: int64 */
+            lastPlayTime?: number;
+            chestGranted?: boolean;
+            /** Format: int32 */
+            tokensEarned?: number;
+        };
         ChampionMatchupsResponse: {
             /** Format: int32 */
             championId?: number;
@@ -4882,6 +4896,18 @@ export interface components {
             displayName?: string | null;
             /** Format: date-time */
             createdAtUtc?: string;
+        };
+        FrequentlyPlayedWithStat: {
+            /** Format: uuid */
+            summonerId?: string;
+            gameName?: string | null;
+            tagLine?: string | null;
+            /** Format: int32 */
+            gamesTogether?: number;
+            /** Format: int32 */
+            sameTeamGames?: number;
+            /** Format: int32 */
+            sameTeamWins?: number;
         };
         LiveGameAnalysisDto: {
             /** Format: date-time */
@@ -5395,6 +5421,8 @@ export interface components {
             flexRank?: components["schemas"]["RankInfo"];
             overviewStats?: components["schemas"]["ProfileOverviewStats"];
             topChampions?: components["schemas"]["ProfileChampionStat"][] | null;
+            frequentlyPlayedWith?: components["schemas"]["FrequentlyPlayedWithStat"][] | null;
+            topMastery?: components["schemas"]["ChampionMasteryStat"][] | null;
             profileAge?: components["schemas"]["DataAgeMetadata"];
             rankAge?: components["schemas"]["DataAgeMetadata"];
             statsAge?: components["schemas"]["DataAgeMetadata"];

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4954,6 +4954,7 @@ export interface components {
             patch?: string | null;
             participants?: components["schemas"]["ParticipantDetailDto"][] | null;
             bans?: components["schemas"]["TeamBansDto"][] | null;
+            objectives?: components["schemas"]["TeamObjectivesDto"][] | null;
         };
         MatchRuneDetailDto: {
             /** Format: int32 */
@@ -5078,6 +5079,11 @@ export interface components {
             missingRoles?: string[] | null;
             potentialAutofills?: components["schemas"]["MultiSearchAutofillRisk"][] | null;
         };
+        ObjectiveStatDto: {
+            /** Format: int32 */
+            kills?: number;
+            first?: boolean;
+        };
         ParticipantDetailDto: {
             puuid?: string | null;
             gameName?: string | null;
@@ -5100,6 +5106,12 @@ export interface components {
             goldEarned?: number;
             /** Format: int32 */
             totalDamageDealtToChampions?: number;
+            /** Format: int32 */
+            physicalDamageDealtToChampions?: number;
+            /** Format: int32 */
+            magicDamageDealtToChampions?: number;
+            /** Format: int32 */
+            trueDamageDealtToChampions?: number;
             /** Format: int32 */
             visionScore?: number;
             /** Format: int32 */
@@ -5418,6 +5430,17 @@ export interface components {
             /** Format: int32 */
             teamId?: number;
             bannedChampionIds?: number[] | null;
+        };
+        TeamObjectivesDto: {
+            /** Format: int32 */
+            teamId?: number;
+            firstBlood?: boolean;
+            baron?: components["schemas"]["ObjectiveStatDto"];
+            dragon?: components["schemas"]["ObjectiveStatDto"];
+            riftHerald?: components["schemas"]["ObjectiveStatDto"];
+            horde?: components["schemas"]["ObjectiveStatDto"];
+            tower?: components["schemas"]["ObjectiveStatDto"];
+            inhibitor?: components["schemas"]["ObjectiveStatDto"];
         };
         TftRankDto: {
             queueType?: string | null;

--- a/tests/Transcendence.Service.Core.Tests/CancellationPropagationTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/CancellationPropagationTests.cs
@@ -51,6 +51,8 @@ public class CancellationPropagationTests
             Mock.Of<ISummonerRepository>(),
             Mock.Of<IMatchRepository>(),
             Mock.Of<IMatchService>(),
+            Mock.Of<IChampionMasteryService>(),
+            Mock.Of<IChampionMasteryRepository>(),
             db,
             refreshLockRepository.Object,
             services.GetRequiredService<ILogger<SummonerRefreshJob>>(),

--- a/tests/Transcendence.Service.Core.Tests/MatchTimelineIngestionJobTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/MatchTimelineIngestionJobTests.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using Transcendence.Service.Core.Services.Jobs;
+
+namespace Transcendence.Service.Core.Tests;
+
+public class MatchTimelineIngestionJobTests
+{
+    [Fact]
+    public void BuildMinuteMarks_CoversCadenceUpToGameLengthPlusAnchor()
+    {
+        // 30-minute game, every-2-min cadence, anchor 15.
+        var marks = MatchTimelineIngestionJob.BuildMinuteMarks(1800, 2, 15);
+
+        marks.Should().BeInAscendingOrder();
+        marks.Should().OnlyHaveUniqueItems();
+        marks.First().Should().Be(2);
+        marks.Last().Should().Be(30);
+        marks.Should().Contain(15); // analytics anchor always present
+    }
+
+    [Fact]
+    public void BuildMinuteMarks_ShortGameStillIncludesAnchorAndStopsAtGameLength()
+    {
+        // 11-minute game -> cadence {2,4,6,8,10} (12 > 11), plus the anchor 15.
+        var marks = MatchTimelineIngestionJob.BuildMinuteMarks(11 * 60, 2, 15);
+
+        marks.Should().Contain(10);
+        marks.Should().Contain(15); // anchor kept even though the game is shorter
+        marks.Should().NotContain(12); // never sample past game length (besides the anchor)
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/SummonerRefreshJobTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerRefreshJobTests.cs
@@ -747,11 +747,19 @@ public class SummonerRefreshJobTests
             });
             var timelineOptions = Options.Create(new TimelineIngestionOptions { Enabled = false });
 
+            var championMasteryService = new Mock<IChampionMasteryService>();
+            championMasteryService
+                .Setup(x => x.GetMasteriesAsync(It.IsAny<string>(), It.IsAny<PlatformRoute>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([]);
+            var championMasteryRepository = new Mock<IChampionMasteryRepository>();
+
             var job = new SummonerRefreshJob(
                 summonerService.Object,
                 summonerRepository.Object,
                 matchRepository.Object,
                 matchService.Object,
+                championMasteryService.Object,
+                championMasteryRepository.Object,
                 db,
                 refreshLockRepository.Object,
                 services.GetRequiredService<ILogger<SummonerRefreshJob>>(),

--- a/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
@@ -295,6 +295,76 @@ public class SummonerStatsServiceTests
     }
 
     [Fact]
+    public async Task GetRankHistoryAsync_FiltersByQueueAndOrdersOldestFirst()
+    {
+        await using var harness = await SummonerStatsHarness.CreateAsync();
+        var summoner = harness.CreateSummoner();
+
+        harness.Db.HistoricalRanks.AddRange(
+            new HistoricalRank
+            {
+                Id = Guid.NewGuid(), Summoner = summoner, QueueType = "RANKED_SOLO_5x5",
+                Tier = "GOLD", RankNumber = "II", LeaguePoints = 40, Wins = 50, Losses = 40,
+                DateRecorded = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc)
+            },
+            new HistoricalRank
+            {
+                Id = Guid.NewGuid(), Summoner = summoner, QueueType = "RANKED_SOLO_5x5",
+                Tier = "SILVER", RankNumber = "I", LeaguePoints = 80, Wins = 30, Losses = 28,
+                DateRecorded = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+            },
+            new HistoricalRank
+            {
+                Id = Guid.NewGuid(), Summoner = summoner, QueueType = "RANKED_FLEX_SR",
+                Tier = "BRONZE", RankNumber = "III", LeaguePoints = 10, Wins = 5, Losses = 9,
+                DateRecorded = new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc)
+            });
+
+        await harness.Db.SaveChangesAsync();
+
+        var solo = await harness.Service.GetRankHistoryAsync(summoner.Id, "RANKED_SOLO_5x5", CancellationToken.None);
+        solo.Should().HaveCount(2);
+        solo.Should().OnlyContain(x => x.QueueType == "RANKED_SOLO_5x5");
+        solo.Select(x => x.Tier).Should().Equal(["SILVER", "GOLD"]); // oldest first
+
+        var all = await harness.Service.GetRankHistoryAsync(summoner.Id, null, CancellationToken.None);
+        all.Should().HaveCount(3);
+        all.Select(x => x.Tier).Should().Equal(["SILVER", "GOLD", "BRONZE"]); // by DateRecorded asc
+    }
+
+    [Fact]
+    public async Task GetMatchDetailAsync_IncludesBansGroupedByTeamOrderedByPickTurn()
+    {
+        await using var harness = await SummonerStatsHarness.CreateAsync();
+        var summoner = harness.CreateSummoner();
+
+        var participant = harness.AddParticipant(
+            summoner,
+            queueId: QueueCatalog.RankedSoloDuoQueueId,
+            queueFamily: QueueCatalog.QueueFamilyRankedSoloDuo,
+            queueType: "RANKED_SOLO_5x5",
+            matchDate: 5000,
+            duration: 1800,
+            kills: 1,
+            deaths: 1,
+            assists: 1);
+
+        harness.Db.Set<MatchBan>().AddRange(
+            new MatchBan { Match = participant.Match, MatchId = participant.MatchId, TeamId = 200, PickTurn = 4, ChampionId = 222 },
+            new MatchBan { Match = participant.Match, MatchId = participant.MatchId, TeamId = 100, PickTurn = 3, ChampionId = 64 },
+            new MatchBan { Match = participant.Match, MatchId = participant.MatchId, TeamId = 100, PickTurn = 1, ChampionId = 17 });
+
+        await harness.Db.SaveChangesAsync();
+
+        var detail = await harness.Service.GetMatchDetailAsync(participant.Match.MatchId!, CancellationToken.None);
+
+        detail.Should().NotBeNull();
+        detail!.Bans.Should().HaveCount(2);
+        detail.Bans.Single(b => b.TeamId == 100).BannedChampionIds.Should().Equal([17, 64]); // ordered by pick turn
+        detail.Bans.Single(b => b.TeamId == 200).BannedChampionIds.Should().Equal([222]);
+    }
+
+    [Fact]
     public async Task GetChampionStatsAsync_WrapsUnexpectedException()
     {
         var harness = await SummonerStatsHarness.CreateAsync();

--- a/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
@@ -418,6 +418,98 @@ public class SummonerStatsServiceTests
     }
 
     [Fact]
+    public async Task GetPlayedWithAsync_AggregatesCoParticipantsByGamesAndSameTeamWins()
+    {
+        await using var harness = await SummonerStatsHarness.CreateAsync();
+
+        static Summoner NewSummoner(string name) => new()
+        {
+            Id = Guid.NewGuid(),
+            PlatformRegion = "NA1",
+            Region = "americas",
+            Puuid = $"puuid-{Guid.NewGuid():N}",
+            GameName = name,
+            TagLine = "NA1",
+            GameNameNormalized = name.ToUpperInvariant(),
+            TagLineNormalized = "NA1",
+            SummonerLevel = 100,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        var me = NewSummoner("Me");
+        var duo = NewSummoner("Duo");
+        var rival = NewSummoner("Rival");
+        harness.Db.Summoners.AddRange(me, duo, rival);
+
+        var matchNum = 0;
+        void AddCoMatch(Summoner other, bool sameTeam, bool myWin)
+        {
+            matchNum++;
+            var match = new Match
+            {
+                Id = Guid.NewGuid(), MatchId = $"NA1_pw{matchNum}", MatchDate = 1000 + matchNum,
+                Duration = 1800, Patch = "14.2", QueueId = QueueCatalog.RankedSoloDuoQueueId,
+                QueueFamily = QueueCatalog.QueueFamilyRankedSoloDuo, QueueType = "RANKED_SOLO_5x5",
+                Status = FetchStatus.Success
+            };
+            harness.Db.MatchParticipants.Add(new MatchParticipant
+            {
+                Id = Guid.NewGuid(), Match = match, MatchId = match.Id, Summoner = me, SummonerId = me.Id,
+                Puuid = me.Puuid, ParticipantId = 1, TeamId = 100, Win = myWin
+            });
+            harness.Db.MatchParticipants.Add(new MatchParticipant
+            {
+                Id = Guid.NewGuid(), Match = match, MatchId = match.Id, Summoner = other, SummonerId = other.Id,
+                Puuid = other.Puuid, ParticipantId = 2, TeamId = sameTeam ? 100 : 200, Win = sameTeam ? myWin : !myWin
+            });
+        }
+
+        AddCoMatch(duo, sameTeam: true, myWin: true);
+        AddCoMatch(duo, sameTeam: true, myWin: true);
+        AddCoMatch(duo, sameTeam: true, myWin: false);
+        AddCoMatch(rival, sameTeam: false, myWin: true);
+        AddCoMatch(rival, sameTeam: false, myWin: false);
+
+        await harness.Db.SaveChangesAsync();
+
+        var result = await harness.Service.GetPlayedWithAsync(me.Id, recentMatches: 100, topCount: 10, CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].SummonerId.Should().Be(duo.Id); // ordered by gamesTogether desc
+
+        var duoEntry = result.Single(x => x.SummonerId == duo.Id);
+        duoEntry.GamesTogether.Should().Be(3);
+        duoEntry.SameTeamGames.Should().Be(3);
+        duoEntry.SameTeamWins.Should().Be(2);
+
+        var rivalEntry = result.Single(x => x.SummonerId == rival.Id);
+        rivalEntry.GamesTogether.Should().Be(2);
+        rivalEntry.SameTeamGames.Should().Be(0);
+        rivalEntry.SameTeamWins.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetTopMasteryAsync_ReturnsHighestByPoints()
+    {
+        await using var harness = await SummonerStatsHarness.CreateAsync();
+        var summoner = harness.CreateSummoner();
+
+        harness.Db.ChampionMasteries.AddRange(
+            new ChampionMastery { SummonerId = summoner.Id, ChampionId = 1, ChampionLevel = 7, ChampionPoints = 500000, LastPlayTime = 100, ChestGranted = true, TokensEarned = 0 },
+            new ChampionMastery { SummonerId = summoner.Id, ChampionId = 2, ChampionLevel = 5, ChampionPoints = 120000, LastPlayTime = 200, ChestGranted = false, TokensEarned = 2 },
+            new ChampionMastery { SummonerId = summoner.Id, ChampionId = 3, ChampionLevel = 6, ChampionPoints = 300000, LastPlayTime = 300, ChestGranted = true, TokensEarned = 1 });
+
+        await harness.Db.SaveChangesAsync();
+
+        var result = await harness.Service.GetTopMasteryAsync(summoner.Id, top: 2, CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result.Select(x => x.ChampionId).Should().Equal([1, 3]); // by points desc: 500k, 300k
+        result[0].ChampionLevel.Should().Be(7);
+        result[0].ChampionPoints.Should().Be(500000);
+    }
+
+    [Fact]
     public async Task GetChampionStatsAsync_WrapsUnexpectedException()
     {
         var harness = await SummonerStatsHarness.CreateAsync();

--- a/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
@@ -365,6 +365,59 @@ public class SummonerStatsServiceTests
     }
 
     [Fact]
+    public async Task GetMatchDetailAsync_IncludesDamageBreakdownAndTeamObjectives()
+    {
+        await using var harness = await SummonerStatsHarness.CreateAsync();
+        var summoner = harness.CreateSummoner();
+
+        var participant = harness.AddParticipant(
+            summoner,
+            queueId: QueueCatalog.RankedSoloDuoQueueId,
+            queueFamily: QueueCatalog.QueueFamilyRankedSoloDuo,
+            queueType: "RANKED_SOLO_5x5",
+            matchDate: 6000,
+            duration: 1800,
+            kills: 1,
+            deaths: 1,
+            assists: 1);
+        participant.PhysicalDamageDealtToChampions = 12000;
+        participant.MagicDamageDealtToChampions = 5000;
+        participant.TrueDamageDealtToChampions = 1000;
+
+        harness.Db.MatchTeamObjectives.AddRange(
+            new MatchTeamObjective
+            {
+                Match = participant.Match, MatchId = participant.MatchId, TeamId = 100,
+                FirstBlood = true, BaronKills = 1, BaronFirst = true, DragonKills = 3, DragonFirst = true,
+                RiftHeraldKills = 1, TowerKills = 9, InhibitorKills = 2
+            },
+            new MatchTeamObjective
+            {
+                Match = participant.Match, MatchId = participant.MatchId, TeamId = 200,
+                FirstBlood = false, DragonKills = 1, TowerKills = 2
+            });
+
+        await harness.Db.SaveChangesAsync();
+
+        var detail = await harness.Service.GetMatchDetailAsync(participant.Match.MatchId!, CancellationToken.None);
+
+        detail.Should().NotBeNull();
+        var p = detail!.Participants.Single();
+        p.PhysicalDamageDealtToChampions.Should().Be(12000);
+        p.MagicDamageDealtToChampions.Should().Be(5000);
+        p.TrueDamageDealtToChampions.Should().Be(1000);
+
+        detail.Objectives.Should().HaveCount(2);
+        var blue = detail.Objectives.Single(o => o.TeamId == 100);
+        blue.FirstBlood.Should().BeTrue();
+        blue.Baron.Kills.Should().Be(1);
+        blue.Baron.First.Should().BeTrue();
+        blue.Dragon.Kills.Should().Be(3);
+        blue.Tower.Kills.Should().Be(9);
+        detail.Objectives.Single(o => o.TeamId == 200).Dragon.Kills.Should().Be(1);
+    }
+
+    [Fact]
     public async Task GetChampionStatsAsync_WrapsUnexpectedException()
     {
         var harness = await SummonerStatsHarness.CreateAsync();

--- a/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
@@ -418,6 +418,58 @@ public class SummonerStatsServiceTests
     }
 
     [Fact]
+    public async Task GetMatchTimelineAsync_BuildsOrderedPerMinuteTeamGoldXpSeries()
+    {
+        await using var harness = await SummonerStatsHarness.CreateAsync();
+        var summoner = harness.CreateSummoner();
+        var enemy = new Summoner
+        {
+            Id = Guid.NewGuid(), PlatformRegion = "NA1", Region = "americas",
+            Puuid = $"puuid-{Guid.NewGuid():N}", GameName = "Enemy", TagLine = "NA1",
+            GameNameNormalized = "ENEMY", TagLineNormalized = "NA1", SummonerLevel = 100, UpdatedAt = DateTime.UtcNow
+        };
+        harness.Db.Summoners.Add(enemy);
+
+        var match = new Match
+        {
+            Id = Guid.NewGuid(), MatchId = "NA1_tl1", MatchDate = 7000, Duration = 1800, Patch = "14.10",
+            QueueId = QueueCatalog.RankedSoloDuoQueueId, QueueFamily = QueueCatalog.QueueFamilyRankedSoloDuo,
+            QueueType = "RANKED_SOLO_5x5", Status = FetchStatus.Success
+        };
+        harness.Db.MatchParticipants.AddRange(
+            new MatchParticipant { Id = Guid.NewGuid(), Match = match, MatchId = match.Id, Summoner = summoner, SummonerId = summoner.Id, ParticipantId = 1, TeamId = 100, ChampionId = 222, Win = true },
+            new MatchParticipant { Id = Guid.NewGuid(), Match = match, MatchId = match.Id, Summoner = enemy, SummonerId = enemy.Id, ParticipantId = 6, TeamId = 200, ChampionId = 122, Win = false });
+
+        // Two frames (@10, @15) seeded out of order to prove ordering.
+        harness.Db.MatchParticipantTimelineSnapshots.AddRange(
+            new MatchParticipantTimelineSnapshot { Match = match, MatchId = match.Id, ParticipantId = 1, MinuteMark = 15, Gold = 8200, Xp = 9000, Cs = 130, Level = 12, FrameTimestampMs = 900000, DerivedAtUtc = DateTime.UtcNow },
+            new MatchParticipantTimelineSnapshot { Match = match, MatchId = match.Id, ParticipantId = 6, MinuteMark = 15, Gold = 7000, Xp = 8400, Cs = 115, Level = 11, FrameTimestampMs = 900000, DerivedAtUtc = DateTime.UtcNow },
+            new MatchParticipantTimelineSnapshot { Match = match, MatchId = match.Id, ParticipantId = 1, MinuteMark = 10, Gold = 5000, Xp = 6000, Cs = 80, Level = 9, FrameTimestampMs = 600000, DerivedAtUtc = DateTime.UtcNow },
+            new MatchParticipantTimelineSnapshot { Match = match, MatchId = match.Id, ParticipantId = 6, MinuteMark = 10, Gold = 4200, Xp = 5500, Cs = 70, Level = 8, FrameTimestampMs = 600000, DerivedAtUtc = DateTime.UtcNow });
+
+        await harness.Db.SaveChangesAsync();
+
+        var result = await harness.Service.GetMatchTimelineAsync("NA1_tl1", CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Duration.Should().Be(1800);
+        result.Frames.Select(f => f.MinuteMark).Should().Equal([10, 15]); // ordered ascending
+        result.Frames[0].BlueGold.Should().Be(5000);
+        result.Frames[0].RedGold.Should().Be(4200);
+        result.Frames[0].BlueXp.Should().Be(6000);
+        result.Frames[1].BlueGold.Should().Be(8200);
+        result.Frames[1].RedGold.Should().Be(7000);
+    }
+
+    [Fact]
+    public async Task GetMatchTimelineAsync_ReturnsNullForUnknownMatch()
+    {
+        await using var harness = await SummonerStatsHarness.CreateAsync();
+        var result = await harness.Service.GetMatchTimelineAsync("NA1_missing", CancellationToken.None);
+        result.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetPlayedWithAsync_AggregatesCoParticipantsByGamesAndSameTeamWins()
     {
         await using var harness = await SummonerStatsHarness.CreateAsync();


### PR DESCRIPTION
## Profile page: end-to-end audit → redesign + 4 backend feature phases + timeline curve

Started from a full audit of the LoL player profile (design / UX / UI / backend) and the operator complaint that the expanded match view felt "clunky and too big" with a broken rune view. Delivered as reviewable, per-phase commits.

### What changed (by commit)

- **`22d77ef` Phase 1 — frontend redesign.** Flat `Toolbar` hero (no glass/splash, rank shown once), the expanded match is now a compact tabbed **scoreboard** (Overview / Runes) replacing the 10 tall cards, **real rune pages** via the existing `RuneTreeDisplay` (a Runes tab + a zero-layout-shift keystone hover tooltip), eased animation, de-cluttered copy, and a class of mobile horizontal-overflow fixes. The root rune fix: `/api/static/runes` was dropping the `trees` field the good renderer needed.
- **`235b8b7` Phase 2 — serve stored-but-hidden data** *(no migration)*. Champion **bans** on match detail + a **rank-history** endpoint feeding a sidebar LP sparkline; dropped a dead embedded DTO.
- **`e0322b0` Phase 3 — richer match data** *(EF migration)*. Per-participant **damage breakdown** (physical/magic/true) + per-team **objectives** (`MatchTeamObjective`). Ingestion in `MatchService`, served on `MatchDetailDto`, rendered as a scoreboard stacked-bar + an Overview objectives strip.
- **`dcb525f` Phase 4 — champion mastery + recently-played-with**. Mastery via a worker-only `ChampionMasteryService` (mastery-v4) wired **fail-soft** into the refresh job (`AddChampionMasteryTracking` migration); recently-played-with via a bounded co-participant query (no migration). Both fold into the profile blob (no new endpoints) + two new sidebar cards.
- **`d550343` UI polish** — research-backed (op.gg/u.gg/deeplol + UX): mastery points → full integers, mastery badge → neutral (gold stays actions-only), damage bar → lobby-max normalization, played-with win-rate gated at ≥2 games. Verified by rendering every new card against a locally-seeded backend.
- **`d6e66cf` Phase 3.5 — multi-frame timeline + gold-diff curve** *(no migration)*. Multi-frame timeline ingestion (cadence ∪ the analytics anchor @15, so champion-analytics + backfill stay intact), a `/matches/{id}/timeline` endpoint, and a centered **gold-lead** area chart in the scoreboard Overview.

### Design language
All new surfaces honor the "Ladder" system: data is the hero, color **encodes** data (win/loss diverging, tier/rank categoricals, AD-red/AP-blue/true-white damage, team-blue/red), **gold reserved for actions only**, flat 1px-border surfaces, tabular numerics. New data cards self-hide when their data is absent (new-data-only features degrade gracefully).

### Validation
- `dotnet build` clean; **146 backend tests** pass (xUnit + SQLite integration tests for every new query, incl. shadow-FK rank query, bans/objectives/damage mapping, played-with aggregation, mastery, timeline series, and a `BuildMinuteMarks` unit test).
- **94 frontend tests** (Vitest), `tsc`, ESLint (`max-warnings=0`), and `next build` all green.
- `api:check` green at every phase (OpenAPI spec + generated client regenerated, never hand-edited).
- Each phase passed an adversarial multi-agent review (0 confirmed findings).
- Every new card + the gold-diff chart visually verified against a locally-seeded DB.

### ⚠️ Database migrations — already applied to prod
Prod has **no auto-migrate**. The two EF migrations in this branch — `AddMatchDamageBreakdownAndTeamObjectives` (Phase 3) and `AddChampionMasteryTracking` (Phase 4) — **have already been applied to the production database** via an idempotent EF script (verified: tables, columns, and `__EFMigrationsHistory`). They are additive/backward-compatible, so the running `main` ignores them; **no migration step is needed at deploy time** for this branch. Phase 2 / 3.5 add no migrations.

### Follow-ups (not blocking)
- New columns/objectives/mastery and the multi-frame timeline are **new-data-only** — they populate on fresh ingestion/refresh once this deploys. A backfill of the existing corpus is a separate operator decision (Riot rate budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
