### PR TITLE
CI: restore solution before EF drift check (fix migration-safety)

### DIFF
--- a/.github/workflows/ci-web-backend.yml
+++ b/.github/workflows/ci-web-backend.yml
@@ -88,5 +88,6 @@ jobs:
       - name: Model/snapshot drift check
         run: |
           dotnet tool restore
+          dotnet restore Transcendence.sln
           dotnet ef migrations has-pending-model-changes \
             --project Transcendence.Service --startup-project Transcendence.Service


### PR DESCRIPTION
## What
Adds `dotnet restore Transcendence.sln` before `dotnet ef migrations has-pending-model-changes` in the `migration-safety` job.

## Why
The job failed on its own PR (#44): clean runners have no `obj/`, and the EF tool reads project metadata without restoring → `NETSDK1004: Assets file project.assets.json not found`. It passed locally only because of pre-existing restore output.

## Verification
Reproduced locally (`rm -rf */obj` → same `NETSDK1004`), then confirmed `dotnet restore Transcendence.sln` + the drift check reports **no drift**. The hot-table DDL lint step was already passing.

## Scope / risk
CI only — no app code, no deploy. After this merges green, `migration-safety` will be promoted to a **required** status check.

Follow-up to **P1.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)