### PR TITLE
fix(refresh): use persisted summoner Id for mastery refresh (closes #73)

### DIFF
--- a/Transcendence.Service.Core/Services/Jobs/SummonerRefreshJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/SummonerRefreshJob.cs
@@ -55,9 +55,17 @@ public class SummonerRefreshJob(
             ct.ThrowIfCancellationRequested();
             var options = ingestionOptions.Value;
 
-            // Fetch/update summoner first.
+            // Fetch/update summoner first. Reassign to the PERSISTED, change-tracked summoner the repo
+            // returns: the Riot-sourced instance from GetSummonerByRiotIdAsync always carries
+            // Id == Guid.Empty (the summoner Id is generated server-side by the raw-SQL upsert and is
+            // never written back to this instance). Using that empty Id downstream is what made champion
+            // mastery refresh fail — UpsertAsync stamped SummonerId = Guid.Empty on new rows and EF threw
+            // "SummonerId is unknown" (the FK is part of the key, so the empty value is the unset-key
+            // sentinel and no principal Summoner is tracked) — and also keyed the ingestion cursors and
+            // the post-refresh stats-cache invalidation to Guid.Empty. (MatchService already captures
+            // this return value; this path did not.)
             var summoner = await summonerService.GetSummonerByRiotIdAsync(gameName, tagLine, platformRoute, ct);
-            await summonerRepository.AddOrUpdateSummonerAsync(summoner, ct);
+            summoner = await summonerRepository.AddOrUpdateSummonerAsync(summoner, ct);
             await db.SaveChangesAsync(ct);
 
             // Enrich with champion mastery (fail-soft — never block a refresh on it).

--- a/tests/Transcendence.Service.Core.Tests/SummonerRefreshJobTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerRefreshJobTests.cs
@@ -139,6 +139,55 @@ public class SummonerRefreshJobTests
     }
 
     [Fact]
+    public async Task RefreshByRiotId_RefreshesMasteryWithPersistedSummonerId_NotEmptyRiotInstanceId()
+    {
+        // Regression for the "ChampionMastery refresh fails with FK 'SummonerId is unknown'" bug:
+        // GetSummonerByRiotIdAsync returns a Riot-sourced summoner whose Id is Guid.Empty (the Id is
+        // generated server-side by the raw-SQL upsert and never written back to this instance), while
+        // AddOrUpdateSummonerAsync returns the PERSISTED summoner with the real Id. The job must refresh
+        // mastery against the persisted Id — not the empty Id of the throwaway Riot instance, which made
+        // the mastery upsert stamp SummonerId = Guid.Empty and EF throw.
+        await using var harness = await SummonerRefreshJobHarness.CreateAsync();
+
+        var persisted = harness.SeedSummoner("name", "tag", "puuid-mastery");
+        await harness.Db.SaveChangesAsync();
+        persisted.Id.Should().NotBe(Guid.Empty);
+
+        // Mirrors SummonerService.CreateSummonerAsync: a fresh entity with no Id assigned.
+        var riotSourced = new Summoner
+        {
+            PlatformRegion = "NA1",
+            Region = "AMERICAS",
+            GameName = "name",
+            TagLine = "tag",
+            Puuid = "puuid-mastery",
+            SummonerLevel = 200
+        };
+        riotSourced.Id.Should().Be(Guid.Empty);
+
+        harness.SummonerService
+            .Setup(x => x.GetSummonerByRiotIdAsync("name", "tag", PlatformRoute.NA1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(riotSourced);
+
+        harness.SummonerRepository
+            .Setup(x => x.AddOrUpdateSummonerAsync(riotSourced, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(persisted);
+
+        harness.ChampionMasteryService
+            .Setup(x => x.GetMasteriesAsync("puuid-mastery", PlatformRoute.NA1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([new ChampionMastery { ChampionId = 1, ChampionLevel = 7, ChampionPoints = 100_000 }]);
+
+        await harness.Job.RefreshByRiotId("name", "tag", PlatformRoute.NA1, "lock:main", "lock:priority");
+
+        harness.ChampionMasteryRepository.Verify(
+            x => x.UpsertAsync(persisted.Id, It.IsAny<List<ChampionMastery>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        harness.ChampionMasteryRepository.Verify(
+            x => x.UpsertAsync(Guid.Empty, It.IsAny<List<ChampionMastery>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task RefreshForAnalytics_ExitsEarly_WhenApiPriorityDemandIsActive()
     {
         await using var harness = await SummonerRefreshJobHarness.CreateAsync();
@@ -647,7 +696,9 @@ public class SummonerRefreshJobTests
             Mock<IRefreshLockRepository> refreshLockRepository,
             Mock<IRiotMatchIdsClient> riotMatchIdsClient,
             Mock<IBackgroundJobClient> backgroundJobClient,
-            Mock<IRefreshLockLifecycleTelemetry> lockTelemetry)
+            Mock<IRefreshLockLifecycleTelemetry> lockTelemetry,
+            Mock<IChampionMasteryService> championMasteryService,
+            Mock<IChampionMasteryRepository> championMasteryRepository)
         {
             _connection = connection;
             Db = db;
@@ -661,6 +712,8 @@ public class SummonerRefreshJobTests
             RiotMatchIdsClient = riotMatchIdsClient;
             BackgroundJobClient = backgroundJobClient;
             LockTelemetry = lockTelemetry;
+            ChampionMasteryService = championMasteryService;
+            ChampionMasteryRepository = championMasteryRepository;
         }
 
         public SqliteCompatibleTranscendenceContext Db { get; }
@@ -674,6 +727,8 @@ public class SummonerRefreshJobTests
         public Mock<IRiotMatchIdsClient> RiotMatchIdsClient { get; }
         public Mock<IBackgroundJobClient> BackgroundJobClient { get; }
         public Mock<IRefreshLockLifecycleTelemetry> LockTelemetry { get; }
+        public Mock<IChampionMasteryService> ChampionMasteryService { get; }
+        public Mock<IChampionMasteryRepository> ChampionMasteryRepository { get; }
 
         public static async Task<SummonerRefreshJobHarness> CreateAsync()
         {
@@ -784,7 +839,9 @@ public class SummonerRefreshJobTests
                 refreshLockRepository,
                 riotMatchIdsClient,
                 backgroundJobClient,
-                lockTelemetry);
+                lockTelemetry,
+                championMasteryService,
+                championMasteryRepository);
         }
 
         public Summoner SeedSummoner(string gameName, string tagLine, string puuid)


### PR DESCRIPTION
## What

`SummonerRefreshJob.RefreshByRiotId` now uses the **persisted** summoner returned by `AddOrUpdateSummonerAsync` instead of the throwaway Riot-sourced instance. **Closes #73.**

## Root cause

Champion-mastery refresh failed in prod with EF `SummonerId is unknown`. Mastery is fail-soft, so it was caught and **silently dropped for every user-initiated refresh**.

1. `SummonerService.CreateSummonerAsync` builds the Riot-sourced `Summoner` with **no `Id`** → always `Id == Guid.Empty`.
2. `SummonerRepository.AddOrUpdateSummonerAsync` upserts via raw SQL (Id generated server-side) and **returns** the persisted, change-tracked summoner with the real Id.
3. But `RefreshByRiotId` **discarded that return** and kept the empty-Id instance.
4. `ChampionMasteryRepository.UpsertAsync` stamped `SummonerId = Guid.Empty` on new rows. Since `SummonerId` is part of `ChampionMastery`'s key **and** its FK, `Guid.Empty` is the unset-key sentinel → EF throws *"SummonerId is unknown ... the principal entity in the relationship is not known."*

The same empty Id also silently mis-keyed two other things off this path:
- the non-ranked-backfill **ingestion cursor** (`SummonerIngestionCursor.SummonerId == Guid.Empty`), and
- the post-refresh **stats-cache invalidation** (`summoner-stats:{Guid.Empty}` → the real summoner's cache was never busted).

All three are fixed by the one-line capture.

## Fix

```csharp
summoner = await summonerRepository.AddOrUpdateSummonerAsync(summoner, ct);
```

This matches the pattern `MatchService` already uses (`var persistedSummoner = await AddOrUpdate...`).

**Audited the other call sites:** `SummonerBootstrapService` doesn't use the Id after upsert; `AddOrUpdateHighEloProfiles` keys `TrackedProSummoner` by `Puuid` — neither is affected.

## Why the existing tests missed it

The job tests seeded **one** summoner (real Id) and returned it from *both* `GetSummonerByRiotIdAsync` and `AddOrUpdateSummonerAsync`, so the empty-Id/persisted-Id split never existed in-test. The new regression test reproduces prod (distinct Riot instance with `Id == Guid.Empty` vs. persisted instance with a real Id) and asserts mastery is refreshed against the persisted Id, never `Guid.Empty`.

## Verification

- **Confirmed the regression test fails against pre-fix code** (mastery was upserted with `Guid.Empty`), passes with the fix.
- Core tests green: **159** (158 + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)