### PR TITLE
Ingestion: select working set by LastActiveAtUtc (skip never-active stubs)

### DIFF
--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -116,6 +116,14 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             .HasIndex(s => new { s.PlatformRegion, s.UpdatedAt })
             .HasDatabaseName("IX_Summoners_Region_UpdatedAt");
 
+        // Partial index over only ACTIVE summoners (LastActiveAtUtc set), supporting activity-aware
+        // candidate selection (PreferActiveSummoners): WHERE PlatformRegion=@r AND LastActiveAtUtc IS
+        // NOT NULL ORDER BY UpdatedAt. Excludes the large inert tail, so the ordered scan never pages
+        // through the MinValue stubs. NOTE: built with CREATE INDEX CONCURRENTLY out-of-band in prod.
+        modelBuilder.Entity<Summoner>()
+            .HasIndex(s => new { s.PlatformRegion, s.UpdatedAt }, "IX_Summoners_Region_UpdatedAt_Active")
+            .HasFilter("\"LastActiveAtUtc\" IS NOT NULL");
+
         // Global query filter to exclude unfetchable matches from normal queries
         modelBuilder.Entity<Match>()
             .HasQueryFilter(m => m.Status != FetchStatus.PermanentlyUnfetchable);

--- a/Transcendence.Service.Core/Services/Jobs/ChampionAnalyticsIngestionJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/ChampionAnalyticsIngestionJob.cs
@@ -649,6 +649,12 @@ public class ChampionAnalyticsIngestionJob(
             if (region != null)
                 fallbackQuery = fallbackQuery.Where(s => s.PlatformRegion == region);
 
+            // Activity selection: skip the inert tail (summoners never seen active — the ~4.1M
+            // MinValue stubs) so the producer refreshes recently-active players instead of paging the
+            // stubs oldest-first. Backed by the IX_Summoners_Region_UpdatedAt_Active partial index.
+            if (multiRegionOptions.Value.PreferActiveSummoners)
+                fallbackQuery = fallbackQuery.Where(s => s.LastActiveAtUtc != null);
+
             var fallbackCandidates = await fallbackQuery
                 .OrderBy(s => s.UpdatedAt)
                 .Take(maxCandidates * 3)

--- a/Transcendence.Service.Core/Services/Jobs/Configuration/MultiRegionIngestionOptions.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Configuration/MultiRegionIngestionOptions.cs
@@ -3,6 +3,16 @@ namespace Transcendence.Service.Core.Services.Jobs.Configuration;
 public class MultiRegionIngestionOptions
 {
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// When true, the discovery producers' fallback candidate selection skips summoners never seen
+    /// active (LastActiveAtUtc is null — the large inert tail of MinValue stubs), refreshing
+    /// recently-active players instead of paging the stubs oldest-first by UpdatedAt. Backed by the
+    /// partial index IX_Summoners_Region_UpdatedAt_Active. Disable with
+    /// Jobs__MultiRegionIngestion__PreferActiveSummoners=false.
+    /// </summary>
+    public bool PreferActiveSummoners { get; set; } = true;
+
     public int MaxConcurrentRegionBootstraps { get; set; } = 3;
     public int HighEloRefreshIntervalHours { get; set; } = 12;
     public List<RegionConfig> Regions { get; set; } = [];

--- a/Transcendence.Service.Core/Services/Jobs/SummonerMaintenanceJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/SummonerMaintenanceJob.cs
@@ -594,6 +594,10 @@ public class SummonerMaintenanceJob(
         if (region != null)
             trackedSummonerQuery = trackedSummonerQuery.Where(s => s.PlatformRegion == region);
 
+        // Activity selection: skip the inert tail so maintenance refreshes recently-active players.
+        if (multiRegionOptions.Value.PreferActiveSummoners)
+            trackedSummonerQuery = trackedSummonerQuery.Where(s => s.LastActiveAtUtc != null);
+
         var trackedCandidates = await trackedSummonerQuery
             .OrderBy(s => s.UpdatedAt)
             .Take(maxCandidates * 3)

--- a/Transcendence.Service/Migrations/20260620055903_AddSummonerActivityIndex.Designer.cs
+++ b/Transcendence.Service/Migrations/20260620055903_AddSummonerActivityIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260620055903_AddSummonerActivityIndex")]
+    partial class AddSummonerActivityIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260620055903_AddSummonerActivityIndex.cs
+++ b/Transcendence.Service/Migrations/20260620055903_AddSummonerActivityIndex.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSummonerActivityIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Hot table (Summoners, ~4M rows, continuously written by ingestion). Build the partial
+            // index CONCURRENTLY so it does not hold a write-blocking SHARE lock for the full build.
+            // CONCURRENTLY cannot run inside a transaction, hence suppressTransaction. (Raw SQL because
+            // EF's CreateIndex emits a locking plain CREATE INDEX — see docs/DEVELOPMENT.md "Applying
+            // index migrations to hot tables".) Snapshot/model carry the index via the named HasIndex.
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_Summoners_Region_UpdatedAt_Active\" " +
+                "ON \"Summoners\" (\"PlatformRegion\", \"UpdatedAt\") WHERE \"LastActiveAtUtc\" IS NOT NULL;",
+                suppressTransaction: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_Summoners_Region_UpdatedAt_Active\";",
+                suppressTransaction: true);
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsIngestionJobRampTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsIngestionJobRampTests.cs
@@ -156,6 +156,39 @@ public class ChampionAnalyticsIngestionJobRampTests
     }
 
     [Fact]
+    public async Task ExecuteForRegionAsync_WhenPreferActiveSummoners_SkipsNeverActiveCandidatesInFavorOfActiveOnes()
+    {
+        var fixedBudgetPolicy = new FixedAdaptiveBudgetPolicy(new AdaptiveThroughputBudgetDecision(
+            AdaptiveThroughputBudgetMode.Balanced,
+            MaxCandidates: 10,
+            QueueTarget: 1,
+            IncludeAllModes: false,
+            CoverageRatio: 0.2d,
+            BacklogAgeMinutes: 120d,
+            RecentVelocityPerHour: 2d,
+            CandidatePressureRatio: 2d));
+
+        await using var harness = await Harness.CreateAsync(fixedBudgetPolicy);
+        harness.SeedActivePatch("15.2", DateTime.UtcNow.AddHours(-2));
+        // The never-active stub is the stalest candidate (would win on staleness scoring) yet must
+        // be skipped, in favour of the active summoner that was refreshed far more recently.
+        harness.SeedInactiveSummoner("NeverActiveStub", "NA1", DateTime.UtcNow.AddHours(-72));
+        harness.SeedSummoner("ActivePlayer", "NA1", DateTime.UtcNow.AddHours(-6));
+        await harness.Db.SaveChangesAsync();
+
+        var queuedJobs = new List<Job>();
+        harness.BackgroundJobClient
+            .Setup(x => x.Create(It.IsAny<Job>(), It.IsAny<IState>()))
+            .Callback<Job, IState>((job, _) => queuedJobs.Add(job))
+            .Returns("job-1");
+
+        await harness.Job.ExecuteForRegionAsync("NA1", CancellationToken.None);
+
+        queuedJobs.Should().ContainSingle();
+        queuedJobs[0].Args[0].Should().Be("ActivePlayer");
+    }
+
+    [Fact]
     public async Task ExecuteForRegionAsync_WhenApiPriorityIsActive_AllowsProgressDuringForcedCatchUpWindow()
     {
         var fixedBudgetPolicy = new FixedAdaptiveBudgetPolicy(new AdaptiveThroughputBudgetDecision(
@@ -507,7 +540,32 @@ public class ChampionAnalyticsIngestionJobRampTests
                 GameNameNormalized = gameName.ToUpperInvariant(),
                 TagLineNormalized = tagLine.ToUpperInvariant(),
                 SummonerLevel = 100,
-                UpdatedAt = updatedAtUtc
+                UpdatedAt = updatedAtUtc,
+                LastActiveAtUtc = updatedAtUtc
+            });
+        }
+
+        // Seeds a summoner that has never been seen active (LastActiveAtUtc == null) — the case the
+        // PreferActiveSummoners filter is meant to skip (stub rows from snowball discovery).
+        public void SeedInactiveSummoner(
+            string gameName,
+            string tagLine,
+            DateTime updatedAtUtc,
+            string platformRegion = "NA1")
+        {
+            Db.Summoners.Add(new Summoner
+            {
+                Id = Guid.NewGuid(),
+                PlatformRegion = platformRegion,
+                Region = platformRegion is "EUW1" or "EUN1" ? "europe" : platformRegion is "KR" ? "asia" : "americas",
+                Puuid = $"puuid-{Guid.NewGuid():N}",
+                GameName = gameName,
+                TagLine = tagLine,
+                GameNameNormalized = gameName.ToUpperInvariant(),
+                TagLineNormalized = tagLine.ToUpperInvariant(),
+                SummonerLevel = 100,
+                UpdatedAt = updatedAtUtc,
+                LastActiveAtUtc = null
             });
         }
 
@@ -524,7 +582,8 @@ public class ChampionAnalyticsIngestionJobRampTests
                 GameNameNormalized = gameName.ToUpperInvariant(),
                 TagLineNormalized = tagLine.ToUpperInvariant(),
                 SummonerLevel = 100,
-                UpdatedAt = DateTime.UtcNow.AddHours(-10)
+                UpdatedAt = DateTime.UtcNow.AddHours(-10),
+                LastActiveAtUtc = DateTime.UtcNow.AddHours(-10)
             });
         }
 

