### PR TITLE
Service: poll-based ingestion-health alerts (P1.4)

### DIFF
--- a/Transcendence.Service.Core/Services/Diagnostics/WebhookAlertNotifier.cs
+++ b/Transcendence.Service.Core/Services/Diagnostics/WebhookAlertNotifier.cs
@@ -1,0 +1,65 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Transcendence.Service.Core.Services.Diagnostics;
+
+public sealed class AlertOptions
+{
+    public AlertWebhookOptions Webhook { get; set; } = new();
+
+    /// <summary>Failed-job count above which a failed-jobs alert fires.</summary>
+    public int FailedJobThreshold { get; set; } = 200;
+
+    /// <summary>Discovery queue depth above which a stuck-backlog alert fires.</summary>
+    public long DiscoveryQueueDepthThreshold { get; set; } = 10_000;
+
+    /// <summary>How long a given condition stays silenced after firing, so it does not re-alert every run.</summary>
+    public TimeSpan Cooldown { get; set; } = TimeSpan.FromMinutes(30);
+}
+
+public sealed class AlertWebhookOptions
+{
+    /// <summary>Discord/Slack-compatible incoming webhook URL. Empty → alerts are logged only.</summary>
+    public string Url { get; set; } = string.Empty;
+}
+
+public interface IAlertNotifier
+{
+    /// <summary>Send an operational alert. No-ops to a log warning when no webhook URL is configured.</summary>
+    Task SendAsync(string title, string body, CancellationToken cancellationToken = default);
+}
+
+public sealed class WebhookAlertNotifier(
+    IHttpClientFactory httpClientFactory,
+    IOptions<AlertOptions> options,
+    ILogger<WebhookAlertNotifier> logger) : IAlertNotifier
+{
+    public async Task SendAsync(string title, string body, CancellationToken cancellationToken = default)
+    {
+        var url = options.Value.Webhook.Url;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            logger.LogWarning("ALERT (no webhook configured): {Title} — {Body}", title, body);
+            return;
+        }
+
+        try
+        {
+            var client = httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(10);
+            // Discord-compatible payload ("content"); Slack incoming webhooks accept "text" instead.
+            var payload = new { content = $"**{title}**\n{body}" };
+            using var response = await client.PostAsJsonAsync(url, payload, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning(
+                    "Alert webhook returned {Status} for {Title}", (int)response.StatusCode, title);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to post alert webhook: {Title}", title);
+        }
+    }
+}

--- a/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<RefreshTftAnalyticsJob>();
         services.AddScoped<TftAnalyticsIngestionJob>();
         services.AddScoped<TftSummonerMaintenanceJob>();
+        services.AddScoped<IngestionHealthAlertJob>();
         services.AddScoped<IIngestionPriorityScoringPolicy, IngestionPriorityScoringPolicy>();
         services.AddSingleton<IQueueDepthProbe, HangfireQueueDepthProbe>();
 

--- a/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerJobScheduleOptions.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerJobScheduleOptions.cs
@@ -17,6 +17,8 @@ public class WorkerJobScheduleOptions
     public string RuneSelectionIntegrityBackfillCron { get; set; } = "*/15 * * * *";
     public string LiveGamePollingCron { get; set; } = "*/2 * * * *";
     public string RefreshLockLifecycleCleanupCron { get; set; } = "*/5 * * * *";
+    public string IngestionHealthAlertCron { get; set; } = "*/5 * * * *";
+    public bool EnableIngestionHealthAlert { get; set; } = true;
     public string TftStaticDataCron { get; set; } = "15 */6 * * *";
     public string TftAnalyticsRefreshCron { get; set; } = "15 */2 * * *";
     public string TftAnalyticsIngestionCron { get; set; } = "*/30 * * * *";

