### PR TITLE
Service: failed-jobs alert on delta, not cumulative (P1.4b)

### DIFF
--- a/Transcendence.Service.Core/Services/Diagnostics/WebhookAlertNotifier.cs
+++ b/Transcendence.Service.Core/Services/Diagnostics/WebhookAlertNotifier.cs
@@ -8,8 +8,10 @@ public sealed class AlertOptions
 {
     public AlertWebhookOptions Webhook { get; set; } = new();
 
-    /// <summary>Failed-job count above which a failed-jobs alert fires.</summary>
-    public int FailedJobThreshold { get; set; } = 200;
+    /// <summary>New failed jobs within one poll interval above which a failed-jobs spike alert fires.
+    /// A delta, not a cumulative count — Hangfire retains old failures, so the absolute count is
+    /// meaningless (it only ever climbs).</summary>
+    public int FailedJobSpikeThreshold { get; set; } = 50;
 
     /// <summary>Discovery queue depth above which a stuck-backlog alert fires.</summary>
     public long DiscoveryQueueDepthThreshold { get; set; } = 10_000;

--- a/Transcendence.Service.Core/Services/Jobs/IngestionHealthAlertJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/IngestionHealthAlertJob.cs
@@ -22,6 +22,7 @@ public sealed class IngestionHealthAlertJob(
     ILogger<IngestionHealthAlertJob> logger)
 {
     private const string PrevSucceededKey = "alert:prevSucceeded";
+    private const string PrevFailedKey = "alert:prevFailed";
     private const string CooldownKeyPrefix = "alert:cooldown:";
 
     public async Task ExecuteAsync(CancellationToken ct = default)
@@ -31,15 +32,21 @@ public sealed class IngestionHealthAlertJob(
         var discoveryDepth = queueDepthProbe.GetEnqueuedCount(HangfireQueues.Discovery);
 
         long? prevSucceeded = null;
-        var prevRaw = await cache.GetStringAsync(PrevSucceededKey, ct).ConfigureAwait(false);
-        if (long.TryParse(prevRaw, out var parsed))
+        if (long.TryParse(await cache.GetStringAsync(PrevSucceededKey, ct).ConfigureAwait(false), out var ps))
         {
-            prevSucceeded = parsed;
+            prevSucceeded = ps;
         }
         await cache.SetStringAsync(PrevSucceededKey, stats.Succeeded.ToString(), ct).ConfigureAwait(false);
 
+        long? prevFailed = null;
+        if (long.TryParse(await cache.GetStringAsync(PrevFailedKey, ct).ConfigureAwait(false), out var pf))
+        {
+            prevFailed = pf;
+        }
+        await cache.SetStringAsync(PrevFailedKey, stats.Failed.ToString(), ct).ConfigureAwait(false);
+
         var conditions = EvaluateConditions(
-            stats.Failed, stats.Succeeded, prevSucceeded, stats.Enqueued, discoveryDepth, opts);
+            stats.Failed, prevFailed, stats.Succeeded, prevSucceeded, stats.Enqueued, discoveryDepth, opts);
 
         foreach (var (key, message) in conditions)
         {
@@ -63,6 +70,7 @@ public sealed class IngestionHealthAlertJob(
     /// <summary>Pure condition evaluation, separated for testability.</summary>
     public static IReadOnlyList<(string Key, string Message)> EvaluateConditions(
         long failed,
+        long? prevFailed,
         long succeeded,
         long? prevSucceeded,
         long enqueued,
@@ -71,10 +79,12 @@ public sealed class IngestionHealthAlertJob(
     {
         var result = new List<(string, string)>();
 
-        if (failed > opts.FailedJobThreshold)
+        // Spike, not cumulative: Hangfire retains old failures, so alert on NEW failures this interval.
+        if (prevFailed.HasValue && (failed - prevFailed.Value) > opts.FailedJobSpikeThreshold)
         {
+            var newFailures = failed - prevFailed.Value;
             result.Add(("failed-jobs",
-                $"{failed} failed Hangfire jobs (threshold {opts.FailedJobThreshold})."));
+                $"{newFailures} new failed Hangfire jobs since the last check (spike threshold {opts.FailedJobSpikeThreshold}; {failed} total retained)."));
         }
 
         if (discoveryDepth > opts.DiscoveryQueueDepthThreshold)

--- a/tests/Transcendence.Service.Core.Tests/IngestionHealthAlertJobTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/IngestionHealthAlertJobTests.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Transcendence.Service.Core.Services.Diagnostics;
 using Transcendence.Service.Core.Services.Jobs;
 using Xunit;
@@ -9,24 +8,45 @@ public class IngestionHealthAlertJobTests
 {
     private static readonly AlertOptions Opts = new()
     {
-        FailedJobThreshold = 200,
+        FailedJobSpikeThreshold = 50,
         DiscoveryQueueDepthThreshold = 10_000,
     };
 
     private static System.Collections.Generic.IReadOnlyList<(string Key, string Message)> Eval(
-        long failed = 0, long succeeded = 100, long? prev = 100, long enqueued = 0, long discovery = 0)
-        => IngestionHealthAlertJob.EvaluateConditions(failed, succeeded, prev, enqueued, discovery, Opts);
+        long failed = 0,
+        long? prevFailed = 0,
+        long succeeded = 100,
+        long? prevSucceeded = 100,
+        long enqueued = 0,
+        long discovery = 0)
+        => IngestionHealthAlertJob.EvaluateConditions(
+            failed, prevFailed, succeeded, prevSucceeded, enqueued, discovery, Opts);
 
     [Fact]
     public void Healthy_NoConditions()
     {
-        Assert.Empty(Eval(failed: 5, succeeded: 200, prev: 100, enqueued: 10, discovery: 10));
+        Assert.Empty(Eval(failed: 5, prevFailed: 0, succeeded: 200, prevSucceeded: 100, enqueued: 10, discovery: 10));
     }
 
     [Fact]
-    public void FailedSpike_Fires()
+    public void FailedSpike_FiresOnDelta()
     {
-        Assert.Contains(Eval(failed: 201), c => c.Key == "failed-jobs");
+        // 60 new failures this interval > spike threshold 50.
+        Assert.Contains(Eval(failed: 1060, prevFailed: 1000), c => c.Key == "failed-jobs");
+    }
+
+    [Fact]
+    public void FailedJobs_DoesNotFireOnAccumulatedHistory()
+    {
+        // The prod scenario: 2743 total retained, but only 3 new since the last check → no alert.
+        Assert.DoesNotContain(Eval(failed: 2743, prevFailed: 2740), c => c.Key == "failed-jobs");
+    }
+
+    [Fact]
+    public void FailedJobs_DoesNotFireOnFirstRun()
+    {
+        // No baseline yet → cannot compute a delta → no alert even with a huge retained count.
+        Assert.DoesNotContain(Eval(failed: 2743, prevFailed: null), c => c.Key == "failed-jobs");
     }
 
     [Fact]
@@ -38,26 +58,24 @@ public class IngestionHealthAlertJobTests
     [Fact]
     public void ThroughputStall_FiresWhenNoCompletionsAndWorkPending()
     {
-        // succeeded unchanged since last check (prev == succeeded) while work is enqueued.
-        Assert.Contains(Eval(succeeded: 100, prev: 100, enqueued: 50), c => c.Key == "throughput-stall");
+        Assert.Contains(Eval(succeeded: 100, prevSucceeded: 100, enqueued: 50), c => c.Key == "throughput-stall");
     }
 
     [Fact]
     public void ThroughputStall_DoesNotFireOnFirstRun()
     {
-        // No previous sample yet → no stall signal even with work enqueued.
-        Assert.DoesNotContain(Eval(succeeded: 100, prev: null, enqueued: 50), c => c.Key == "throughput-stall");
+        Assert.DoesNotContain(Eval(succeeded: 100, prevSucceeded: null, enqueued: 50), c => c.Key == "throughput-stall");
     }
 
     [Fact]
     public void ThroughputStall_DoesNotFireWhenCompletionsAdvance()
     {
-        Assert.DoesNotContain(Eval(succeeded: 150, prev: 100, enqueued: 50), c => c.Key == "throughput-stall");
+        Assert.DoesNotContain(Eval(succeeded: 150, prevSucceeded: 100, enqueued: 50), c => c.Key == "throughput-stall");
     }
 
     [Fact]
     public void ThroughputStall_DoesNotFireWhenNothingEnqueued()
     {
-        Assert.DoesNotContain(Eval(succeeded: 100, prev: 100, enqueued: 0, discovery: 0), c => c.Key == "throughput-stall");
+        Assert.DoesNotContain(Eval(succeeded: 100, prevSucceeded: 100, enqueued: 0, discovery: 0), c => c.Key == "throughput-stall");
     }
 }


### PR DESCRIPTION
## What
Changes the failed-jobs alert condition from Hangfire's **cumulative** `FailedCount` to a **per-interval delta** (`FailedJobSpikeThreshold`, default 50 new failures), tracked via `prevFailed` in Redis.

## Why
Prod verification of P1.4 caught this immediately: the alert fired on **2743** failed jobs — but only **1** occurred in the last 24h and **0** in the last hour. They're accumulated history since June 4, not a problem. Cumulative count only ever climbs, so it's the wrong signal; a spike (new failures this interval) is what matters.

## Verification
`dotnet build` clean; **9 alert tests pass** including the exact prod scenario (`failed=2743, prevFailed=2740` → no alert) and no-first-run-alert.

Roadmap **P1.4b**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)