### PR TITLE
Cache: raise HybridCache MaximumPayloadBytes to 8 MiB

### DIFF
--- a/Transcendence.Service/Program.cs
+++ b/Transcendence.Service/Program.cs
@@ -110,6 +110,9 @@ builder.Services.AddHybridCache(options =>
         Expiration = TimeSpan.FromHours(1),           // L2 Redis TTL
         LocalCacheExpiration = TimeSpan.FromMinutes(5) // L1 Memory TTL (shorter than L2)
     };
+    // Raise from the ~1 MiB default so large match-timeline DTOs still serialize to L2 (Redis)
+    // instead of being silently dropped, which re-runs DB-bound compute on every cold read.
+    options.MaximumPayloadBytes = 8 * 1024 * 1024; // 8 MiB
 });
 
 builder.Services.Configure<WorkerJobScheduleOptions>(builder.Configuration.GetSection("Jobs:Schedule"));

--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -194,6 +194,9 @@ builder.Services.AddHybridCache(options =>
         Expiration = TimeSpan.FromHours(1),           // L2 Redis TTL
         LocalCacheExpiration = TimeSpan.FromMinutes(5) // L1 Memory TTL (shorter than L2)
     };
+    // Raise from the ~1 MiB default so large match-timeline DTOs still serialize to L2 (Redis)
+    // instead of being silently dropped, which re-runs DB-bound compute on every cold read.
+    options.MaximumPayloadBytes = 8 * 1024 * 1024; // 8 MiB
 });
 
 // Register keyless application services used by the WebAPI host.


### PR DESCRIPTION
## What

Set `options.MaximumPayloadBytes = 8 * 1024 * 1024` (8 MiB) inside **both** `AddHybridCache` option lambdas:
- `Transcendence.WebAPI/Program.cs`
- `Transcendence.Service/Program.cs`

## Why

HybridCache's `MaximumPayloadBytes` defaults to ~1 MiB. Large match-timeline DTOs exceed that and are silently dropped from L2 (Redis) rather than serialized, so popular cold matches re-run DB-bound compute on every read with no signal. Raising the cap to 8 MiB lets those payloads round-trip through Redis.

Both registrations are kept identical; a one-line comment documents the rationale at each call site. No other behavior changes.

## Verification

- `dotnet build Transcendence.sln -c Debug` — succeeds (0 errors; only pre-existing warnings).
- `pnpm api:spec` boots the WebAPI and re-exports the OpenAPI spec; `git diff --exit-code -- openapi/transcendence.v1.json` reports **no contract change** (expected — this is a DI cache-config change with no surface impact).

Note: the full `pnpm api:check` also runs `api:client` (TS regen), which fails in this fresh worktree only because node_modules is not installed (`openapi-typescript: command not found`) — an environment artifact, not a contract drift. CI installs deps and runs the full check.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)