### PR TITLE
Docs: use standalone pnpm for local dev (P2.9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,29 +6,29 @@ Instructions for coding agents working in this repository.
 
 ```bash
 # Frontend (Next.js)
-corepack pnpm web:dev          # dev server
-corepack pnpm web:build        # production build
-corepack pnpm web:test         # Vitest
-corepack pnpm web:lint         # ESLint
+pnpm web:dev          # dev server
+pnpm web:build        # production build
+pnpm web:test         # Vitest
+pnpm web:lint         # ESLint
 
 # Backend (.NET)
-corepack pnpm backend:test     # run all .NET test projects
+pnpm backend:test     # run all .NET test projects
 dotnet test tests/Transcendence.Service.Core.Tests   # single project
 dotnet test tests/Transcendence.WebAPI.Tests          # single project
 
 # API client generation
-corepack pnpm api:gen          # generate TS client from OpenAPI spec
-corepack pnpm api:check        # verify spec is in sync
+pnpm api:gen          # generate TS client from OpenAPI spec
+pnpm api:check        # verify spec is in sync
 
 # Docker
 docker compose up --build      # full stack (API + worker + web + Postgres + Redis)
 
 # E2E
-corepack pnpm e2e:stack        # start stack for E2E tests
-corepack pnpm e2e:local        # run Playwright E2E tests locally
+pnpm e2e:stack        # start stack for E2E tests
+pnpm e2e:local        # run Playwright E2E tests locally
 
 # Git hooks
-corepack pnpm hooks:install    # configure git core.hooksPath to .githooks
+pnpm hooks:install    # configure git core.hooksPath to .githooks
 
 # EF Migrations (run from repo root)
 dotnet ef migrations add <Name> --project Transcendence.Service --startup-project Transcendence.Service

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ flowchart LR
 
 > **Prerequisites:** [.NET SDK 10.0.102](global.json) · [Node 22](.nvmrc) · [pnpm 10.22.0](package.json) · Docker (for PostgreSQL &amp; Redis).
 >
-> Run `corepack enable` once and `pnpm` will automatically use the version pinned in `package.json`. Prefer not to enable Corepack? `corepack pnpm <script>` works the same way.
+> Install [pnpm](https://pnpm.io/installation) (the repo pins `pnpm@10.22.0` via the `packageManager` field), then run any script with `pnpm <script>`. Already a Corepack user? `corepack enable` picks up the pinned version automatically — both work.
 
 ```bash
 # 1. Clone

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -28,13 +28,13 @@ Compose reads local backend credentials from the repo-root [`.env.example`](../.
 2. Install JS dependencies:
 
 ```bash
-corepack pnpm install
+pnpm install
 ```
 
 3. Install repo Git hooks (recommended once per clone):
 
 ```bash
-corepack pnpm hooks:install
+pnpm hooks:install
 ```
 
 4. Configure the web app:
@@ -59,7 +59,7 @@ Optional:
 5. Run the web app:
 
 ```bash
-corepack pnpm web:dev
+pnpm web:dev
 ```
 
 Web: `http://localhost:3000`
@@ -74,7 +74,7 @@ Use full Compose when you want the simplest end-to-end path and you need the wor
 
 ```bash
 cp .env.example .env
-corepack pnpm e2e:stack
+pnpm e2e:stack
 ```
 
 That script:
@@ -89,12 +89,12 @@ For a faster frontend loop, keep backend services in Compose and run Next locall
 ```bash
 docker compose up --build -d postgres redis webapi service
 cp apps/web/.env.example apps/web/.env.local
-corepack pnpm web:dev
-corepack pnpm e2e:local
+pnpm web:dev
+pnpm e2e:local
 ```
 
 Rule of thumb:
-- Use `corepack pnpm e2e:stack` for true local E2E and TFT/worker verification.
+- Use `pnpm e2e:stack` for true local E2E and TFT/worker verification.
 - Use the hybrid mode for day-to-day UI changes when you want faster frontend rebuilds.
 
 ## Run Without Docker (Backend)
@@ -231,13 +231,13 @@ Compose env contract:
 From repo root:
 
 ```bash
-corepack pnpm backend:test
-corepack pnpm hooks:install
-corepack pnpm precommit:check
-corepack pnpm web:dev
-corepack pnpm web:test
-corepack pnpm web:lint
-corepack pnpm web:build
+pnpm backend:test
+pnpm hooks:install
+pnpm precommit:check
+pnpm web:dev
+pnpm web:test
+pnpm web:lint
+pnpm web:build
 ```
 
 ## Backend Tests
@@ -261,11 +261,11 @@ Note:
 Source of truth: `openapi/transcendence.v1.json` (committed). The generated client schema is rebuilt locally from that spec and is not committed.
 
 ```bash
-corepack pnpm api:gen
-corepack pnpm api:check
+pnpm api:gen
+pnpm api:check
 ```
 
-If hooks are installed (`corepack pnpm hooks:install`), pre-commit runs path-aware checks automatically before each commit:
+If hooks are installed (`pnpm hooks:install`), pre-commit runs path-aware checks automatically before each commit:
 - `pnpm precommit:api-sync` runs only when staged files touch API-relevant paths (`Transcendence.WebAPI/`, `Transcendence.Service.Core/`, `Transcendence.Data/`, `scripts/openapi/export.sh`, committed OpenAPI spec), regenerates the client locally, and stages the refreshed spec.
 - `pnpm precommit:check` runs `git diff --cached --check` to catch staged whitespace issues.
 


### PR DESCRIPTION
## What

Switches local-dev docs from `corepack pnpm <script>` to standalone `pnpm <script>`, and reframes the README prerequisite to default to standalone pnpm (pinned via the `packageManager` field) with Corepack as an optional alternative.

## Why

The maintainer's environment uses standalone pnpm; `corepack` is not installed, so a contributor following the docs verbatim hits a wall on the first command. CI is unchanged (still uses `corepack enable`).

## Scope / risk

Docs only — no code, no image rebuild, no deploy. First change through the new branch-protection + auto-merge gate (canary).

Roadmap **P2.9**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)