### PR TITLE
test(riot): HTTP-level tests for the Riot API clients (P6.1)

### DIFF
--- a/tests/Transcendence.Service.Core.Tests/RiotApiServiceHttpTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/RiotApiServiceHttpTests.cs
@@ -1,0 +1,146 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using Camille.Enums;
+using Camille.RiotGames;
+using Camille.RiotGames.Util;
+using FluentAssertions;
+using Moq;
+using Transcendence.Service.Core.Services.RiotApi;
+using Transcendence.Service.Core.Services.RiotApi.Implementations;
+using Transcendence.Service.Core.Services.RiotApi.Interfaces;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// HTTP-level tests for the Camille-backed Riot API service clients. Camille exposes no
+/// HttpMessageHandler seam, but its config takes a base <c>ApiUrl</c>; we point it at a loopback
+/// <see cref="HttpListener"/> stub returning canned status codes + bodies, so the real request/parse/
+/// error path runs without touching the network. Retries are disabled so 429/5xx tests are instant.
+///
+/// Note on 404: Camille treats 404/204/422 as "null-success" — the call returns null rather than
+/// throwing — so a not-found surfaces as a null result, which is exactly what the services rely on.
+/// A genuinely thrown <see cref="RiotResponseException"/> only happens for non-retryable errors like 403.
+/// </summary>
+public class RiotApiServiceHttpTests
+{
+    [Fact]
+    public async Task ResolvePuuidAsync_OnSuccess_ParsesAndReturnsPuuid()
+    {
+        using var stub = new RiotApiStub
+        {
+            Response = (HttpStatusCode.OK, """{"puuid":"PUUID-123","gameName":"Faker","tagLine":"KR1"}""")
+        };
+        var service = new RiotAccountService(stub.BuildContext());
+
+        var puuid = await service.ResolvePuuidAsync("Faker", "KR1", PlatformRoute.NA1);
+
+        puuid.Should().Be("PUUID-123");
+    }
+
+    [Fact]
+    public async Task ResolvePuuidAsync_OnNotFound_ReturnsNull()
+    {
+        using var stub = new RiotApiStub { Response = (HttpStatusCode.NotFound, null) };
+        var service = new RiotAccountService(stub.BuildContext());
+
+        var puuid = await service.ResolvePuuidAsync("Ghost", "NA1", PlatformRoute.NA1);
+
+        puuid.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ResolvePuuidAsync_OnForbidden_PropagatesRiotResponseException()
+    {
+        // A non-null-success, non-retryable status (403, e.g. key revoked) must NOT be swallowed by
+        // the service's NotFound-only catch — it propagates so the caller/job can fail loudly.
+        using var stub = new RiotApiStub { Response = (HttpStatusCode.Forbidden, null) };
+        var service = new RiotAccountService(stub.BuildContext());
+
+        var act = () => service.ResolvePuuidAsync("Faker", "KR1", PlatformRoute.NA1);
+
+        var ex = await act.Should().ThrowAsync<RiotResponseException>();
+        ex.Which.GetResponse()!.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetSummonerByRiotIdAsync_WhenAccountNotFound_ThrowsRiotAccountNotFound()
+    {
+        // AccountV1 404 -> Camille returns a null account -> service maps it to the typed
+        // RiotAccountNotFoundException (so the refresh job skips a dead riot-id instead of crashing).
+        using var stub = new RiotApiStub { Response = (HttpStatusCode.NotFound, null) };
+        var service = new SummonerService(stub.BuildContext(), Mock.Of<IRankService>());
+
+        var act = () => service.GetSummonerByRiotIdAsync("Ghost", "NA1", PlatformRoute.NA1);
+
+        await act.Should().ThrowAsync<RiotAccountNotFoundException>();
+    }
+
+    /// <summary>
+    /// Loopback <see cref="HttpListener"/> stub. Returns the same canned response to every request
+    /// (the tests above each make a single Riot call before asserting). Camille's <c>ApiUrl</c> has no
+    /// <c>{0}</c> placeholder, so the regional route is ignored and every call hits this stub verbatim.
+    /// </summary>
+    private sealed class RiotApiStub : IDisposable
+    {
+        private readonly HttpListener _listener = new();
+        private readonly string _baseUrl;
+
+        public (HttpStatusCode Status, string? Body) Response { get; set; } = (HttpStatusCode.OK, "{}");
+
+        public RiotApiStub()
+        {
+            var port = FreeLoopbackPort();
+            _baseUrl = $"http://127.0.0.1:{port}/";
+            _listener.Prefixes.Add(_baseUrl);
+            _listener.Start();
+            _ = Task.Run(ServeLoopAsync);
+        }
+
+        public LeagueRiotApiContext BuildContext()
+        {
+            var config = new RiotGamesApiConfig.Builder("FAKE-KEY")
+            {
+                ApiUrl = _baseUrl,
+                Retries = 0,                       // no retry loop — 429/5xx would otherwise sleep seconds
+                BackoffStrategy = (_, _, _) => 0.0,
+            }.Build();
+            return new LeagueRiotApiContext(RiotGamesApi.NewInstance(config));
+        }
+
+        private async Task ServeLoopAsync()
+        {
+            while (_listener.IsListening)
+            {
+                HttpListenerContext ctx;
+                try { ctx = await _listener.GetContextAsync(); }
+                catch { break; }   // listener stopped
+
+                var (status, body) = Response;
+                ctx.Response.StatusCode = (int)status;
+                if (!string.IsNullOrEmpty(body))
+                {
+                    var bytes = Encoding.UTF8.GetBytes(body);
+                    ctx.Response.ContentType = "application/json";
+                    ctx.Response.ContentLength64 = bytes.Length;
+                    await ctx.Response.OutputStream.WriteAsync(bytes);
+                }
+                ctx.Response.Close();
+            }
+        }
+
+        private static int FreeLoopbackPort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        public void Dispose()
+        {
+            try { _listener.Stop(); _listener.Close(); } catch { /* already torn down */ }
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/RiotRoutingExtensionsTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/RiotRoutingExtensionsTests.cs
@@ -1,0 +1,46 @@
+using Camille.Enums;
+using FluentAssertions;
+using Transcendence.Service.Core.Services.RiotApi;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// Account-V1 routing: Camille maps South-East-Asia platforms (OCE + the SEA servers) to
+/// <see cref="RegionalRoute.SEA"/>, which is correct for Match-V5 but 404s for Account-V1 (which has
+/// no SEA cluster). <see cref="RiotRoutingExtensions.ToAccountRegional"/> clamps SEA -> ASIA. This
+/// was a real prod bug — every OC1 summoner enrichment 404'd, yielding 0 seeds for the region.
+/// </summary>
+public class RiotRoutingExtensionsTests
+{
+    [Theory]
+    [InlineData(PlatformRoute.OC1)]   // OCE -> SEA (Match-V5) -> must clamp to ASIA for Account-V1
+    [InlineData(PlatformRoute.PH2)]
+    [InlineData(PlatformRoute.SG2)]
+    [InlineData(PlatformRoute.TH2)]
+    [InlineData(PlatformRoute.TW2)]
+    [InlineData(PlatformRoute.VN2)]
+    public void ToAccountRegional_ClampsSeaPlatformsToAsia(PlatformRoute platform)
+    {
+        // Precondition: these platforms really do route to SEA for Match-V5 (so the clamp matters).
+        platform.ToRegional().Should().Be(RegionalRoute.SEA);
+
+        platform.ToAccountRegional().Should().Be(RegionalRoute.ASIA);
+    }
+
+    [Theory]
+    [InlineData(PlatformRoute.NA1, RegionalRoute.AMERICAS)]
+    [InlineData(PlatformRoute.BR1, RegionalRoute.AMERICAS)]
+    [InlineData(PlatformRoute.LA1, RegionalRoute.AMERICAS)]
+    [InlineData(PlatformRoute.EUW1, RegionalRoute.EUROPE)]
+    [InlineData(PlatformRoute.EUN1, RegionalRoute.EUROPE)]
+    [InlineData(PlatformRoute.TR1, RegionalRoute.EUROPE)]
+    [InlineData(PlatformRoute.KR, RegionalRoute.ASIA)]
+    [InlineData(PlatformRoute.JP1, RegionalRoute.ASIA)]
+    public void ToAccountRegional_LeavesNonSeaPlatformsOnTheirRegionalCluster(
+        PlatformRoute platform, RegionalRoute expected)
+    {
+        // Non-SEA platforms are unaffected — Account-V1 routing == Match-V5 routing for them.
+        platform.ToAccountRegional().Should().Be(expected);
+        platform.ToAccountRegional().Should().Be(platform.ToRegional());
+    }
+}


### PR DESCRIPTION
## P6.1 — HTTP-level tests for the RiotApi clients

The services wrap **Camille** (`RiotGamesApi`), which has no `HttpMessageHandler` injection seam. The working seam (verified by decompiling Camille + a compiling spike) is its config's base `ApiUrl` — pointed at a loopback `HttpListener` stub returning canned status + body, with `Retries=0` + zero backoff so error-path tests are instant.

**`RiotApiServiceHttpTests` (4):**
- `ResolvePuuidAsync` 200 → parses the typed Camille DTO and returns the puuid
- `ResolvePuuidAsync` 404 → **null** — Camille treats 404/204/422 as *null-success* (returns null rather than throwing), which is exactly the not-found contract the services rely on
- `ResolvePuuidAsync` 403 → `RiotResponseException` **propagates** (the `NotFound`-only catch must not swallow a key-revoked/forbidden error)
- `GetSummonerByRiotIdAsync` account-404 → `RiotAccountNotFoundException` (so the refresh job skips a dead riot-id instead of crashing)

**`RiotRoutingExtensionsTests` (14):** `ToAccountRegional` clamps SEA platforms (OC1/PH2/SG2/TH2/TW2/VN2) → ASIA for Account-V1 (no SEA cluster — the real OC1 enrichment-404 prod bug) and leaves non-SEA platforms on their Match-V5 cluster.

158 Service.Core + 34 WebAPI green. Test-only — no app code, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)