### PR TITLE
Service: worker liveness heartbeat + watchdog (P1.2)

### DIFF
--- a/Transcendence.Service.Core/Services/Diagnostics/WorkerHeartbeat.cs
+++ b/Transcendence.Service.Core/Services/Diagnostics/WorkerHeartbeat.cs
@@ -1,0 +1,81 @@
+using System.Globalization;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Transcendence.Service.Core.Services.Diagnostics;
+
+/// <summary>
+/// Records a liveness "beat" from the ingestion producers so a watchdog can tell whether the
+/// worker is still executing Hangfire jobs (vs. the documented hang where every worker parks on
+/// a non-stoppable job and the process sits idle). Distinct from the dispatcher pacing cron —
+/// this is the process-liveness marker.
+/// </summary>
+public interface IWorkerHeartbeat
+{
+    /// <summary>UTC time of the last recorded producer beat, or null if none yet.</summary>
+    DateTime? LastBeatUtc { get; }
+
+    /// <summary>
+    /// Record a producer beat: updates the in-memory marker (read by the watchdog), the heartbeat
+    /// file (read by the container HEALTHCHECK), and a Redis key (external observability / alerting).
+    /// File and Redis writes are best-effort and never throw into the caller.
+    /// </summary>
+    Task BeatAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class WorkerHeartbeat(
+    IDistributedCache cache,
+    IOptions<WorkerWatchdogOptions> options,
+    ILogger<WorkerHeartbeat> logger) : IWorkerHeartbeat
+{
+    /// <summary>Redis key other processes (WebAPI admin, alerting) can read for worker liveness.</summary>
+    public const string RedisKey = "worker:heartbeat:lastBeatUtc";
+
+    private long _lastBeatTicks; // 0 = never beat
+
+    public DateTime? LastBeatUtc
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _lastBeatTicks);
+            return ticks == 0 ? null : new DateTime(ticks, DateTimeKind.Utc);
+        }
+    }
+
+    public async Task BeatAsync(CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        Interlocked.Exchange(ref _lastBeatTicks, now.Ticks);
+
+        var stamp = now.ToString("O", CultureInfo.InvariantCulture);
+
+        // File marker for the container HEALTHCHECK.
+        var path = options.Value.HeartbeatFilePath;
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            try
+            {
+                await File.WriteAllTextAsync(path, stamp, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Worker heartbeat: failed to write heartbeat file {Path}", path);
+            }
+        }
+
+        // Redis marker for external observability / alerting.
+        try
+        {
+            await cache.SetStringAsync(
+                RedisKey,
+                stamp,
+                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1) },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Worker heartbeat: failed to write Redis heartbeat key");
+        }
+    }
+}

--- a/Transcendence.Service.Core/Services/Diagnostics/WorkerWatchdog.cs
+++ b/Transcendence.Service.Core/Services/Diagnostics/WorkerWatchdog.cs
@@ -1,0 +1,107 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Transcendence.Service.Core.Services.Diagnostics;
+
+public sealed class WorkerWatchdogOptions
+{
+    /// <summary>
+    /// When true, the watchdog exits the process (so the container restart policy recreates it)
+    /// once the producer heartbeat goes stale past <see cref="StalenessThreshold"/>. A Docker
+    /// HEALTHCHECK only marks a container unhealthy — it does not restart it — so an in-process
+    /// exit is what actually makes restart:unless-stopped fire on a hang.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// How stale the last producer beat may get before the worker is considered hung. Must
+    /// comfortably exceed the producer cadence (ChampionAnalyticsIngestion fires every 2 min).
+    /// </summary>
+    public TimeSpan StalenessThreshold { get; set; } = TimeSpan.FromMinutes(10);
+
+    /// <summary>How often the watchdog re-checks heartbeat freshness.</summary>
+    public TimeSpan CheckInterval { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>Path to the heartbeat file the container HEALTHCHECK reads.</summary>
+    public string HeartbeatFilePath { get; set; } = "/tmp/worker-heartbeat";
+}
+
+/// <summary>
+/// Watches the producer heartbeat on a dedicated thread — not a thread-pool timer — so it keeps
+/// running even when the managed thread pool is exhausted (the documented worker-hang class). When
+/// the heartbeat goes stale it exits the process so the container restart policy recreates the
+/// worker. It arms only after the first beat, so broken wiring or a deliberately-disabled producer
+/// can never drive a restart loop (a never-beating worker is left alone).
+/// </summary>
+public sealed class WorkerWatchdogService(
+    IWorkerHeartbeat heartbeat,
+    IOptions<WorkerWatchdogOptions> options,
+    ILogger<WorkerWatchdogService> logger) : IHostedService
+{
+    private readonly CancellationTokenSource _stopping = new();
+    private Thread? _thread;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var opts = options.Value;
+        if (!opts.Enabled)
+        {
+            logger.LogInformation("Worker watchdog disabled (Worker:Watchdog:Enabled=false).");
+            return Task.CompletedTask;
+        }
+
+        _thread = new Thread(() => Loop(opts))
+        {
+            IsBackground = true,
+            Name = "worker-watchdog",
+        };
+        _thread.Start();
+        logger.LogInformation(
+            "Worker watchdog armed: staleness threshold {Threshold}, check interval {Interval}.",
+            opts.StalenessThreshold,
+            opts.CheckInterval);
+        return Task.CompletedTask;
+    }
+
+    private void Loop(WorkerWatchdogOptions opts)
+    {
+        var token = _stopping.Token;
+        while (!token.IsCancellationRequested)
+        {
+            // WaitHandle (not Thread.Sleep) so a graceful stop wakes the loop immediately.
+            token.WaitHandle.WaitOne(opts.CheckInterval);
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var last = heartbeat.LastBeatUtc;
+            if (!ShouldRestart(last, DateTime.UtcNow, opts.StalenessThreshold))
+            {
+                continue;
+            }
+
+            logger.LogCritical(
+                "Worker watchdog: last producer beat {LastBeatUtc:o} is older than {Threshold}; the worker " +
+                "appears hung. Exiting so the container restart policy recreates it.",
+                last,
+                opts.StalenessThreshold);
+
+            Environment.Exit(70); // EX_SOFTWARE — non-zero so restart:unless-stopped recreates the container.
+        }
+    }
+
+    /// <summary>
+    /// Pure decision: restart only once a beat has occurred (armed) and the last beat has since
+    /// aged past the staleness threshold.
+    /// </summary>
+    public static bool ShouldRestart(DateTime? lastBeatUtc, DateTime nowUtc, TimeSpan stalenessThreshold)
+        => lastBeatUtc.HasValue && (nowUtc - lastBeatUtc.Value) > stalenessThreshold;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _stopping.Cancel();
+        return Task.CompletedTask;
+    }
+}

