### PR TITLE
Ingestion: route TFT Riot calls through IRiotRateGate (P2.2)

### DIFF
--- a/Transcendence.Service.Core/Services/Tft/Implementations/TftMatchIdsClient.cs
+++ b/Transcendence.Service.Core/Services/Tft/Implementations/TftMatchIdsClient.cs
@@ -5,7 +5,7 @@ using Transcendence.Service.Core.Services.Tft.Interfaces;
 
 namespace Transcendence.Service.Core.Services.Tft.Implementations;
 
-public class TftMatchIdsClient(TftRiotApiContext riotApiContext) : ITftMatchIdsClient
+public class TftMatchIdsClient(TftRiotApiContext riotApiContext, IRiotRateGate rateGate) : ITftMatchIdsClient
 {
     public async Task<IReadOnlyList<string>> GetMatchIdsByPuuidAsync(
         RegionalRoute regionalRoute,
@@ -16,6 +16,12 @@ public class TftMatchIdsClient(TftRiotApiContext riotApiContext) : ITftMatchIdsC
         long? startTimeEpochSeconds,
         CancellationToken ct = default)
     {
+        // Pace under the per-region Riot budget (shared gate with the LoL vertical). An empty list means
+        // "no new ids this run" to the caller, which simply ends paging — safe when the region's budget is
+        // momentarily exhausted past the gate's max wait.
+        if (!await rateGate.AcquireAsync(regionalRoute.ToString(), ct))
+            return [];
+
         return await riotApiContext.Api.TftMatchV1()
             .GetMatchIdsByPUUIDAsync(regionalRoute, puuid, count, endTimeEpochSeconds, start, startTimeEpochSeconds, ct);
     }

--- a/Transcendence.Service.Core/Services/Tft/Implementations/TftMatchService.cs
+++ b/Transcendence.Service.Core/Services/Tft/Implementations/TftMatchService.cs
@@ -11,11 +11,17 @@ namespace Transcendence.Service.Core.Services.Tft.Implementations;
 
 public class TftMatchService(
     TftRiotApiContext riotApiContext,
-    ITftSummonerRepository summonerRepository) : ITftMatchService
+    ITftSummonerRepository summonerRepository,
+    IRiotRateGate rateGate) : ITftMatchService
 {
     public async Task<TftMatch?> GetMatchDetailsAsync(string matchId, RegionalRoute regionalRoute, PlatformRoute platformRoute,
         CancellationToken ct = default)
     {
+        // Pace under the per-region Riot budget (shared gate with the LoL vertical); skip (retry later)
+        // rather than park this worker if the region's budget stays exhausted past the gate's max wait.
+        if (!await rateGate.AcquireAsync(regionalRoute.ToString(), ct))
+            return null;
+
         var matchDto = await riotApiContext.Api.TftMatchV1().GetMatchAsync(regionalRoute, matchId, ct);
         if (matchDto == null)
             return null;

--- a/Transcendence.Service.Core/Services/Tft/Implementations/TftSummonerBootstrapService.cs
+++ b/Transcendence.Service.Core/Services/Tft/Implementations/TftSummonerBootstrapService.cs
@@ -18,6 +18,7 @@ public class TftSummonerBootstrapService(
     ITftSummonerRepository summonerRepository,
     IRefreshLockRepository refreshLockRepository,
     IOptions<MultiRegionIngestionOptions> multiRegionOptions,
+    IRiotRateGate rateGate,
     ILogger<TftSummonerBootstrapService> logger) : ITftSummonerBootstrapService
 {
     private const string RankedTftQueue = "RANKED_TFT";
@@ -53,8 +54,21 @@ public class TftSummonerBootstrapService(
 
         try
         {
+            // Pace each league pull under the per-region Riot budget (shared gate with the LoL vertical),
+            // keyed by the platform's regional route. If the budget stays exhausted past the gate's max wait,
+            // skip seeding this platform this run — it is idempotent and lock-guarded, so a later run retries.
+            var routingKey = platform.ToRegional().ToString();
+
+            if (!await rateGate.AcquireAsync(routingKey, ct))
+                return;
             var challengerLeague = await riotApiContext.Api.TftLeagueV1().GetChallengerLeagueAsync(platform, RankedTftQueue, ct);
+
+            if (!await rateGate.AcquireAsync(routingKey, ct))
+                return;
             var grandmasterLeague = await riotApiContext.Api.TftLeagueV1().GetGrandmasterLeagueAsync(platform, RankedTftQueue, ct);
+
+            if (!await rateGate.AcquireAsync(routingKey, ct))
+                return;
             var masterLeague = await riotApiContext.Api.TftLeagueV1().GetMasterLeagueAsync(platform, RankedTftQueue, ct);
 
             var puuids = challengerLeague.Entries.Select(entry => entry.Puuid)


### PR DESCRIPTION
## What

TFT ingestion bypassed `IRiotRateGate` entirely (zero references under `Services/Tft`). Its Camille limiter has no per-region pacing, so if `RIOT_API_KEY_TFT` is ever low-rate or shares the LoL key, the LoL and TFT verticals could jointly exceed the real per-region quota with no gate — the exact saturation class the LoL side was hardened against.

This routes the TFT Riot HTTP calls through the same singleton gate, mirroring the LoL usage (`MatchService.GetMatchDetailsAsync`, `RiotMatchIdsClient.GetMatchIdsByPuuidAsync`: `await rateGate.AcquireAsync(regionalRoute.ToString(), ct)` before the call, skip-on-rejection).

## Gated call sites

- **`TftMatchIdsClient.GetMatchIdsByPuuidAsync`** — keyed by `regionalRoute.ToString()`; returns `[]` on gate rejection (no new ids this run → caller ends paging; identical to the LoL `RiotMatchIdsClient` contract).
- **`TftMatchService.GetMatchDetailsAsync`** — keyed by `regionalRoute.ToString()`; returns `null` on rejection (caller `continue`s — skip, retried later; identical to LoL `MatchService`).
- **`TftSummonerBootstrapService.SeedPlatformAsync`** — the 3 league pulls (challenger/grandmaster/master) are platform-routed; each acquires a token keyed by `platform.ToRegional().ToString()`, sharing the region budget with that region's match calls. On rejection it returns (seed is idempotent + lock-guarded, so a later run retries).

The gate itself is unchanged. It is a singleton already registered in DI (`ServiceCollectionExtensions` L94); injected via primary-constructor parameters into the three scoped TFT services.

## Verify

- `dotnet build Transcendence.sln -c Debug` — succeeded, 0 errors.
- `dotnet test Transcendence.sln -v minimal` — 172 passed, 0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)