### PR TITLE
WebAPI: real readiness health checks + container healthcheck (P1.1)

### DIFF
--- a/Transcendence.WebAPI/Dockerfile
+++ b/Transcendence.WebAPI/Dockerfile
@@ -20,6 +20,16 @@ ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "Transcendence.WebAPI.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
+# curl is needed for the container HEALTHCHECK (aspnet image ships without it).
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+USER $APP_UID
 WORKDIR /app
 COPY --from=publish /app/publish .
+# Readiness healthcheck travels with the image, so it applies in prod (wud-managed)
+# without editing the deployment compose. /health/ready verifies Postgres + Redis.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD curl -fsS http://localhost:8080/health/ready || exit 1
 ENTRYPOINT ["dotnet", "Transcendence.WebAPI.dll"]

--- a/Transcendence.WebAPI/Health/ReadinessHealthChecks.cs
+++ b/Transcendence.WebAPI/Health/ReadinessHealthChecks.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using StackExchange.Redis;
+using Transcendence.Data;
+
+namespace Transcendence.WebAPI.Health;
+
+/// <summary>
+/// Readiness probe for PostgreSQL — confirms the API can open a database connection.
+/// Tagged "ready" so it backs /health/ready but not the shallow /health/live.
+/// </summary>
+internal sealed class DatabaseReadinessHealthCheck(TranscendenceContext db) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await db.Database.CanConnectAsync(cancellationToken)
+                ? HealthCheckResult.Healthy()
+                : HealthCheckResult.Unhealthy("PostgreSQL CanConnect returned false");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("PostgreSQL unreachable", ex);
+        }
+    }
+}
+
+/// <summary>
+/// Readiness probe for Redis — pings the shared connection multiplexer.
+/// </summary>
+internal sealed class RedisReadinessHealthCheck(IConnectionMultiplexer redis) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await redis.GetDatabase().PingAsync();
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("Redis unreachable", ex);
+        }
+    }
+}

--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using StackExchange.Redis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration.Json;
@@ -13,6 +14,7 @@ using System.Threading.RateLimiting;
 using System.Text;
 using Transcendence.Data;
 using Transcendence.Data.Extensions;
+using Transcendence.WebAPI.Health;
 using Transcendence.Service.Core.Services.Auth.Implementations;
 using Transcendence.Service.Core.Services.Auth.Interfaces;
 using Transcendence.Service.Core.Services.Auth.Models;
@@ -143,7 +145,15 @@ builder.Services.AddSwaggerGen(options =>
 builder.Services.AddDbContext<TranscendenceContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("MainDatabase"),
         b => b.MigrationsAssembly("Transcendence.Service")));
-builder.Services.AddHealthChecks();
+// Readiness checks (tagged "ready") back /health/ready; /health/live stays shallow
+// (process-up only). Redis check is registered only when Redis is configured so the
+// keyless OpenAPI export / api:check boot (no Redis) does not fail.
+var healthChecks = builder.Services.AddHealthChecks()
+    .AddCheck<DatabaseReadinessHealthCheck>("postgres", tags: new[] { "ready" });
+if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("Redis")))
+{
+    healthChecks.AddCheck<RedisReadinessHealthCheck>("redis", tags: new[] { "ready" });
+}
 
 builder.Services.AddHttpClient();
 
@@ -154,21 +164,25 @@ builder.Services.AddStackExchangeRedisCache(options =>
     options.InstanceName = "Transcendence_";
 });
 