--- a/tests/Transcendence.Service.Core.Tests/SummonerMaintenanceJobTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerMaintenanceJobTests.cs
@@ -389,7 +389,11 @@ public class SummonerMaintenanceJobTests
                 GameNameNormalized = gameName.ToUpperInvariant(),
                 TagLineNormalized = tagLine.ToUpperInvariant(),
                 SummonerLevel = 100,
-                UpdatedAt = updatedAtUtc
+                UpdatedAt = updatedAtUtc,
+                // Seeded summoners represent real tracked players, which in production carry a
+                // LastActiveAtUtc stamp (written by MatchService on detail ingest). Default them
+                // active so the activity filter (PreferActiveSummoners) keeps selecting them.
+                LastActiveAtUtc = updatedAtUtc
             });
         }
 


### PR DESCRIPTION
## What
Both ingestion candidate producers — `ChampionAnalyticsIngestionJob` (fallback roster) and `SummonerMaintenanceJob` (tracked roster) — previously scanned **all** `Summoners`, including the millions of never-active stub rows that snowball discovery inserts with a `MinValue`/null `LastActiveAtUtc`. Those stubs perpetually win staleness scoring yet yield no matches, starving real active players of refresh budget.

## Change
- New option `MultiRegionIngestion.PreferActiveSummoners` (**default on**). Both producers add `.Where(s => s.LastActiveAtUtc != null)` when set.
- Partial index `IX_Summoners_Region_UpdatedAt_Active` on `(PlatformRegion, UpdatedAt) WHERE LastActiveAtUtc IS NOT NULL`, applied **`CREATE INDEX CONCURRENTLY`** out-of-band on the ~4M-row hot `Summoners` table (raw-SQL migration, `suppressTransaction`). Snapshot carries it via a **named** `HasIndex` overload so the existing `IX_Summoners_Region_UpdatedAt` is preserved.
- **Escape hatch:** `Jobs__MultiRegionIngestion__PreferActiveSummoners=false`.

## Tests
- Seeded summoners now default **active** (`LastActiveAtUtc = UpdatedAt`) — realistic, since `MatchService` stamps `LastActiveAtUtc` on detail ingest in prod.
- New contrastive test: the **stalest never-active stub** is skipped in favour of a more-recently-refreshed **active** summoner, proving the filter overrides staleness scoring.
- Full suite green (139 Service.Core + 34 WebAPI); drift clean; migration-safety lint passes (raw-SQL `CONCURRENTLY`, no `CreateIndex(`).

## Prod rollout
The migration is `CONCURRENTLY` (NOT auto-applied — prod has no auto-migrate). The index is applied out-of-band on prod and recorded in `__EFMigrationsHistory` before the worker rolls out; the flag default-on then takes effect on deploy. Watched on the Ingestion & Rate-Gate Grafana dashboard post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)