### PR TITLE
CI: migration-safety gate — hot-table DDL lint + drift check (P1.6)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -6,8 +6,15 @@
       "version": "10.1.1",
       "commands": [
         "swagger"
-      ]
+      ],
+      "rollForward": false
+    },
+    "dotnet-ef": {
+      "version": "10.0.2",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
     }
   }
 }
-

--- a/.github/workflows/ci-web-backend.yml
+++ b/.github/workflows/ci-web-backend.yml
@@ -60,3 +60,33 @@ jobs:
 
       - name: Build
         run: pnpm --filter web build
+
+  migration-safety:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      # Fails the PR if a newly-added migration write-locks/rewrites a hot table
+      # (Summoners/Matches/MatchParticipants). See docs/DEVELOPMENT.md.
+      - name: Hot-table DDL lint (newly-added migrations)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha || 'origin/main' }}
+        run: bash scripts/ci/check-migrations.sh
+
+      # Fails if the EF model and the latest migration snapshot have drifted
+      # (an entity changed without a migration → deployed code expects columns
+      # that prod, which never auto-migrates, does not have).
+      - name: Model/snapshot drift check
+        run: |
+          dotnet tool restore
+          dotnet ef migrations has-pending-model-changes \
+            --project Transcendence.Service --startup-project Transcendence.Service

--- a/scripts/ci/check-migrations.sh
+++ b/scripts/ci/check-migrations.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# check-migrations.sh — hot-table DDL safety lint for EF migrations.
+#
+# Fails when a migration ADDED by this branch (vs the base ref) performs DDL that
+# write-locks or rewrites one of the large, continuously-written tables. Such DDL
+# must be applied out-of-band — see docs/DEVELOPMENT.md, "Applying index migrations
+# to hot tables". Only newly-added migrations are inspected, so the many existing
+# plain-CreateIndex migrations already in history are never flagged.
+#
+# Env:
+#   BASE_REF   git ref to diff against (default: origin/main)
+#
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/main}"
+MIG_DIR='Transcendence.Service/Migrations'
+HOT_TABLES='Summoners|Matches|MatchParticipants'
+
+if ! git rev-parse --verify -q "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+  echo "check-migrations: base ref '${BASE_REF}' not found; skipping hot-table lint."
+  exit 0
+fi
+MERGE_BASE="$(git merge-base "${BASE_REF}" HEAD 2>/dev/null || echo "${BASE_REF}")"
+
+# Newly ADDED migration files only (exclude Designer + ModelSnapshot).
+NEW_MIGRATIONS=()
+while IFS= read -r line; do
+  [ -n "$line" ] && NEW_MIGRATIONS+=("$line")
+done < <(git diff --name-only --diff-filter=A "${MERGE_BASE}...HEAD" -- "${MIG_DIR}" \
+           | grep -E '\.cs$' | grep -vE '\.Designer\.cs$|ModelSnapshot\.cs$' || true)
+
+if [ "${#NEW_MIGRATIONS[@]}" -eq 0 ]; then
+  echo "check-migrations: no new migrations in this change. OK."
+  exit 0
+fi
+
+violations=0
+for f in "${NEW_MIGRATIONS[@]}"; do
+  [ -f "$f" ] || continue
+
+  # (1) CreateIndex on a hot table — CREATE INDEX always takes a SHARE lock that
+  #     blocks writes for the full build. Split RS on ");" so each migrationBuilder
+  #     call is one record and the table is matched to the CreateIndex it belongs to.
+  if awk 'BEGIN{RS=");"} /CreateIndex\(/ && /table: *"('"$HOT_TABLES"')"/ {hit=1} END{exit !hit}' "$f"; then
+    echo "::error file=$f::Adds an index on a hot table (Summoners/Matches/MatchParticipants) via plain CreateIndex, which write-locks the table. Apply it out-of-band with CREATE INDEX CONCURRENTLY and record it manually — see docs/DEVELOPMENT.md 'Applying index migrations to hot tables'."
+    violations=$((violations + 1))
+  fi
+
+  # (2) AddColumn with a SQL default on a hot table — a volatile defaultValueSql
+  #     rewrites the entire table under lock. (Plain constant defaultValue is a
+  #     fast metadata-only default on PostgreSQL 11+, so it is not flagged.)
+  if awk 'BEGIN{RS=");"} /AddColumn[<(]/ && /table: *"('"$HOT_TABLES"')"/ && /defaultValueSql:/ {hit=1} END{exit !hit}' "$f"; then
+    echo "::error file=$f::Adds a column with a SQL default (defaultValueSql) on a hot table; a volatile default rewrites the whole table under lock. Review and apply out-of-band if needed — see docs/DEVELOPMENT.md."
+    violations=$((violations + 1))
+  fi
+done
+
+if [ "$violations" -gt 0 ]; then
+  echo ""
+  echo "check-migrations: ${violations} hot-table DDL violation(s) in newly-added migration(s)."
+  exit 1
+fi
+
+echo "check-migrations: ${#NEW_MIGRATIONS[@]} new migration(s) inspected, no hot-table lock/rewrite DDL. OK."


### PR DESCRIPTION
## What
New `migration-safety` CI job:
- **Hot-table DDL lint** (`scripts/ci/check-migrations.sh`): diff-based — only inspects migrations *added* vs the PR base — and fails on a plain `CreateIndex` (write-locking `SHARE` lock) or a `defaultValueSql` `AddColumn` (volatile-default table rewrite) targeting `Summoners`/`Matches`/`MatchParticipants`, pointing to the `docs/DEVELOPMENT.md` split-apply recipe.
- **Model/snapshot drift check**: `dotnet ef migrations has-pending-model-changes`, catching an entity changed without a migration (ships code expecting columns prod doesn't have, since prod never auto-migrates). Adds `dotnet-ef` 10.0.2 to the tool manifest.

## Why
Encodes the "don't straight-apply locking DDL on hot tables" rule as an enforced gate rather than a code comment, and prevents silent model drift on a no-auto-migrate deploy.

## Verification
Locally: lint OK on a no-migration diff; lint **fails** (with annotation) when diffed against the parent of the `AddSummonerRegionUpdatedAtIndex` commit; drift check reports **no drift** on `main`. Existing migrations are never re-flagged (diff-based).

## Scope / risk
CI + script + tool manifest only — no app code, no image rebuild, no deploy. After merge, `migration-safety` will be added to the required status checks.

Roadmap **P1.6** (pairs with P1.7 recipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)