--- a/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerRecurringJobPolicy.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerRecurringJobPolicy.cs
@@ -38,6 +38,7 @@ public sealed class WorkerRecurringJobPolicy(
     public const string PollLiveGamesJobId = "poll-live-games";
     public const string HighEloProfileRefreshJobId = "high-elo-profile-refresh";
     public const string RefreshLockLifecycleCleanupJobId = "refresh-lock-lifecycle-cleanup";
+    public const string IngestionHealthAlertJobId = "ingestion-health-alert";
     public const string TftStaticDataJobId = "tft-static-data-refresh";
     public const string TftAnalyticsRefreshJobId = "tft-analytics-refresh";
     public const string TftAnalyticsIngestionJobId = "tft-analytics-ingestion";
@@ -66,6 +67,7 @@ public sealed class WorkerRecurringJobPolicy(
         PollLiveGamesJobId,
         HighEloProfileRefreshJobId,
         RefreshLockLifecycleCleanupJobId,
+        IngestionHealthAlertJobId,
         TftStaticDataJobId,
         TftAnalyticsRefreshJobId,
         TftAnalyticsIngestionJobId,
@@ -163,6 +165,12 @@ public sealed class WorkerRecurringJobPolicy(
                 schedule.RefreshLockLifecycleCleanupCron,
                 schedule.EnableRefreshLockLifecycleCleanup,
                 ConfigureRefreshLockLifecycleCleanup),
+            CreateDescriptor(
+                IngestionHealthAlertJobId,
+                "Jobs:Schedule:IngestionHealthAlertCron",
+                schedule.IngestionHealthAlertCron,
+                schedule.EnableIngestionHealthAlert,
+                ConfigureIngestionHealthAlert),
             CreateDescriptor(
                 TftStaticDataJobId,
                 "Jobs:Schedule:TftStaticDataCron",
@@ -332,6 +340,15 @@ public sealed class WorkerRecurringJobPolicy(
         string cronExpression) =>
         recurringJobManager.AddOrUpdate<RefreshLockLifecycleJob>(
             RefreshLockLifecycleCleanupJobId,
+            job => job.ExecuteAsync(CancellationToken.None),
+            cronExpression,
+            new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+
+    private static void ConfigureIngestionHealthAlert(
+        IRecurringJobManager recurringJobManager,
+        string cronExpression) =>
+        recurringJobManager.AddOrUpdate<IngestionHealthAlertJob>(
+            IngestionHealthAlertJobId,
             job => job.ExecuteAsync(CancellationToken.None),
             cronExpression,
             new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });

--- a/Transcendence.Service.Core/Services/Jobs/IngestionHealthAlertJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/IngestionHealthAlertJob.cs
@@ -1,0 +1,95 @@
+using Hangfire;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Transcendence.Service.Core.Services.Diagnostics;
+
+namespace Transcendence.Service.Core.Services.Jobs;
+
+/// <summary>
+/// Polls Hangfire health every few minutes and pushes an alert (webhook, or log-only when no webhook
+/// URL is configured) on a degradation signal: a failed-job spike, a stuck discovery backlog, or zero
+/// throughput while work is enqueued (the stall class the discovery lane was hardened against). A
+/// per-condition cooldown stops a persistent condition from re-alerting every run. Poll-based, so it
+/// needs no metrics exporter and can ship ahead of full telemetry (P3.1).
+/// </summary>
+public sealed class IngestionHealthAlertJob(
+    JobStorage jobStorage,
+    IQueueDepthProbe queueDepthProbe,
+    IAlertNotifier notifier,
+    IDistributedCache cache,
+    IOptions<AlertOptions> options,
+    ILogger<IngestionHealthAlertJob> logger)
+{
+    private const string PrevSucceededKey = "alert:prevSucceeded";
+    private const string CooldownKeyPrefix = "alert:cooldown:";
+
+    public async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        var opts = options.Value;
+        var stats = jobStorage.GetMonitoringApi().GetStatistics();
+        var discoveryDepth = queueDepthProbe.GetEnqueuedCount(HangfireQueues.Discovery);
+
+        long? prevSucceeded = null;
+        var prevRaw = await cache.GetStringAsync(PrevSucceededKey, ct).ConfigureAwait(false);
+        if (long.TryParse(prevRaw, out var parsed))
+        {
+            prevSucceeded = parsed;
+        }
+        await cache.SetStringAsync(PrevSucceededKey, stats.Succeeded.ToString(), ct).ConfigureAwait(false);
+
+        var conditions = EvaluateConditions(
+            stats.Failed, stats.Succeeded, prevSucceeded, stats.Enqueued, discoveryDepth, opts);
+
+        foreach (var (key, message) in conditions)
+        {
+            // Per-condition cooldown so a persistent condition does not re-alert on every poll.
+            var cooldownKey = CooldownKeyPrefix + key;
+            if (await cache.GetStringAsync(cooldownKey, ct).ConfigureAwait(false) is not null)
+            {
+                continue;
+            }
+
+            logger.LogWarning("Ingestion health alert [{Key}]: {Message}", key, message);
+            await notifier.SendAsync($"Transcendence ingestion: {key}", message, ct).ConfigureAwait(false);
+            await cache.SetStringAsync(
+                cooldownKey,
+                "1",
+                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = opts.Cooldown },
+                ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Pure condition evaluation, separated for testability.</summary>
+    public static IReadOnlyList<(string Key, string Message)> EvaluateConditions(
+        long failed,
+        long succeeded,
+        long? prevSucceeded,
+        long enqueued,
+        long discoveryDepth,
+        AlertOptions opts)
+    {
+        var result = new List<(string, string)>();
+
+        if (failed > opts.FailedJobThreshold)
+        {
+            result.Add(("failed-jobs",
+                $"{failed} failed Hangfire jobs (threshold {opts.FailedJobThreshold})."));
+        }
+
+        if (discoveryDepth > opts.DiscoveryQueueDepthThreshold)
+        {
+            result.Add(("discovery-backlog",
+                $"Discovery queue depth {discoveryDepth} exceeds {opts.DiscoveryQueueDepthThreshold} — workers may be stuck."));
+        }
+
+        // Throughput stall: nothing completed since the last check while work is waiting.
+        if (prevSucceeded.HasValue && succeeded == prevSucceeded.Value && (enqueued + discoveryDepth) > 0)
+        {
+            result.Add(("throughput-stall",
+                $"No Hangfire jobs completed since the last check while {enqueued + discoveryDepth} are enqueued — ingestion appears stalled."));
+        }
+
+        return result;
+    }
+}

--- a/Transcendence.Service/Program.cs
+++ b/Transcendence.Service/Program.cs
@@ -152,6 +152,11 @@ builder.Services.Configure<WorkerWatchdogOptions>(builder.Configuration.GetSecti
 builder.Services.AddSingleton<IWorkerHeartbeat, WorkerHeartbeat>();
 builder.Services.AddHostedService<WorkerWatchdogService>();
 
+// Poll-based ingestion-health alerts (failed-job spike / stuck discovery backlog / throughput
+// stall). Posts to Alerts:Webhook:Url; logs only when unset, so this ships without a secret.
+builder.Services.Configure<AlertOptions>(builder.Configuration.GetSection("Alerts"));
+builder.Services.AddSingleton<IAlertNotifier, WebhookAlertNotifier>();
+
 // worker that initiates services
 if (builder.Environment.IsDevelopment())
     // development worker directly enqueues and cleans up jobs for development

--- a/tests/Transcendence.Service.Core.Tests/IngestionHealthAlertJobTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/IngestionHealthAlertJobTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using Transcendence.Service.Core.Services.Diagnostics;
+using Transcendence.Service.Core.Services.Jobs;
+using Xunit;
+
+namespace Transcendence.Service.Core.Tests;
+
+public class IngestionHealthAlertJobTests
+{
+    private static readonly AlertOptions Opts = new()
+    {
+        FailedJobThreshold = 200,
+        DiscoveryQueueDepthThreshold = 10_000,
+    };
+
+    private static System.Collections.Generic.IReadOnlyList<(string Key, string Message)> Eval(
+        long failed = 0, long succeeded = 100, long? prev = 100, long enqueued = 0, long discovery = 0)
+        => IngestionHealthAlertJob.EvaluateConditions(failed, succeeded, prev, enqueued, discovery, Opts);
+
+    [Fact]
+    public void Healthy_NoConditions()
+    {
+        Assert.Empty(Eval(failed: 5, succeeded: 200, prev: 100, enqueued: 10, discovery: 10));
+    }
+
+    [Fact]
+    public void FailedSpike_Fires()
+    {
+        Assert.Contains(Eval(failed: 201), c => c.Key == "failed-jobs");
+    }
+
+    [Fact]
+    public void DiscoveryBacklog_Fires()
+    {
+        Assert.Contains(Eval(discovery: 10_001), c => c.Key == "discovery-backlog");
+    }
+
+    [Fact]
+    public void ThroughputStall_FiresWhenNoCompletionsAndWorkPending()
+    {
+        // succeeded unchanged since last check (prev == succeeded) while work is enqueued.
+        Assert.Contains(Eval(succeeded: 100, prev: 100, enqueued: 50), c => c.Key == "throughput-stall");
+    }
+
+    [Fact]
+    public void ThroughputStall_DoesNotFireOnFirstRun()
+    {
+        // No previous sample yet → no stall signal even with work enqueued.
+        Assert.DoesNotContain(Eval(succeeded: 100, prev: null, enqueued: 50), c => c.Key == "throughput-stall");
+    }
+
+    [Fact]
+    public void ThroughputStall_DoesNotFireWhenCompletionsAdvance()
+    {
+        Assert.DoesNotContain(Eval(succeeded: 150, prev: 100, enqueued: 50), c => c.Key == "throughput-stall");
+    }
+
+    [Fact]
+    public void ThroughputStall_DoesNotFireWhenNothingEnqueued()
+    {
+        Assert.DoesNotContain(Eval(succeeded: 100, prev: 100, enqueued: 0, discovery: 0), c => c.Key == "throughput-stall");
+    }
+}


### PR DESCRIPTION
## What
A recurring `IngestionHealthAlertJob` (every 5 min) that reads Hangfire stats + discovery queue depth and pushes an alert when:
- failed Hangfire jobs exceed a threshold,
- the discovery queue is backed up past a cap, or
- nothing completed since the last check while work is enqueued (**throughput stall** — the signal the discovery lane was hardened against).

Delivery via `WebhookAlertNotifier` → `Alerts:Webhook:Url` (Discord/Slack-compatible), or a **log warning when no URL is set**, so it ships without a secret. Per-condition Redis cooldown (30 min) prevents spam.

## Why
There was zero alerting — degraded-worker detection was 100% human-pull, so on push-to-main the gap between "prod degraded" and "human notices" was unbounded. Poll-based, so it needs no metrics exporter and lands ahead of P3.1 telemetry.

## Verification
`dotnet build` clean; **170 backend tests pass** incl. 7 `EvaluateConditions` cases (healthy, failed-spike, backlog, stall, first-run-no-stall, completions-advance, nothing-enqueued).

## To enable pushes
Set `Alerts__Webhook__Url=<discord-or-slack-webhook>` in the worker env. Until then it logs alerts as warnings (visible in `/admin/logs` + dozzle).

## Deploy note
Worker-only change (rebuilds service + webapi images). Defaults: every 5 min, enabled, log-only. Closes **Phase 1**.

Roadmap **P1.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)