--- a/Transcendence.Service.Core/Services/Jobs/ChampionAnalyticsIngestionJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/ChampionAnalyticsIngestionJob.cs
@@ -27,6 +27,7 @@ public class ChampionAnalyticsIngestionJob(
     IQueueDepthProbe queueDepthProbe,
     IOptions<ChampionAnalyticsIngestionJobOptions> options,
     IOptions<MultiRegionIngestionOptions> multiRegionOptions,
+    IWorkerHeartbeat workerHeartbeat,
     ILogger<ChampionAnalyticsIngestionJob> logger)
 {
     private static readonly TimeSpan QueueFailureLockReleaseTimeout = TimeSpan.FromSeconds(5);
@@ -44,6 +45,10 @@ public class ChampionAnalyticsIngestionJob(
 
     public async Task ExecuteAsync(CancellationToken ct = default)
     {
+        // Liveness beat for the worker watchdog — recorded on every dispatcher fire, before the
+        // pacing gate, so a hung worker (no dispatcher fires at all) goes stale even in steady state.
+        await workerHeartbeat.BeatAsync(ct);
+
         // Self-pacing: one fast heartbeat cron fires this dispatcher; the pacing slot decides whether
         // this tick actually fans out (tighter cadence during a new-patch ramp, looser in steady state).
         if (!await TryAcquirePacingSlotAsync(ct))

--- a/Transcendence.Service/Dockerfile
+++ b/Transcendence.Service/Dockerfile
@@ -20,4 +20,9 @@ RUN dotnet publish "Transcendence.Service.csproj" -c $BUILD_CONFIGURATION -o /ap
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+# Liveness: the worker writes /tmp/worker-heartbeat on every producer tick. Mark the container
+# unhealthy when that file is missing or older than 10 min (the in-process watchdog exits on the
+# same condition to trigger a restart; this gives docker ps / monitoring visibility). coreutils only.
+HEALTHCHECK --interval=60s --timeout=10s --start-period=240s --retries=3 \
+    CMD test -f /tmp/worker-heartbeat && test $(( $(date +%s) - $(stat -c %Y /tmp/worker-heartbeat) )) -lt 600
 ENTRYPOINT ["dotnet", "Transcendence.Service.dll"]

--- a/Transcendence.Service/Program.cs
+++ b/Transcendence.Service/Program.cs
@@ -145,6 +145,13 @@ builder.Services.AddSingleton<IStartupPatchRolloverService, StartupPatchRollover
 builder.Services.AddSingleton<IAdaptiveThroughputBudgetPolicy, AdaptiveThroughputBudgetPolicy>();
 builder.Services.AddSingleton<IStarvationGuardrailPolicy, StarvationGuardrailPolicy>();
 
+// Worker liveness: producers beat IWorkerHeartbeat each dispatcher tick; the watchdog exits the
+// process when the beat goes stale so restart:unless-stopped recreates a hung worker (a Docker
+// HEALTHCHECK only marks unhealthy, it does not restart). Disable with Worker__Watchdog__Enabled=false.
+builder.Services.Configure<WorkerWatchdogOptions>(builder.Configuration.GetSection("Worker:Watchdog"));
+builder.Services.AddSingleton<IWorkerHeartbeat, WorkerHeartbeat>();
+builder.Services.AddHostedService<WorkerWatchdogService>();
+
 // worker that initiates services
 if (builder.Environment.IsDevelopment())
     // development worker directly enqueues and cleans up jobs for development

--- a/tests/Transcendence.Service.Core.Tests/CancellationPropagationTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/CancellationPropagationTests.cs
@@ -128,6 +128,7 @@ public class CancellationPropagationTests
             Mock.Of<IQueueDepthProbe>(),
             Options.Create(new ChampionAnalyticsIngestionJobOptions()),
             Options.Create(new MultiRegionIngestionOptions()),
+            Mock.Of<IWorkerHeartbeat>(),
             Mock.Of<ILogger<ChampionAnalyticsIngestionJob>>());
 
         using var cts = new CancellationTokenSource();

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsIngestionJobRampTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsIngestionJobRampTests.cs
@@ -470,6 +470,7 @@ public class ChampionAnalyticsIngestionJobRampTests
                     RampMaxRefreshJobsToQueuePerRun = 10
                 }),
                 Options.Create(multiRegionOptions ?? new MultiRegionIngestionOptions()),