-// Persist DataProtection keys to Redis so antiforgery/auth cookies survive container
-// redeploys. The default ephemeral container key-ring is regenerated on every deploy
-// (logging users out and emitting a startup warning). No-op when Redis isn't configured.
+// Shared Redis multiplexer — registered as a singleton and reused for both DataProtection
+// key persistence and the readiness health check, so the host holds one connection rather
+// than several. AbortOnConnectFail=false so the host still starts when Redis is briefly
+// unreachable (CI/OpenAPI-export has no Redis; prod startup shouldn't hard-fail on a Redis
+// blip). No-op when Redis isn't configured.
 var dataProtectionRedis = builder.Configuration.GetConnectionString("Redis");
 if (!string.IsNullOrWhiteSpace(dataProtectionRedis))
 {
-    // AbortOnConnectFail=false so the host still starts when Redis is briefly unreachable
-    // (CI/OpenAPI-export has no Redis; prod startup shouldn't hard-fail on a Redis blip).
-    var dataProtectionRedisOptions = ConfigurationOptions.Parse(dataProtectionRedis);
-    dataProtectionRedisOptions.AbortOnConnectFail = false;
+    var redisOptions = ConfigurationOptions.Parse(dataProtectionRedis);
+    redisOptions.AbortOnConnectFail = false;
+    var redisMultiplexer = ConnectionMultiplexer.Connect(redisOptions);
+    builder.Services.AddSingleton<IConnectionMultiplexer>(redisMultiplexer);
+
+    // Persist DataProtection keys to Redis so antiforgery/auth cookies survive container
+    // redeploys (the default ephemeral key-ring is regenerated on every deploy, logging
+    // users out and emitting a startup warning).
     builder.Services.AddDataProtection()
         .SetApplicationName("Transcendence")
-        .PersistKeysToStackExchangeRedis(
-            ConnectionMultiplexer.Connect(dataProtectionRedisOptions),
-            "Transcendence:DataProtection:Keys");
+        .PersistKeysToStackExchangeRedis(redisMultiplexer, "Transcendence:DataProtection:Keys");
 }
 
 // Configure HybridCache with L1/L2 TTL relationship
@@ -281,8 +295,10 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
-app.MapHealthChecks("/health/live");
-app.MapHealthChecks("/health/ready");
+// Liveness: process is up and can serve HTTP — no dependency checks run.
+app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = _ => false });
+// Readiness: dependencies (PostgreSQL, Redis) reachable — gates traffic / deploy readiness.
+app.MapHealthChecks("/health/ready", new HealthCheckOptions { Predicate = check => check.Tags.Contains("ready") });
 
 using (var scope = app.Services.CreateScope())
 {

--- a/compose.yml
+++ b/compose.yml
@@ -59,7 +59,7 @@ services:
       - "${WEB_PORT:-3000}:3000"
     depends_on:
       webapi:
-        condition: service_started
+        condition: service_healthy
     networks:
       - transcendence-net
 


### PR DESCRIPTION
## What
Makes `/health/ready` actually verify dependencies instead of always returning 200.

- `/health/live` → shallow (process up).
- `/health/ready` → DB (`CanConnectAsync`) + Redis (multiplexer `PingAsync`) via a `ready` tag predicate.
- Consolidates the inline DataProtection Redis multiplexer into one shared `IConnectionMultiplexer` singleton (reused by the Redis check).
- webapi Dockerfile: installs `curl` + `HEALTHCHECK` on `/health/ready` so the probe ships **with the image** and reaches prod via wud without touching the Portainer stack.
- compose: `web` now `depends_on webapi: service_healthy`.

## Why
Readiness was a lie; this gives external monitors, the rollback runbook, and future alerting a real signal, and lets compose gate startup on dependency readiness.

## Verification
- `dotnet build Transcendence.sln` clean; **159 backend tests pass**.
- `pnpm api:check` boots the WebAPI with these changes (real startup path, Redis-unconfigured guard exercised) and the **OpenAPI contract is unchanged**.
- No new package deps (ASP.NET Core shared framework). The PR's docker-images build verifies the Dockerfile (curl install) builds.

## Deploy note
First **deploying** change of Phase 1 — rebuilds the webapi image (auto-deploys via wud on merge). I'll confirm `/health/ready` on prod post-deploy.

Roadmap **P1.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)