### PR TITLE
CI: build solution for EF drift check (fix migration-safety, take 2)

### DIFF
--- a/.github/workflows/ci-web-backend.yml
+++ b/.github/workflows/ci-web-backend.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Model/snapshot drift check
         run: |
           dotnet tool restore
-          dotnet restore Transcendence.sln
+          # Build the whole solution (a clean standalone build of Transcendence.Service
+          # trips MSB3552 on the resx glob; the solution build is the known-good path the
+          # backend job uses), then run EF against that output with --no-build.
+          dotnet build Transcendence.sln -c Debug
           dotnet ef migrations has-pending-model-changes \
-            --project Transcendence.Service --startup-project Transcendence.Service
+            --project Transcendence.Service --startup-project Transcendence.Service --no-build


### PR DESCRIPTION
## What
Drift step now runs `dotnet build Transcendence.sln -c Debug` then `dotnet ef migrations has-pending-model-changes ... --no-build`.

## Why
After the restore fix (#45), the step still failed: `dotnet ef`'s default **standalone** build of `Transcendence.Service` trips `MSB3552: Resource file "**/*.resx" cannot be found`. The `backend` job builds the **solution** fine, so build the `.sln` and run EF with `--no-build`.

## Verification
Locally: clean `dotnet build Transcendence.Service.csproj` reproduces `MSB3552`; clean `dotnet build Transcendence.sln` + `dotnet ef --no-build` reports **no drift**.

## Scope / risk
CI only. The standalone-build bug itself is tracked as a follow-up (P1.6b). Once this is green, `migration-safety` will be promoted to a required check.

Follow-up to **P1.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)