### PR TITLE
Observability: OpenTelemetry metrics → Prometheus (P3.1)

### DIFF
--- a/Transcendence.Service.Core/Services/RiotApi/RiotRateGate.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/RiotRateGate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using Transcendence.Service.Core.Services.Jobs.Configuration;
 
@@ -21,18 +22,23 @@ public interface IRiotRateGate
 /// timer at the sustained rate. Each region's bucket is independent, so the regions' budgets are used in
 /// parallel. Registered as a singleton; injected into the Riot client wrappers.
 /// </summary>
-public sealed class RiotRateGate(IOptions<RiotRateGateOptions> options) : IRiotRateGate, IDisposable
+public sealed class RiotRateGate(
+    IOptions<RiotRateGateOptions> options,
+    RiotRateGateTelemetry? telemetry = null) : IRiotRateGate, IDisposable
 {
     private readonly RiotRateGateOptions _options = options.Value;
     private readonly ConcurrentDictionary<string, Bucket> _buckets = new(StringComparer.OrdinalIgnoreCase);
 
-    public Task<bool> AcquireAsync(string routingKey, CancellationToken ct = default)
+    public async Task<bool> AcquireAsync(string routingKey, CancellationToken ct = default)
     {
         if (!_options.Enabled)
-            return Task.FromResult(true);
+            return true;
 
         var key = string.IsNullOrWhiteSpace(routingKey) ? "default" : routingKey.Trim().ToUpperInvariant();
-        return _buckets.GetOrAdd(key, _ => new Bucket(_options)).AcquireAsync(ct);
+        var startTimestamp = telemetry is null ? 0 : Stopwatch.GetTimestamp();
+        var acquired = await _buckets.GetOrAdd(key, _ => new Bucket(_options)).AcquireAsync(ct);
+        telemetry?.RecordAcquire(key, acquired, Stopwatch.GetElapsedTime(startTimestamp).TotalSeconds);
+        return acquired;
     }
 
     public void Dispose()

--- a/Transcendence.Service.Core/Services/RiotApi/RiotRateGateTelemetry.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/RiotRateGateTelemetry.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.Metrics;
+
+namespace Transcendence.Service.Core.Services.RiotApi;
+
+/// <summary>
+/// Metrics for the <see cref="RiotRateGate"/> — the central per-region pacing constraint against the
+/// low-rate Riot key. A "rejected" acquisition means a region's budget stayed exhausted past the gate's
+/// max wait, which is the exact saturation signal that preceded the historical ingestion stall.
+/// Registered as a singleton in the worker; the gate records to it when enabled.
+/// </summary>
+public sealed class RiotRateGateTelemetry : IDisposable
+{
+    public const string MeterName = "Transcendence.RiotRateGate";
+
+    private readonly Meter _meter;
+    private readonly Counter<long> _acquisitions;
+    private readonly Histogram<double> _waitSeconds;
+
+    public RiotRateGateTelemetry()
+    {
+        _meter = new Meter(MeterName);
+        _acquisitions = _meter.CreateCounter<long>(
+            "transcendence.riot_rate_gate.acquisitions",
+            unit: "{acquisition}",
+            description: "Rate-gate token acquisition attempts, tagged by region and outcome (acquired|rejected).");
+        _waitSeconds = _meter.CreateHistogram<double>(
+            "transcendence.riot_rate_gate.wait",
+            unit: "s",
+            description: "Time spent waiting for a rate-gate token, tagged by region.");
+    }
+
+    public void RecordAcquire(string region, bool acquired, double waitSeconds)
+    {
+        _acquisitions.Add(
+            1,
+            new KeyValuePair<string, object?>("region", region),
+            new KeyValuePair<string, object?>("outcome", acquired ? "acquired" : "rejected"));
+        _waitSeconds.Record(waitSeconds, new KeyValuePair<string, object?>("region", region));
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/Transcendence.Service/Program.cs
+++ b/Transcendence.Service/Program.cs
@@ -6,6 +6,9 @@ using Transcendence.Data;
 using Transcendence.Data.Extensions;
 using Transcendence.Service.Core.Services.Analytics.Models;
 using Transcendence.Service.Core.Services.Diagnostics;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using Transcendence.Service.Core.Services.Extensions;
 using Transcendence.Service.Core.Services.Jobs;
 using Transcendence.Service.Core.Services.Jobs.Configuration;
@@ -159,6 +162,26 @@ builder.Services.AddHostedService<WorkerWatchdogService>();
 // stall). Posts to Alerts:Webhook:Url; logs only when unset, so this ships without a secret.
 builder.Services.Configure<AlertOptions>(builder.Configuration.GetSection("Alerts"));
 builder.Services.AddSingleton<IAlertNotifier, WebhookAlertNotifier>();
+
+// Worker metrics → Prometheus via a standalone HttpListener on :9464 (the worker has no HTTP server).
+// Exports the ingestion-throughput + refresh-lock meters, the rate-gate telemetry, plus .NET runtime
+// (GC / thread pool), outbound HTTP (Riot API), and HybridCache instrumentation. Gated so a
+// listener/binding problem can be disabled via env (Telemetry__Enabled=false) without a rollback.
+if (builder.Configuration.GetValue("Telemetry:Enabled", true))
+{
+    var metricsPort = builder.Configuration.GetValue("Telemetry:PrometheusPort", 9464);
+    builder.Services.AddSingleton<Transcendence.Service.Core.Services.RiotApi.RiotRateGateTelemetry>();
+    builder.Services.AddOpenTelemetry()
+        .ConfigureResource(resource => resource.AddService("transcendence-worker"))
+        .WithMetrics(metrics => metrics
+            .AddMeter("Transcendence.IngestionThroughput")
+            .AddMeter("Transcendence.RefreshLocks")
+            .AddMeter(Transcendence.Service.Core.Services.RiotApi.RiotRateGateTelemetry.MeterName)
+            .AddMeter("Microsoft.Extensions.Caching.Hybrid")
+            .AddRuntimeInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddPrometheusHttpListener(o => o.UriPrefixes = new[] { $"http://+:{metricsPort}/" }));
+}
 
 // worker that initiates services
 if (builder.Environment.IsDevelopment())

--- a/Transcendence.Service/Transcendence.Service.csproj
+++ b/Transcendence.Service/Transcendence.Service.csproj
@@ -21,6 +21,10 @@
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.2" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.HttpListener" Version="1.16.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
         <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
     </ItemGroup>
 

--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.HttpOverrides;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using StackExchange.Redis;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration.Json;
@@ -157,6 +160,17 @@ if (!string.IsNullOrWhiteSpace(builder.Configuration.GetConnectionString("Redis"
 }
 
 builder.Services.AddHttpClient();
+
+// Metrics → Prometheus, scraped at /metrics. Exports ASP.NET request, outbound HTTP, .NET runtime
+// (GC / thread pool), and HybridCache instrumentation for the read API.
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("transcendence-webapi"))
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddRuntimeInstrumentation()
+        .AddMeter("Microsoft.Extensions.Caching.Hybrid")
+        .AddPrometheusExporter());
 
 // Configure Redis distributed cache
 builder.Services.AddStackExchangeRedisCache(options =>
@@ -317,6 +331,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapPrometheusScrapingEndpoint(); // Prometheus scrape at /metrics (internal network only)
 // Liveness: process is up and can serve HTTP — no dependency checks run.
 app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = _ => false });
 // Readiness: dependencies (PostgreSQL, Redis) reachable — gates traffic / deploy readiness.

--- a/Transcendence.WebAPI/Transcendence.WebAPI.csproj
+++ b/Transcendence.WebAPI/Transcendence.WebAPI.csproj
@@ -14,6 +14,11 @@
         <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.2" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
         <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.1" />
         <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />

--- a/compose.yml
+++ b/compose.yml
@@ -148,11 +148,28 @@ services:
     networks:
       - transcendence-net
 
+  prometheus:
+    image: prom/prometheus:v3.1.0
+    container_name: transcendence-prometheus
+    restart: unless-stopped
+    profiles: ["ops-tools"]
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.retention.time=15d"
+    volumes:
+      - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    networks:
+      - transcendence-net
+
 volumes:
   postgres_data:
   redis_data:
   pgadmin_data:
   operational_logs:
+  prometheus_data:
 
 networks:
   transcendence-net:

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,0 +1,23 @@
+# Prometheus scrape config for the Transcendence stack.
+# Targets use compose service names, resolved over the `transcendence-net` Docker network — so this
+# same file works locally (repo compose) and in prod (Portainer stack), which share those names.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # WebAPI exposes /metrics via the ASP.NET Core Prometheus exporter.
+  - job_name: transcendence-webapi
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["webapi:8080"]
+
+  # The worker has no HTTP server, so it exposes /metrics via a standalone Prometheus HttpListener.
+  - job_name: transcendence-worker
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["service:9464"]


### PR DESCRIPTION
## What
Wires OpenTelemetry metrics with a Prometheus exporter on both hosts (the meters were dead — defined but unexported).

- **WebAPI** → `/metrics` (ASP.NET Core Prometheus exporter): ASP.NET request, outbound HTTP, .NET runtime (GC/thread-pool), HybridCache.
- **Worker** → `:9464/metrics` (standalone HttpListener, since it has no web server): the existing `IngestionThroughput` + `RefreshLocks` meters, a **new `RiotRateGateTelemetry`** (acquisitions/**rejections** + wait per region — rejection = the saturation signal behind the historical stall), runtime, HTTP (Riot API), HybridCache. Gated by `Telemetry:Enabled` (default true) — env escape hatch.
- **Prometheus container** (`ops-tools` profile) + `config/prometheus/prometheus.yml` scraping both.

## Verification
`dotnet build` clean; **172 tests pass**; `pnpm api:check` boots the WebAPI with `/metrics` and the OpenAPI contract is unchanged. The worker's `:9464` listener can't be boot-tested without Docker — verified on deploy; if it misbehaves, `Telemetry__Enabled=false` disables it without a rollback.

## Deploy
Rebuilds webapi+service. After the `/metrics` endpoints verify on prod, I'll add the Prometheus container to the Portainer stack (it doesn't auto-deploy from the repo compose).

Roadmap **P3.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)