### PR TITLE
CI: single-arch manifests (provenance off) so wud auto-deploys :main

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -56,6 +56,7 @@ jobs:
               - 'global.json'
               - 'Transcendence.sln'
               - 'Transcendence.WebAPI/Dockerfile'
+              - '.github/workflows/docker-images.yml'
             service:
               - 'Transcendence.Service/**'
               - 'Transcendence.Service.Core/**'
@@ -63,6 +64,7 @@ jobs:
               - 'global.json'
               - 'Transcendence.sln'
               - 'Transcendence.Service/Dockerfile'
+              - '.github/workflows/docker-images.yml'
             web:
               - 'apps/web/**'
               - 'openapi/**'
@@ -72,6 +74,7 @@ jobs:
               - 'pnpm-workspace.yaml'
               - '.nvmrc'
               - 'apps/web/Dockerfile'
+              - '.github/workflows/docker-images.yml'
 
       - name: Plan component build
         id: plan
@@ -151,6 +154,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ${{ matrix.dockerfile }}
+          # Publish a plain single-arch manifest, NOT an OCI image index. Buildx defaults
+          # provenance/SBOM attestations ON, which wraps even a single-platform image in an
+          # index with an `unknown/unknown` attestation sub-manifest. That breaks wud's
+          # local-vs-remote digest comparison on the moving `:main` tag (it resolves the new
+          # remote digest correctly but reports updateAvailable=false), so pushes silently
+          # fail to auto-deploy and require a manual `compose up`. See docs + task P1.3b.
+          provenance: false
+          sbom: false
 
       - name: Sign the published Docker image
         if: steps.plan.outputs.run == 'true' && github.event_name != 'pull_request'


### PR DESCRIPTION
## Problem
wud silently stopped auto-deploying `:main` pushes — P4.1 (#62) had to be recreated by hand (`docker compose up`). wud's API for `transcendence-service` showed it **resolved the new remote digest correctly** (`digest.value=aa2b0c55 != digest.repo=e956f2a4`) yet reported **`updateAvailable: false`**.

## Root cause
`docker/build-push-action` runs under buildx with **provenance + SBOM attestations ON by default**. That wraps even a single-platform image in an **OCI image index** plus an `unknown/unknown` attestation sub-manifest (confirmed: `:main` is `vnd.oci.image.index.v1+json`). The index breaks wud's local-vs-remote digest comparison on the moving `:main` tag, so a new push never flags an update and never recreates the container.

## Fix
- `provenance: false` + `sbom: false` → publish a **plain single-arch manifest**. Keyless cosign signing of the pushed digest is unaffected.
- Add `.github/workflows/docker-images.yml` to each component's path filter so a build-config change rebuilds the images (it should).

## Self-validating
Because of the path-filter change, **this PR rebuilds all three images** as clean manifests on merge. Success criterion: wud auto-recreates `web`/`webapi`/`service` onto the new revision **with no manual `compose up`**. I'll verify the worker revision flips on its own; if the index→manifest transition needs one nudge, I'll recreate once and steady-state is then clean-vs-clean.

Closes the investigation in task P1.3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)