+                Mock.Of<IWorkerHeartbeat>(),
                 Mock.Of<ILogger<ChampionAnalyticsIngestionJob>>());
 
             return new Harness(connection, db, job, bootstrap, backgroundJobs, refreshLocks);

--- a/tests/Transcendence.Service.Core.Tests/WorkerWatchdogTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/WorkerWatchdogTests.cs
@@ -1,0 +1,36 @@
+using Transcendence.Service.Core.Services.Diagnostics;
+using Xunit;
+
+namespace Transcendence.Service.Core.Tests;
+
+public class WorkerWatchdogTests
+{
+    private static readonly TimeSpan Threshold = TimeSpan.FromMinutes(10);
+    private static readonly DateTime Now = new(2026, 6, 19, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void ShouldRestart_NeverBeat_IsFalse()
+    {
+        // Disarmed until the first beat, so broken wiring / a disabled producer can't crash-loop.
+        Assert.False(WorkerWatchdogService.ShouldRestart(null, Now, Threshold));
+    }
+
+    [Fact]
+    public void ShouldRestart_RecentBeat_IsFalse()
+    {
+        Assert.False(WorkerWatchdogService.ShouldRestart(Now.AddMinutes(-3), Now, Threshold));
+    }
+
+    [Fact]
+    public void ShouldRestart_StaleBeat_IsTrue()
+    {
+        Assert.True(WorkerWatchdogService.ShouldRestart(Now.AddMinutes(-11), Now, Threshold));
+    }
+
+    [Fact]
+    public void ShouldRestart_ExactlyAtThreshold_IsFalse()
+    {
+        // Strictly greater-than, so the boundary is not a restart.
+        Assert.False(WorkerWatchdogService.ShouldRestart(Now - Threshold, Now, Threshold));
+    }
+}


### PR DESCRIPTION
## What
Makes the worker restart itself on the documented silent hang.

- Producer (`ChampionAnalyticsIngestionJob`, `*/2`) beats `IWorkerHeartbeat` each dispatcher fire → in-memory marker + `/tmp/worker-heartbeat` + Redis `worker:heartbeat:lastBeatUtc`.
- `WorkerWatchdogService` on a **dedicated thread** (survives thread-pool exhaustion) `Environment.Exit(70)`s when the beat is >10 min stale, so `restart:unless-stopped` recreates the worker. **Arms only after the first beat** → broken wiring / disabled producer cannot crash-loop.
- service Dockerfile `HEALTHCHECK` on the same staleness (coreutils only) for visibility.

## Why
A Docker `HEALTHCHECK` alone does **not** restart a container, and the restart policy fires only on process exit — so a hang previously went undetected. The dedicated-thread watchdog is what actually makes the restart fire.

## Verification
- `dotnet build` clean; **163 backend tests pass** incl. 4 new `WorkerWatchdogService.ShouldRestart` cases.
- `stat -c %Y` + `date` confirmed present in the prod service image.

## Deploy / rollout note
Deploys the **worker** (critical). Watchdog defaults on but is crash-loop-safe (arm-after-first-beat). Post-deploy I verify: healthcheck `healthy`, Redis heartbeat updating, "Worker watchdog armed" in logs, no restart loop. Escape hatch: `Worker__Watchdog__Enabled=false`.

Roadmap **P1.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)