### PR TITLE
perf(analytics): covering index for the matchup gold/xp-diff join (closes #69)

### DIFF
--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -513,6 +513,22 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
                 .HasForeignKey(x => x.MatchId)
                 .OnDelete(DeleteBehavior.Cascade);
             entity.HasIndex(x => new { x.MinuteMark, x.MatchId });
+            // Covering index for the matchup gold/xp-diff-at-15 join
+            // (ChampionAnalyticsComputeService.ComputeMatchupsAsync). That query LEFT-joins this
+            // 22.5M-row table twice — championTimeline and opponentTimeline — on
+            // (MatchId, ParticipantId) with MinuteMark == 15. The key columns mirror the PK, so the
+            // join key was already seekable; the win is the INCLUDE payload, which lets both scans run
+            // index-only instead of heap-fetching Gold/Xp (both sides) and DerivedAtUtc (champion side,
+            // for LatestTimelineAtUtc) per row. On the HDD-backed prod DB that heap fetch pushed the
+            // matchup query to ~28s and tripped the 30s command timeout, failing WarmDefaultChampion-
+            // ProfilesJob every cycle. INCLUDE (Gold, Xp, DerivedAtUtc) is Npgsql-specific and this
+            // project references only EF.Relational, so it lives in the raw-SQL migration; the model
+            // declares the bare (MatchId, ParticipantId, MinuteMark) shape under the same name. Built
+            // CONCURRENTLY out-of-band on the hot table — see docs/DEVELOPMENT.md "Applying index
+            // migrations to hot tables".
+            entity.HasIndex(
+                x => new { x.MatchId, x.ParticipantId, x.MinuteMark },
+                "IX_MatchParticipantTimelineSnapshots_Matchup");
         });
 
         modelBuilder.Entity<MatchParticipantTimelineSnapshot>()

--- a/Transcendence.Service/Migrations/20260621195700_AddTimelineSnapshotMatchupCoveringIndex.Designer.cs
+++ b/Transcendence.Service/Migrations/20260621195700_AddTimelineSnapshotMatchupCoveringIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260621195700_AddTimelineSnapshotMatchupCoveringIndex")]
+    partial class AddTimelineSnapshotMatchupCoveringIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260621195700_AddTimelineSnapshotMatchupCoveringIndex.cs
+++ b/Transcendence.Service/Migrations/20260621195700_AddTimelineSnapshotMatchupCoveringIndex.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTimelineSnapshotMatchupCoveringIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Hot table (MatchParticipantTimelineSnapshots, ~22.5M rows, continuously written by the
+            // timeline ingestion/backfill jobs). Build CONCURRENTLY so it never holds a write-blocking
+            // SHARE lock for the full build; CONCURRENTLY cannot run inside a transaction, hence
+            // suppressTransaction. **Apply out-of-band on prod** (NOT via `database update`) and in a
+            // top-of-hour gap — a 22.5M-row build on the HDD must not compete with the `:00` warm storm.
+            // See docs/DEVELOPMENT.md "Applying index migrations to hot tables".
+            //
+            // Raw SQL (not EF CreateIndex) for two reasons: (1) EF's CreateIndex emits a locking plain
+            // CREATE INDEX; (2) the INCLUDE payload is Npgsql-specific and Transcendence.Data references
+            // only EF.Relational, so the model carries the bare (MatchId, ParticipantId, MinuteMark)
+            // shape and the INCLUDE columns live here.
+            //
+            // The key columns mirror the PK, so the matchup join key was already seekable — the win is
+            // the INCLUDE payload. ChampionAnalyticsComputeService.ComputeMatchupsAsync LEFT-joins this
+            // table twice (championTimeline + opponentTimeline) on (MatchId, ParticipantId) with
+            // MinuteMark == 15: opponentTimeline reads Gold/Xp, championTimeline reads Gold/Xp plus
+            // DerivedAtUtc (for LatestTimelineAtUtc). INCLUDE (Gold, Xp, DerivedAtUtc) lets BOTH scans
+            // run index-only — DerivedAtUtc is required or the champion-side scan still heap-fetches and
+            // the INCLUDE buys nothing there. The heap fetch is what pushed the matchup query to ~28s on
+            // the HDD-backed prod DB and tripped the 30s command timeout, failing a chunk of
+            // WarmDefaultChampionProfilesJob every cycle.
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_MatchParticipantTimelineSnapshots_Matchup\" " +
+                "ON \"MatchParticipantTimelineSnapshots\" (\"MatchId\", \"ParticipantId\", \"MinuteMark\") " +
+                "INCLUDE (\"Gold\", \"Xp\", \"DerivedAtUtc\");",
+                suppressTransaction: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_MatchParticipantTimelineSnapshots_Matchup\";",
+                suppressTransaction: true);
+        }
+    }
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -148,11 +148,11 @@ dotnet ef database update --project Transcendence.Service --startup-project Tran
 Migration policy:
 - Do not hand-author or hand-edit EF migration files.
 - Generate migrations only via EF CLI (for example: `dotnet ef migrations add <Name> --project Transcendence.Service --startup-project Transcendence.Service`).
-- **Hot-table index/DDL is applied out-of-band, not via `database update`** — see the recipe below. CI (the migration-safety check) fails a PR that adds a non-concurrent `CreateIndex` or a defaulted `AddColumn` on `Summoners` / `Matches` / `MatchParticipants` and points back here.
+- **Hot-table index/DDL is applied out-of-band, not via `database update`** — see the recipe below. CI (the migration-safety check) fails a PR that adds a non-concurrent `CreateIndex` or a defaulted `AddColumn` on `Summoners` / `Matches` / `MatchParticipants` / `MatchParticipantTimelineSnapshots` and points back here.
 
 #### Applying index migrations to hot tables
 
