### PR TITLE
Analytics: core-grouped builds + TFT comp set cache token

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
@@ -498,6 +498,12 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
     private const double ItemMetadataCoverageFallbackThreshold = 0.90;
     private const int CoreBuildPathSlots = 3;
     private const int MaxBuildPathSlots = 6;
+    // Top builds are grouped on the first N core legendaries rather than the full 6-item set so a
+    // single situational-slot difference does not fragment otherwise-identical builds below the
+    // sample floor. The completed-item set is sorted ascending, so we cannot recover purchase order
+    // here — we use the global-core membership (items appearing in >= CoreItemThreshold of games) as
+    // the core signal, which is the same core notion surfaced by globalCoreItems.
+    private const int BuildGroupingCoreSlots = 4;
     private static readonly IReadOnlyDictionary<int, BuildItemMetadata> EmptyItemMetadata =
         new Dictionary<int, BuildItemMetadata>();
 
@@ -653,7 +659,8 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             .Select(m => new
             {
                 m.Win,
-                ItemKey = string.Join(",", m.Items),
+                // Group on the first N core legendaries, not the full 6-item set (see BuildGroupingKey).
+                ItemKey = BuildGroupingKey(m.Items, globalCoreItems),
                 // Build rune structure
                 RuneInfo = BuildRuneInfo(m.Runes, runeMetadata),
                 Items = m.Items
@@ -678,7 +685,7 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
                 .Select(m => new
                 {
                     m.Win,
-                    ItemKey = string.Join(",", m.Items),
+                    ItemKey = BuildGroupingKey(m.Items, globalCoreItems),
                     RuneInfo = BuildRuneInfo(m.Runes, runeMetadata),
                     Items = m.Items
                 })
@@ -1116,6 +1123,25 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
 
         filtered.Sort();
         return filtered;
+    }
+
+    /// <summary>
+    /// Builds the grouping key for a completed build. Collapses builds that share the same core
+    /// legendaries (the first <see cref="BuildGroupingCoreSlots"/> items that are global-core) so a
+    /// differing situational slot does not fragment the group. Builds with no detectable core items
+    /// fall back to their full item set so they still group by exact match rather than collapsing
+    /// into a single empty-key bucket.
+    /// </summary>
+    private static string BuildGroupingKey(IReadOnlyList<int> sortedBuildItems, IReadOnlyCollection<int> globalCoreItems)
+    {
+        var coreItems = sortedBuildItems
+            .Where(globalCoreItems.Contains)
+            .Take(BuildGroupingCoreSlots)
+            .ToList();
+
+        return coreItems.Count > 0
+            ? string.Join(",", coreItems)
+            : string.Join(",", sortedBuildItems);
     }
 
     private readonly record struct BuildPathParticipantInput(

--- a/Transcendence.Service.Core/Services/Tft/Implementations/TftAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Tft/Implementations/TftAnalyticsService.cs
@@ -26,8 +26,11 @@ public class TftAnalyticsService(
 
     public async Task<IReadOnlyList<TftCompListItemDto>> GetCompListAsync(string? rankTier, string? region, CancellationToken ct = default)
     {
+        // Set token in the key so a TFT set rollover invalidates stale comps immediately instead of
+        // serving them until the 6h cache entry expires.
+        var setToken = await ResolveSetTokenAsync(ct);
         return await cache.GetOrCreateAsync(
-            $"tft:analytics:comps:{NormalizeRankTier(rankTier)}:{NormalizeRegion(region)}",
+            $"tft:analytics:comps:{setToken}:{NormalizeRankTier(rankTier)}:{NormalizeRegion(region)}",
             async cancel => await computeService.ComputeCompListAsync(rankTier, region, cancel),
             CacheOptions,
             tags: ["tft-analytics", "tft-comps"],
@@ -36,12 +39,21 @@ public class TftAnalyticsService(
 
     public async Task<TftCompDetailDto?> GetCompDetailAsync(string compSlug, string? rankTier, string? region, CancellationToken ct = default)
     {
+        var setToken = await ResolveSetTokenAsync(ct);
         return await cache.GetOrCreateAsync(
-            $"tft:analytics:comp:{compSlug}:{NormalizeRankTier(rankTier)}:{NormalizeRegion(region)}",
+            $"tft:analytics:comp:{setToken}:{compSlug}:{NormalizeRankTier(rankTier)}:{NormalizeRegion(region)}",
             async cancel => await computeService.ComputeCompDetailAsync(compSlug, rankTier, region, cancel),
             CacheOptions,
             tags: ["tft-analytics", "tft-comps"],
             cancellationToken: ct);
+    }
+
+    // Active TFT set as a cache-key token. Resolved the same way as the static-data catalogs
+    // (ITftStaticDataService.GetActiveSetNumberAsync); falls back to "set?" when none is active yet.
+    private async Task<string> ResolveSetTokenAsync(CancellationToken ct)
+    {
+        var activeSet = await staticDataService.GetActiveSetNumberAsync(ct);
+        return activeSet is { } set ? $"set{set}" : "set?";
     }
 
     public Task<IReadOnlyList<TftStaticEntityDto>> GetChampionsAsync(CancellationToken ct = default) => staticDataService.GetChampionCatalogAsync(ct);


### PR DESCRIPTION
## P2.7 — Build grouping + TFT comp cache token

Two cache/grouping correctness fixes in the analytics layer.

### GOAL 1 — core-grouped top builds
`ChampionAnalyticsComputeService.ComputeBuildsAsync` grouped the champion "top builds" on the **full sorted 6-item** completed-build key (`string.Join(",", m.Items)`). A single differing situational slot fragmented otherwise-identical builds, splitting their games across buckets and pushing real builds below the build sample floor — producing a noisy or empty top-3.

Now builds are grouped on the first **4** core legendaries via a new `BuildGroupingKey(sortedBuildItems, globalCoreItems)` helper. "Core" reuses the already-computed `globalCoreItems` signal (items appearing in ≥ `CoreItemThreshold` = 70% of games) — the same core notion the response already surfaces. Builds with **no** detectable core fall back to their full item set so they still group by exact match instead of collapsing into one empty-key bucket. The output DTO shape, the `globalCoreItems`/per-build core/situational split, and ordering semantics (`Games * WinRate`, `Take(3)`) are unchanged. Applied to both the primary and the relaxed-floor fallback grouping blocks.

The completed-item list is sorted ascending by item id (`NormalizeCompletedBuildItems`), so true purchase order is unavailable in this aggregation path — global-core membership is the correct in-scope core signal. (The separate timeline-derived `CoreBuildPath`/`SituationalSlots` sections, which *do* have purchase order, are untouched.)

### GOAL 2 — TFT comp set cache token
`TftAnalyticsService` comp / comp-detail `HybridCache` keys carried no set/patch token, so a TFT set rollover served stale comps for up to the 6h entry lifetime. Both keys now prefix the active set, resolved via `ITftStaticDataService.GetActiveSetNumberAsync` (the same path the static-data catalogs use), formatted `set{N}` (or `set?` when none is active yet).

### Verify
- `dotnet build Transcendence.sln -c Debug` — green (pre-existing warnings only)
- `dotnet test Transcendence.sln -v minimal` — 172 passed / 0 failed

No test asserted the old 6-item grouping, so no test changes were required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>