### PR TITLE
Ingestion: bound candidate sub-queries + skip disabled-guardrail MIN scan (P2.5/P2.6)

### DIFF
--- a/Transcendence.Service.Core/Services/Jobs/ChampionAnalyticsIngestionJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/ChampionAnalyticsIngestionJob.cs
@@ -547,7 +547,12 @@ public class ChampionAnalyticsIngestionJob(
             if (region != null)
                 trackedQuery = trackedQuery.Where(x => x.PlatformRegion == region);
 
+            // Bound the high-value sub-queries: only the top `maxCandidates` (most stale) are ever
+            // selected after ranking, so materializing the entire tracked/favorite/high-elo rosters
+            // (which grow unbounded across regions) is pure waste.
             var trackedCandidates = await trackedQuery
+                .OrderBy(x => x.UpdatedAt)
+                .Take(maxCandidates)
                 .ToListAsync(ct);
 
             combined.AddRange(trackedCandidates.Select(x => new CandidateSummoner(
@@ -575,6 +580,8 @@ public class ChampionAnalyticsIngestionJob(
                 query = query.Where(s => s.PlatformRegion == region);
 
             var favoriteCandidates = await query
+                .OrderBy(s => s.UpdatedAt)
+                .Take(maxCandidates)
                 .Select(s => new CandidateSummoner(
                     s.PlatformRegion!,
                     s.GameName!,
@@ -611,6 +618,8 @@ public class ChampionAnalyticsIngestionJob(
                 highEloQuery = highEloQuery.Where(x => x.PlatformRegion == region);
 
             var highEloCandidates = await highEloQuery
+                .OrderBy(x => x.UpdatedAt)
+                .Take(maxCandidates)
                 .Select(x => new
                 {
                     x.PlatformRegion,
@@ -750,7 +759,12 @@ public class ChampionAnalyticsIngestionJob(
     {
         var catchUpWindowKey = RefreshLockKeys.BuildStarvationGuardrailCatchUpKey(producerKey);
         var catchUpCooldownKey = RefreshLockKeys.BuildStarvationGuardrailCooldownKey(producerKey);
-        var maxDeferAgeMinutes = await EstimateMaxEligibleDeferAgeMinutesAsync(region, evaluationUtc, ct);
+        // Skip the full MIN(UpdatedAt) scan over Summoners when the guardrail is disabled — its
+        // Evaluate() returns Disabled without using the value, so the scan would be pure wasted
+        // load (per region × per producer × heartbeat).
+        var maxDeferAgeMinutes = starvationGuardrailPolicy.Enabled
+            ? await EstimateMaxEligibleDeferAgeMinutesAsync(region, evaluationUtc, ct)
+            : (double?)null;
         var telemetrySource = region != null ? $"{TelemetrySource}:{region}" : TelemetrySource;
 
         var catchUpWindowState = await refreshLockRepository.GetAsync(catchUpWindowKey, ct);

--- a/Transcendence.Service.Core/Services/Jobs/Priority/IStarvationGuardrailPolicy.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Priority/IStarvationGuardrailPolicy.cs
@@ -31,5 +31,9 @@ public enum StarvationGuardrailOutcome
 
 public interface IStarvationGuardrailPolicy
 {
+    /// <summary>Whether the guardrail is enabled. When false, callers can skip computing its
+    /// (expensive) inputs since Evaluate returns Disabled regardless of them.</summary>
+    bool Enabled { get; }
+
     StarvationGuardrailDecision Evaluate(StarvationGuardrailInput input);
 }

--- a/Transcendence.Service.Core/Services/Jobs/Priority/StarvationGuardrailPolicy.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Priority/StarvationGuardrailPolicy.cs
@@ -5,6 +5,8 @@ namespace Transcendence.Service.Core.Services.Jobs.Priority;
 
 public class StarvationGuardrailPolicy(IOptions<StarvationGuardrailOptions> options) : IStarvationGuardrailPolicy
 {
+    public bool Enabled => options.Value.Enabled;
+
     public StarvationGuardrailDecision Evaluate(StarvationGuardrailInput input)
     {
         var config = options.Value;

--- a/Transcendence.Service.Core/Services/Jobs/SummonerMaintenanceJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/SummonerMaintenanceJob.cs
@@ -500,7 +500,12 @@ public class SummonerMaintenanceJob(
             if (region != null)
                 trackedQuery = trackedQuery.Where(x => x.PlatformRegion == region);
 
-            var trackedHighValueCandidates = await trackedQuery.ToListAsync(ct);
+            // Bound the high-value sub-queries: only the top `maxCandidates` (most stale) are ever
+            // selected after ranking, so materializing whole rosters across regions is pure waste.
+            var trackedHighValueCandidates = await trackedQuery
+                .OrderBy(x => x.UpdatedAt)
+                .Take(maxCandidates)
+                .ToListAsync(ct);
 
             combined.AddRange(trackedHighValueCandidates.Select(x => new CandidateSummoner(
                 x.PlatformRegion!,
@@ -528,6 +533,8 @@ public class SummonerMaintenanceJob(
                 query = query.Where(s => s.PlatformRegion == region);
 
             var favoriteCandidates = await query
+                .OrderBy(s => s.UpdatedAt)
+                .Take(maxCandidates)
                 .Select(s => new CandidateSummoner(
                     s.PlatformRegion!,
                     s.GameName!,
@@ -564,7 +571,10 @@ public class SummonerMaintenanceJob(
             if (region != null)
                 highEloQuery = highEloQuery.Where(x => x.PlatformRegion == region);
 
-            var highEloCandidates = await highEloQuery.ToListAsync(ct);
+            var highEloCandidates = await highEloQuery
+                .OrderBy(x => x.UpdatedAt)
+                .Take(maxCandidates)
+                .ToListAsync(ct);
 
             combined.AddRange(highEloCandidates.Select(x => new CandidateSummoner(
                 x.PlatformRegion!,


### PR DESCRIPTION
## What
Cuts per-heartbeat DB load in both discovery producers.

**P2.5** — `tracked` / `favorite` / `high-elo` candidate sub-queries materialized entire Master+ rosters across all regions (`ToListAsync`, no bound) to feed a ranker that keeps only the top `maxCandidates`. Added `OrderBy(UpdatedAt).Take(maxCandidates)` to all three in both `ChampionAnalyticsIngestionJob` and `SummonerMaintenanceJob` (only the fallback was bounded before). **No change to the selected set** — `RankCandidates` already caps to `maxCandidates`.

**P2.6 (part 1)** — each run ran a full `MIN(UpdatedAt)` scan over Summoners to feed the starvation guardrail, which is **disabled** in prod and ignores the value. Added `IStarvationGuardrailPolicy.Enabled` and skip the scan when disabled.

## Verification
`dotnet build` clean; **172 backend tests pass** (ramp / maintenance / cancellation tests construct both producers + the real guardrail policy).

## Deploy note
Touches the hot ingestion producers (worker). I'll verify post-deploy: heartbeat fresh, ranked-head completions continuing, no errors. P2.6 part 2 (aggregate memoization) tracked as **P2.6b**.

Roadmap **P2.5 + P2.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)