### PR TITLE
Analytics: aggregate champion win rates in SQL + fix champion-level ban rate

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
@@ -97,25 +97,25 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
                 .Where(pr => pr.RankTier == rankTierScope.ExactTier);
         }
 
-        var participantRankRows = await participantRanks.ToListAsync(ct);
-        var totalGames = participantRankRows.Count;
+        // P5.2: total games + the per-(role, tier) aggregation are computed in SQL instead of
+        // materialising every participant row (~tens of thousands for a popular champion) and
+        // grouping in memory. Only the handful of grouped rows come back.
+        var totalGames = await participantRanks.CountAsync(ct);
         if (totalGames == 0)
             return [];
 
         var effectiveMinimumGames = ResolveEffectiveSampleSize(minimumGamesRequired, totalGames, floor: 3);
 
-        // Group by role and rank tier, calculate win rates
-        var groupedData = participantRankRows
+        var groupedData = await participantRanks
             .GroupBy(pr => new { pr.TeamPosition, pr.RankTier })
             .Select(g => new
             {
                 Role = g.Key.TeamPosition!,
                 RankTier = g.Key.RankTier,
                 Games = g.Count(),
-                Wins = g.Sum(pr => pr.Win ? 1 : 0),
-                MatchIds = g.Select(pr => pr.MatchId).Distinct().ToList()
+                Wins = g.Sum(pr => pr.Win ? 1 : 0)
             })
-            .ToList();
+            .ToListAsync(ct);
 
         var winRateData = groupedData
             .Where(x => x.Games >= effectiveMinimumGames)
@@ -129,25 +129,27 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
                 .ToList();
         }
 
-        // Convert to DTOs
-        var scopedMatchIds = participantRankRows
-            .Select(pr => pr.MatchId)
-            .Distinct()
-            .ToList();
-        var bannedMatchIds = scopedMatchIds.Count == 0
-            ? new HashSet<Guid>()
-            : (await _context.MatchBans
-                    .AsNoTracking()
-                    .Where(b => b.ChampionId == championId && scopedMatchIds.Contains(b.MatchId))
-                    .Select(b => b.MatchId)
-                    .Distinct()
-                    .ToListAsync(ct))
-                .ToHashSet();
+        // P7.1: champion-level ban rate over the rank-scoped match population (all champions),
+        // matching ComputeTierListAsync — distinct matches in scope where this champion was banned
+        // over total distinct matches in scope, uniform across the role rows. The previous code
+        // intersected each group's *played* matches with this champion's *banned* matches, which is
+        // structurally ~0 (a banned champion is never picked in that match), so ban rate always read
+        // as 0. Stays in SQL: a subquery COUNT plus a Contains-subquery, no id set is materialised.
+        var scopedMatchIds = BuildScopedMatchIdQuery(patch, filter.Region, rankTierScope);
+        var totalMatchesInScope = await scopedMatchIds.CountAsync(ct);
+        var bannedMatches = totalMatchesInScope == 0
+            ? 0
+            : await _context.MatchBans
+                .AsNoTracking()
+                .Where(b => b.ChampionId == championId && scopedMatchIds.Contains(b.MatchId))
+                .Select(b => b.MatchId)
+                .Distinct()
+                .CountAsync(ct);
+        var banRate = totalMatchesInScope > 0 ? (double)bannedMatches / totalMatchesInScope : 0.0;
 
         var result = new List<ChampionWinRateDto>(winRateData.Count);
         foreach (var data in winRateData)
         {
-            var rowBanCount = data.MatchIds.Count(matchId => bannedMatchIds.Contains(matchId));
             var roleRank = await ComputeRoleRankAsync(
                 championId,
                 data.Role,
@@ -164,18 +166,16 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
                 Wins: data.Wins,
                 WinRate: data.Games > 0 ? (double)data.Wins / data.Games : 0.0,
                 PickRate: totalGames > 0 ? (double)data.Games / totalGames : 0.0,
-                BanRate: data.MatchIds.Count > 0 ? (double)rowBanCount / data.MatchIds.Count : 0.0,
+                BanRate: banRate,
                 RoleRank: roleRank.RoleRank,
                 RolePopulation: roleRank.RolePopulation,
                 Patch: patch
             ));
         }
 
-        result = result
+        return result
             .OrderByDescending(x => x.Games)
             .ToList();
-
-        return result;
     }
 
     /// <summary>
@@ -404,6 +404,28 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             r.QueueType == "RANKED_SOLO_5x5" &&
             r.SummonerId == mp.SummonerId &&
             r.Tier == scope.ExactTier));
