### PR TITLE
Web: add root + segment error.tsx boundaries

### DIFF
--- a/apps/web/app/admin/error.tsx
+++ b/apps/web/app/admin/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { RouteError } from "@/components/RouteError";
+
+export default function Error({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <RouteError
+      title="Admin"
+      message="We couldn't render this admin page."
+      error={error}
+      reset={reset}
+    />
+  );
+}

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { RouteError } from "@/components/RouteError";
+
+export default function Error({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <RouteError
+      title="Something went wrong"
+      message="An unexpected error interrupted this page."
+      error={error}
+      reset={reset}
+    />
+  );
+}

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Bricolage_Grotesque, Hanken_Grotesk, JetBrains_Mono } from "next/font/google";
+
+import "@/app/globals.css";
+import { RouteError } from "@/components/RouteError";
+
+const displayFont = Bricolage_Grotesque({
+  subsets: ["latin"],
+  variable: "--font-display-face",
+  display: "swap"
+});
+
+const bodyFont = Hanken_Grotesk({
+  subsets: ["latin"],
+  variable: "--font-body",
+  display: "swap"
+});
+
+const monoFont = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono-face",
+  display: "swap"
+});
+
+// global-error replaces the root layout, so it must resolve the theme itself to
+// avoid a flash of the wrong palette (mirrors the script in app/layout.tsx).
+const themeScript = `(function(){try{var p=localStorage.getItem("theme");var d=p?p==="dark":window.matchMedia("(prefers-color-scheme: dark)").matches;document.documentElement.classList.toggle("dark",d);document.documentElement.style.colorScheme=d?"dark":"light";}catch(e){}})();`;
+
+export default function GlobalError({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${displayFont.variable} ${bodyFont.variable} ${monoFont.variable}`}
+    >
+      <body className="antialiased">
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+        <main className="mx-auto flex w-full max-w-[1440px] flex-1 flex-col px-4 py-8 md:px-6 md:py-10 lg:px-8">
+          <RouteError
+            title="Something went wrong"
+            message="The application hit an unexpected error and couldn't render."
+            error={error}
+            reset={reset}
+          />
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/lol/error.tsx
+++ b/apps/web/app/lol/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { RouteError } from "@/components/RouteError";
+
+export default function Error({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <RouteError
+      title="League of Legends"
+      message="We couldn't render this League of Legends page."
+      error={error}
+      reset={reset}
+    />
+  );
+}

--- a/apps/web/app/tft/error.tsx
+++ b/apps/web/app/tft/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { RouteError } from "@/components/RouteError";
+
+export default function Error({
+  error,
+  reset
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <RouteError
+      title="Teamfight Tactics"
+      message="We couldn't render this Teamfight Tactics page."
+      error={error}
+      reset={reset}
+    />
+  );
+}

--- a/apps/web/components/RouteError.tsx
+++ b/apps/web/components/RouteError.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { BackendErrorCard } from "@/components/BackendErrorCard";
+import { Button } from "@/components/ui/Button";
+
+export type RouteErrorProps = {
+  /** Heading for the error card (usually the surface or section name). */
+  title?: string;
+  /** Short, user-facing explanation. */
+  message?: string;
+  /** The error thrown during render, forwarded by the Next.js error boundary. */
+  error: Error & { digest?: string };
+  /** Re-render the segment to attempt recovery. */
+  reset: () => void;
+};
+
+/**
+ * Shared, branded fallback for route-level error boundaries. Reuses
+ * {@link BackendErrorCard} and wires the retry action to `reset()`.
+ */
+export function RouteError({
+  title = "Something went wrong",
+  message = "An unexpected error interrupted this page.",
+  error,
+  reset
+}: RouteErrorProps) {
+  useEffect(() => {
+    // Surface the error for client-side logging/telemetry without leaking it
+    // into the rendered UI.
+    console.error(error);
+  }, [error]);
+
+  return (
+    <BackendErrorCard
+      title={title}
+      message={message}
+      hint="You can retry, or reload the page if the problem persists."
+      detail={error.digest ? `Error reference: ${error.digest}` : null}
+    >
+      <Button type="button" onClick={() => reset()}>
+        Try again
+      </Button>
+    </BackendErrorCard>
+  );
+}


### PR DESCRIPTION
## What

`apps/web` had **zero** route-level error boundaries across ~33 pages, so any uncaught render error degraded to Next's default (unbranded) error screen with no recovery path.

This adds the standard Next.js App Router error-boundary files, all reusing the existing branded UI.

## Changes

- **`components/RouteError.tsx`** (new) — shared `"use client"` fallback. Reuses `BackendErrorCard` and wires a "Try again" `Button` to `reset()`. Logs the error via `useEffect(console.error)` and surfaces `error.digest` as a reference in the collapsible details.
- **`app/error.tsx`** — root segment boundary.
- **`app/global-error.tsx`** — replaces the root layout on a layout/root error, so it renders its own `<html>`/`<body>`, font variables, and the FOUC-safe theme-resolution script (mirrors `app/layout.tsx`).
- **`app/lol/error.tsx`, `app/tft/error.tsx`, `app/admin/error.tsx`** — per-surface segment boundaries with surface-specific copy.

All boundaries use the canonical signature `{ error, reset }: { error: Error & { digest?: string }; reset: () => void }`.

## Verify

- `pnpm install --frozen-lockfile` — clean (lockfile unchanged).
- `pnpm --filter web build` — succeeds.
- `pnpm --filter web lint` (eslint `--max-warnings=0`) — passes.

## Risk

Low. Additive only — six new files, no existing files touched. Boundaries only render on otherwise-uncaught errors; existing per-page `BackendErrorCard` returns (e.g. backend fetch failures) are unaffected.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)