### PR TITLE
docs(ops): document match-detail retention (P5.3)

### DIFF
--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -47,3 +47,40 @@ file and `compose up -d` it (see `docs/ARCHITECTURE.md` "Deployment & rollback")
 > If wud's app-container watching is ever wanted back, note it is unreliable here; this
 > poller is the source of truth. wud still works fine for the public Docker Hub
 > sidecars (portainer/dozzle/grafana/prometheus).
+
+## `archive-old-patches.sh` — match-detail retention (archive-then-prune)
+
+Keeps the DB bounded by archiving **old-patch** LoL match detail to the NAS and then
+pruning it, keeping only the newest `KEEP_PATCHES` (default 3) patches plus the active
+patch. For each eligible patch it freezes that patch's match-ID set into a work table
+(T0 snapshot — consistent under the live ingestion worker, which keeps inserting
+old-patch rows as lapsed players return), streams every match table (`Matches` + all
+cascade children) out via Postgres `COPY` → `gzip` → `ssh` to the NAS, **verifies**
+(gzip integrity + exact row count), writes a manifest, and only then prunes — one
+cascading `DELETE` on `Matches` in bounded batches (`DELETE_BATCH=20000`). It is a
+**bounded-batch job**: dry-run by default (`APPLY=1` to act), verify-before-delete is
+mandatory (a failed verify skips the prune and leaves the NAS archive intact),
+residual-safe/idempotent (post-T0 inserts to an already-`_DONE` patch archive to
+`residual-<epoch>/`), and HDD-adaptive (big slice → seq scan; small slice → forced
+index nested-loops, since forcing index on a big slice = catastrophic random HDD reads).
+
+**Why a host cron, not a Hangfire job:** it needs host-level `docker exec` (psql `COPY`)
+and NAS `ssh` that the worker container neither has nor should have. The script is the
+version-controlled source of truth; prod runs a synced copy (`sha256` must match).
+
+### Install / operate (on prod, as root)
+
+```bash
+install -m 0755 archive-old-patches.sh /root/archive-old-patches.sh   # keep in sync with repo
+# /etc/cron.d/trn-archive runs it weekly:
+#   0 5 * * 0 root APPLY=1 KEEP_PATCHES=3 bash /root/archive-old-patches.sh >> /root/trn-archive.log 2>&1
+APPLY=0 bash /root/archive-old-patches.sh                    # dry-run (preview eligible patches + counts)
+ONLY_PATCH=16.9 APPLY=1 bash /root/archive-old-patches.sh    # archive+prune one patch
+tail -f /root/trn-archive.log                                # run history
+```
+
+`archive-remaining-bulk.sh` is the one-time bulk sweep used to clear the initial backlog
+(same archive-then-prune guarantees, looped). **Do not run either during a DB-load
+incident** — the `COPY` of millions of rows saturates the HDD. Restore instructions are
+in each script's header. Deleted rows free pages for reuse inside Postgres; the file does
+not shrink without `VACUUM FULL` (intentionally avoided — it locks the table).


### PR DESCRIPTION
## P5.3 — match-detail retention as a version-controlled bounded-batch job

Investigation found the retention is **already** version-controlled and bounded — `scripts/ops/archive-old-patches.sh`:
- **Bounded-batch:** freezes each patch's match-ID set into a T0 work table (consistent under the live ingestion worker), `DELETE_BATCH=20000` cascading prune, HDD-adaptive query plan.
- **Safe:** dry-run by default, **verify-before-prune** (gzip integrity + exact row count; a failed verify skips the prune and leaves the NAS archive intact), residual-safe/idempotent.
- **Installed + working on prod:** weekly `/etc/cron.d/trn-archive` (`APPLY=1 KEEP_PATCHES=3`); prod copy **sha256-matches the repo**; last run archived + verified + pruned 16.8/16.9 cleanly; DB holds only the newest 3 patches + tiny residuals.

It's correctly a **host cron, not a Hangfire job** — it needs host-level `docker exec` (psql `COPY`) + NAS `ssh` the worker container neither has nor should have.

The only gap was documentation: `scripts/ops/README.md` only covered the deploy poller. This adds the retention section (what it does, install/operate, the host-cron rationale, and a do-not-run-during-an-incident caveat). Docs-only — no build/deploy triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)