-`Summoners` (~4M+ rows), `Matches`, and `MatchParticipants` are large and continuously written by ingestion. EF's generated `CreateIndex` emits a plain `CREATE INDEX`, which holds a `SHARE` lock for the entire build and blocks ingestion writes for its duration. **Do not** apply such a migration with `dotnet ef database update`. Split the apply instead:
+`Summoners` (~4M+ rows), `Matches`, `MatchParticipants`, and `MatchParticipantTimelineSnapshots` (~22.5M rows) are large and continuously written by ingestion. EF's generated `CreateIndex` emits a plain `CREATE INDEX`, which holds a `SHARE` lock for the entire build and blocks ingestion writes for its duration. **Do not** apply such a migration with `dotnet ef database update`. Split the apply instead:
 
 1. Isolate the index in its own migration (don't bundle it with other DDL) so the steps below stay clean.
 2. Read the index name / table / columns from the generated migration's `Up()`.

--- a/scripts/ci/check-migrations.sh
+++ b/scripts/ci/check-migrations.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 BASE_REF="${BASE_REF:-origin/main}"
 MIG_DIR='Transcendence.Service/Migrations'
-HOT_TABLES='Summoners|Matches|MatchParticipants'
+HOT_TABLES='Summoners|Matches|MatchParticipants|MatchParticipantTimelineSnapshots'
 
 if ! git rev-parse --verify -q "${BASE_REF}^{commit}" >/dev/null 2>&1; then
   echo "check-migrations: base ref '${BASE_REF}' not found; skipping hot-table lint."


### PR DESCRIPTION
## What

Adds `IX_MatchParticipantTimelineSnapshots_Matchup` on `(MatchId, ParticipantId, MinuteMark) INCLUDE (Gold, Xp, DerivedAtUtc)` — a covering index for the matchup gold/xp-diff-at-15 join. **Closes #69**, which closes the loop on the 2026-06-21 DB-saturation incident.

## Why

`ChampionAnalyticsComputeService.ComputeMatchupsAsync` LEFT-joins the ~22.5M-row `MatchParticipantTimelineSnapshots` table **twice** (`championTimeline` + `opponentTimeline`) on `(MatchId, ParticipantId)` with `MinuteMark == 15`. The only secondary index was `(MinuteMark, MatchId)` — no `ParticipantId` — so the join heap-fetched `ParticipantId/Gold/Xp/DerivedAtUtc` per row. On the HDD-backed prod DB that pushed the matchup query to **~28s**, tripping the default 30s Npgsql command timeout, so `WarmDefaultChampionProfilesJob` failed to warm a chunk of champion profiles **every hourly cycle**. Warm concurrency is already only 3 — throttling (#70) was never the lever; this is.

## Design notes

- **Key columns mirror the PK** `(MatchId, ParticipantId, MinuteMark)`, so the join key was already seekable — the entire win is the `INCLUDE` payload, which turns **both** timeline scans index-only (no heap I/O on the HDD).
- **`INCLUDE` carries `DerivedAtUtc`**, deviating from #69's proposed `(Gold, Xp)`: the champion-side scan also reads `DerivedAtUtc` (for `LatestTimelineAtUtc` freshness). Without it, that scan still heap-fetches and the `INCLUDE` buys nothing on the champion side — leaving half the join heap-bound. Verified the matchup query reads exactly `Gold/Xp/DerivedAtUtc` off timeline rows, nothing else.
- **No reader is pessimized.** `SummonerStatsService` (single-match timeline) actually becomes index-only too (bonus); `MatchTimelineBackfillJob`'s `EXISTS(MatchId && MinuteMark)` still prefers the retained `(MinuteMark, MatchId)` index. Cost is one more index to maintain on inserts — modest, worth it.

## Hot-table recipe (same as P5.1 `MatchParticipants` covering index)

`INCLUDE` is Npgsql-specific and `Transcendence.Data` references only EF.Relational, so the model declares the **bare** `(MatchId, ParticipantId, MinuteMark)` shape under the index name and the payload lives in a **raw-SQL `CREATE INDEX CONCURRENTLY ... INCLUDE`** migration (`suppressTransaction`). `has-pending-model-changes` reports no drift.

⚠️ **Prod apply is out-of-band, NOT `database update`.** Build `CONCURRENTLY` in a **top-of-hour gap** (a 22.5M-row build on the HDD must not compete with the `:00` warm storm), verify `indisvalid = 't'`, then record in `__EFMigrationsHistory`. Then verify the matchup `EXPLAIN` is an index-only scan and warm failures drop the next cycle. See `docs/DEVELOPMENT.md` → "Applying index migrations to hot tables".

## Also

- Add `MatchParticipantTimelineSnapshots` to the **CI migration-safety hot-table guard** (`check-migrations.sh`) + the DEVELOPMENT.md hot-table list — it was missing despite being the second-largest continuously-written table, so a future plain `CreateIndex` on it would have slipped past the lint and SHARE-locked ingestion for the whole build.

## Verification

- `dotnet build` clean, `dotnet ef migrations has-pending-model-changes` → no drift
- `check-migrations.sh` → 1 migration inspected, no hot-table lock/rewrite DDL
- Backend tests green: **158** (Core) + **34** (WebAPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)