+    }
+
+    // Distinct match IDs for the full (all-champion) rank-scoped ranked-solo population in a
+    // patch/region — the denominator population for champion-level ban rate. Returned as IQueryable
+    // so callers compose CountAsync / Contains in SQL without materialising the (large) id set.
+    private IQueryable<Guid> BuildScopedMatchIdQuery(string patch, string? region, RankTierScope rankTierScope)
+    {
+        var scope = _context.MatchParticipants
+            .AsNoTracking()
+            .Where(mp => mp.Match.Patch == patch)
+            .Where(mp => mp.Match.Status == FetchStatus.Success)
+            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
+                         (mp.Match.QueueId == 0 &&
+                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .Where(mp => mp.TeamPosition != null && mp.TeamPosition != "");
+
+        if (!string.IsNullOrEmpty(region))
+            scope = scope.Where(mp => mp.Summoner.PlatformRegion == region);
+
+        scope = ApplyRankTierScopeToParticipants(scope, rankTierScope, _context.Ranks.AsNoTracking());
+
+        return scope.Select(mp => mp.MatchId).Distinct();
     }
 
     private static HashSet<string> ResolvePlatformsForRegion(string region)

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
@@ -69,6 +69,74 @@ public class ChampionAnalyticsComputeServiceTests
     }
 
     [Fact]
+    public async Task ComputeWinRatesAsync_AggregatesInSqlAndComputesChampionLevelBanRate()
+    {
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<TranscendenceContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Patches.Add(new Patch
+        {
+            Version = "15.2",
+            ReleaseDate = DateTime.UtcNow.AddDays(-2),
+            DetectedAt = DateTime.UtcNow.AddDays(-2),
+            IsActive = true
+        });
+
+        // Champion 266 played TOP twice (1 win, 1 loss)...
+        SeedMatch(db, "15.2", "NA1_A", summonerName: "PlayerA", championId: 266, role: "TOP", win: true);
+        SeedMatch(db, "15.2", "NA1_B", summonerName: "PlayerB", championId: 266, role: "TOP", win: false);
+        // ...and banned in a third, in-scope match (a different champion was actually played there).
+        SeedMatch(db, "15.2", "NA1_C", summonerName: "PlayerC", championId: 64, role: "JUNGLE", win: true);
+        await db.SaveChangesAsync();
+
+        var bannedMatch = db.Matches.Single(m => m.MatchId == "NA1_C");
+        db.MatchBans.Add(new MatchBan
+        {
+            MatchId = bannedMatch.Id,
+            Match = bannedMatch,
+            TeamId = 100,
+            PickTurn = 1,
+            ChampionId = 266
+        });
+        await db.SaveChangesAsync();
+
+        var service = new ChampionAnalyticsComputeService(
+            db,
+            Options.Create(new ChampionAnalyticsComputeOptions
+            {
+                MinimumGamesRequired = 1,
+                EarlyPatchMinimumGamesRequired = 1,
+                BootstrapPatchMinimumGamesRequired = 1,
+                BootstrapWindowHours = 24,
+                ProvisionalWindowHours = 96,
+                MaturingWindowHours = 240
+            }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+
+        var result = await service.ComputeWinRatesAsync(
+            266, new ChampionAnalyticsFilter(), "15.2", CancellationToken.None);
+
+        // The (role, tier) aggregation is now done in SQL; only the grouped row comes back.
+        result.Should().ContainSingle();
+        var row = result[0];
+        row.Role.Should().Be("TOP");
+        row.Games.Should().Be(2);
+        row.Wins.Should().Be(1);
+        row.WinRate.Should().BeApproximately(0.5, 0.0001);
+        row.PickRate.Should().BeApproximately(1.0, 0.0001);
+        // P7.1: champion-level ban rate = 1 banned match / 3 matches in scope. The old per-group
+        // played-and-banned intersection was structurally ~0, so this asserts the fix (non-zero).
+        row.BanRate.Should().BeApproximately(1.0 / 3.0, 0.0001);
+    }
+
+    [Fact]
     public async Task ComputeProChampionPlayrateAsync_RanksChampionsAndHonorsScope()
     {
         await using var connection = new SqliteConnection("Data Source=:memory:");


### PR DESCRIPTION
## P5.2 — reduce client-side materialization
`ComputeWinRatesAsync` materialized **every** participant row for a champion (tens of thousands for a popular pick) and grouped in memory. This pushes the total count and the per-`(role, tier)` `Games/Wins` aggregation into **SQL `GroupBy`** — only the handful of grouped rows come back. (`ComputeTierListAsync` already used this pattern; the win-rate path now also rides the new `(ChampionId)` covering index from #65.) The other big analytics path, the tier list, was already SQL-aggregated, so this was the one remaining materializer.

## P7.1 — fix the broken ban rate (combined per your call)
The old per-`(role, tier)` ban rate intersected the group's **played** matches with this champion's **banned** matches — structurally ~0 (a banned champion is never picked in that match), so ban rate always rendered as **0**. Replaced with a champion-level rate matching `ComputeTierListAsync`: *distinct matches in the rank-scoped population where the champion was banned / total distinct matches in scope*, uniform across the role rows. Kept fully in SQL (subquery `COUNT` + `Contains`-subquery) so no id set is materialized.

## Tests
New `ComputeWinRatesAsync` case exercises the real query end-to-end (confirms the SQL `GroupBy` translates on SQLite) and asserts the now **non-zero** ban rate (1 banned / 3 in-scope matches). Full suite green (140 Service.Core + 34 WebAPI); no schema change (drift clean).

Note: pick-rate semantics are unchanged (group games / this champion's total in scope); broader cross-surface pick-rate denominator review remains under P7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)