### PR TITLE
ops: pull-based prod deploy (poll-deploy.sh) — reliable replacement for wud

### DIFF
--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -1,0 +1,49 @@
+# Ops scripts
+
+## `poll-deploy.sh` — pull-based prod deploy (replaces wud)
+
+Prod is a single Docker host on a private LAN with no public SSH and no tunnel, so a
+cloud GitHub runner cannot push a deploy to it. The intended auto-updater, **wud**
+(what's-up-docker), silently fails to detect new `:main` digests for these ghcr
+packages — wud 8.2.2 (the latest release) reports `updateAvailable=false` even when
+the registry digest has changed, so pushes never auto-deployed and each release had to
+be recreated by hand (see task **P1.3b**).
+
+`poll-deploy.sh` replaces wud for the three app services (`web`, `webapi`, `service`)
+with a deterministic, **outbound-only** digest poll:
+
+1. Resolve the current `:main` manifest digest from ghcr with an anonymous pull token
+   (the packages are public).
+2. Compare it to the digest the running container was pulled at.
+3. If they differ, `docker compose pull` + `up -d --no-deps <svc>` (postgres/redis are
+   never touched), then post a Discord notification via `ALERTS_WEBHOOK_URL`.
+
+No inbound exposure, no CI secret, no self-hosted runner. A `flock` guard prevents
+overlapping runs. Runs every ~60s via the systemd timer (≈ wud's old cadence).
+
+### Install (on prod, as root)
+
+```bash
+# from a checkout / scp of scripts/ops/
+install -D -m 0755 poll-deploy.sh /root/deploy/poll-deploy.sh
+install -D -m 0644 transcendence-deploy.service /etc/systemd/system/transcendence-deploy.service
+install -D -m 0644 transcendence-deploy.timer   /etc/systemd/system/transcendence-deploy.timer
+systemctl daemon-reload
+systemctl enable --now transcendence-deploy.timer
+```
+
+### Operate
+
+```bash
+systemctl list-timers transcendence-deploy.timer   # next/last run
+journalctl -u transcendence-deploy.service -n 50   # deploy history
+/root/deploy/poll-deploy.sh                         # force a poll now
+systemctl disable --now transcendence-deploy.timer  # pause auto-deploy (e.g. during an incident)
+```
+
+Rollback is unchanged: pin a service to an immutable `:sha-<short>` tag in the compose
+file and `compose up -d` it (see `docs/ARCHITECTURE.md` "Deployment & rollback").
+
+> If wud's app-container watching is ever wanted back, note it is unreliable here; this
+> poller is the source of truth. wud still works fine for the public Docker Hub
+> sidecars (portainer/dozzle/grafana/prometheus).

--- a/scripts/ops/poll-deploy.sh
+++ b/scripts/ops/poll-deploy.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# poll-deploy.sh — deterministic pull-based deploy for the Transcendence prod stack.
+#
+# WHY THIS EXISTS
+#   Prod is a single Docker host on a private LAN (no public SSH, no tunnel), so a
+#   cloud GitHub runner cannot push a deploy to it. wud (what's-up-docker) was meant
+#   to auto-pull `:main`, but wud 8.2.2 silently fails to resolve the ghcr manifest
+#   digest for these packages (reports updateAvailable=false even when the registry
+#   digest changed), so pushes never auto-deployed. See task P1.3b.
+#
+#   This script replaces wud for the three app services with a dead-simple, reliable
+#   digest poll: it is OUTBOUND-ONLY (prod -> ghcr), needs no inbound exposure, no CI
+#   secret, and no self-hosted runner. Run it every ~60s via the systemd timer
+#   (scripts/ops/transcendence-deploy.timer).
+#
+# WHAT IT DOES
+#   For each app service, resolve the current `:main` manifest digest from ghcr
+#   (anonymous token — the packages are public) and compare it to the digest the
+#   running container was pulled at. If they differ, `compose pull` + `up -d` just
+#   that service (--no-deps, so postgres/redis are never touched), then optionally
+#   post a Discord notification.
+#
+# INSTALL (on prod, as root):
+#   install -D -m 0755 poll-deploy.sh /root/deploy/poll-deploy.sh
+#   install -D -m 0644 transcendence-deploy.service /etc/systemd/system/transcendence-deploy.service
+#   install -D -m 0644 transcendence-deploy.timer   /etc/systemd/system/transcendence-deploy.timer
+#   systemctl daemon-reload && systemctl enable --now transcendence-deploy.timer
+#
+set -uo pipefail
+
+REGISTRY_HOST="ghcr.io"
+OWNER="luisgon-dev"
+COMPOSE_DIR="/var/lib/docker/volumes/portainer_data/_data/compose/2"
+COMPOSE_PROJECT="transcendence"
+ENV_FILE="${COMPOSE_DIR}/stack.env"
+COMPOSE_FILE="${COMPOSE_DIR}/docker-compose.yml"
+LOCK_FILE="/run/transcendence-deploy.lock"
+
+# service (compose) : container name : ghcr image repo
+SERVICES=(
+  "web:transcendence-web:transcendence-web"
+  "webapi:transcendence-webapi:transcendence-webapi"
+  "service:transcendence-service:transcendence-service"
+)
+
+log() { printf '%s poll-deploy: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+
+# Resolve the remote :main manifest digest via an anonymous ghcr pull token.
+remote_digest() {
+  local repo="$1" tok
+  tok="$(curl -fsSL --max-time 20 \
+        "https://${REGISTRY_HOST}/token?scope=repository:${OWNER}/${repo}:pull&service=${REGISTRY_HOST}" \
+        2>/dev/null | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  [ -z "$tok" ] && return 1
+  curl -fsSL -I --max-time 20 \
+    -H "Authorization: Bearer ${tok}" \
+    -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+    -H "Accept: application/vnd.oci.image.index.v1+json" \
+    -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+    "https://${REGISTRY_HOST}/v2/${OWNER}/${repo}/manifests/main" 2>/dev/null \
+    | tr -d '\r' | sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest: //p' | head -1
+}
+
+# The manifest digest the running container's image was pulled at.
+local_digest() {
+  local container="$1" image_id
+  image_id="$(docker inspect "$container" --format '{{.Image}}' 2>/dev/null)" || return 1
+  [ -z "$image_id" ] && return 1
+  docker image inspect "$image_id" --format '{{range .RepoDigests}}{{println .}}{{end}}' 2>/dev/null \
+    | sed -n "s#^${REGISTRY_HOST}/${OWNER}/[^@]*@##p" | head -1
+}
+
+notify() {
+  local msg="$1" url
+  url="$(sed -n 's/^ALERTS_WEBHOOK_URL=//p' "$ENV_FILE" 2>/dev/null | head -1)"
+  [ -z "$url" ] && return 0
+  curl -fsS --max-time 15 -H 'Content-Type: application/json' \
+    -d "$(printf '{"content":"%s"}' "$msg")" "$url" >/dev/null 2>&1 || true
+}
+
+deploy_one() {
+  local svc="$1" container="$2" repo="$3" remote current
+  remote="$(remote_digest "$repo")"
+  if [ -z "$remote" ]; then log "WARN ${svc}: could not resolve remote digest; skipping"; return 0; fi
+  current="$(local_digest "$container")"
+  if [ -z "$current" ]; then log "WARN ${svc}: could not read local digest; skipping"; return 0; fi
+  if [ "$remote" = "$current" ]; then return 0; fi
+
+  log "UPDATE ${svc}: ${current:0:19} -> ${remote:0:19}; deploying"
+  if [ "${DRY_RUN:-0}" = "1" ]; then log "DRY_RUN ${svc}: would compose pull + up -d --no-deps"; return 0; fi
+  if ! docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull "$svc" >/dev/null 2>&1; then
+    log "ERROR ${svc}: pull failed"; notify "⚠️ deploy: ${svc} pull failed"; return 1
+  fi
+  if ! docker compose -p "$COMPOSE_PROJECT" --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --no-deps "$svc" >/dev/null 2>&1; then
+    log "ERROR ${svc}: up -d failed"; notify "🚨 deploy: ${svc} up -d FAILED"; return 1
+  fi
+  local rev
+  rev="$(docker inspect "$container" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' 2>/dev/null)"
+  log "DEPLOYED ${svc} -> rev ${rev:0:12}"
+  notify "✅ deployed ${svc} @ ${rev:0:12}"
+}
+
+main() {
+  # Single-flight: never let two polls overlap a recreate.
+  exec 9>"$LOCK_FILE"
+  flock -n 9 || { log "another run in progress; exiting"; exit 0; }
+
+  [ -f "$COMPOSE_FILE" ] || { log "FATAL compose file not found: $COMPOSE_FILE"; exit 1; }
+  local rc=0
+  for entry in "${SERVICES[@]}"; do
+    IFS=':' read -r svc container repo <<<"$entry"
+    deploy_one "$svc" "$container" "$repo" || rc=1
+  done
+  docker image prune -f >/dev/null 2>&1 || true
+  exit $rc
+}
+
+main "$@"

--- a/scripts/ops/transcendence-deploy.service
+++ b/scripts/ops/transcendence-deploy.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Transcendence pull-based deploy (poll ghcr :main, recreate changed app services)
+Documentation=https://github.com/luisgon-dev/Transcendence/blob/main/scripts/ops/README.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/root/deploy/poll-deploy.sh
+# Journald captures stdout; inspect with: journalctl -u transcendence-deploy.service

--- a/scripts/ops/transcendence-deploy.timer
+++ b/scripts/ops/transcendence-deploy.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run Transcendence poll-deploy every minute (replaces wud auto-update)
+
+[Timer]
+# First run shortly after boot, then every 60s while active. ~60s deploy latency
+# after an image is pushed to ghcr :main, matching the old wud cadence.
+OnBootSec=90s
+OnUnitActiveSec=60s
+AccuracySec=10s
+Unit=transcendence-deploy.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Why
wud 8.2.2 (latest release) silently fails to detect new ghcr `:main` digests for the app packages — its API reports `updateAvailable: false` / `remote: None` even when the registry digest changed — so pushes never auto-deployed (#62, #63 had to be deployed by hand). Prod is a single Docker host on a **private LAN** (no public SSH, no tunnel), so a cloud GitHub runner can't push a deploy in, and a self-hosted runner would mean CI code executing on the prod host.

## What
A prod-side, **outbound-only** poller that does what wud botched, reliably:
- Every ~60s (systemd timer) resolve each app service's `:main` manifest digest from ghcr via an anonymous pull token (packages are public — verified `HTTP 200` + `Docker-Content-Digest`).
- If it differs from the running container's pulled digest → `docker compose pull` + `up -d --no-deps <svc>` (postgres/redis untouched) → Discord notification.
- `flock` single-flight guard; idempotent.

No inbound exposure, no CI secret, no self-hosted runner.

## Validated on prod
Installed and run: deployed `web` + `webapi` + `service` to current `main` (`3fb69a9`); all healthy, 0 restarts; the next timer tick was a clean no-op. Pairs with the provenance fix (#63) that makes `:main` a clean single-arch manifest.

Files here are the version-controlled source of truth; install/operate steps in `scripts/ops/README.md`. (Scripts-only change — no image build or app deploy is triggered by merging this.)

Closes P1.3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)