### PR TITLE
docs(dev): explain stray bin\Debug glob-corruption build failure (closes #74)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -182,6 +182,22 @@ Migration policy:
 
 Prod precedent: `IX_Summoners_Region_UpdatedAt` was applied exactly this way — see the note on the `HasIndex(PlatformRegion, UpdatedAt)` call in `Transcendence.Data/TranscendenceContext.cs`.
 
+#### Troubleshooting: `MSB3552` / `CS2001` on `**/*.cs` or `**/*.resx`
+
+If a **single-project** build or a `dotnet ef` design-time build of `Transcendence.Service` fails with the SDK default item glob shown *literally* —
+
+```
+error MSB3552: Resource file "**/*.resx" cannot be found.
+error CS2001: Source file '**/*.cs' could not be found.
+```
+
+— the project directory has a stray folder whose **name contains a backslash**, typically `bin\Debug` (one literal path component, not `bin/Debug`), left behind by an external tool that wrote a Windows-style path on macOS/Linux. MSBuild treats `\` as a path separator, so this entry corrupts the recursive `**` enumeration and `FileMatcher` falls back to returning the glob unexpanded. A plain `rm -rf bin obj` does **not** remove it (that only matches the folder named `bin`), and the whole-solution build masks it — which is why CI (`dotnet build Transcendence.sln`) stays green while `dotnet build Transcendence.Service/Transcendence.Service.csproj` (and `dotnet ef … --no-build` against it) break. Remove it explicitly:
+
+```bash
+rm -rf 'Transcendence.Service/bin\Debug'   # quote the backslash; it is part of the name
+# nuke-from-orbit equivalent: git clean -dfx -- Transcendence.Service
+```
+
 ### Run services
 
 ```bash


### PR DESCRIPTION
## TL;DR

`Transcendence.Service` standalone clean build failing with `MSB3552` / `CS2001` on `**/*.resx` / `**/*.cs` is **not a project-globbing defect**. Root cause: a stray folder named `bin\Debug` (a single path component with a **literal backslash**) left in the project dir by an external tool that wrote a Windows-style path on macOS. **Closes #74.**

## Diagnosis

The error shows the SDK default item glob reaching the compiler/`GenerateResource` *unexpanded*:

```
error MSB3552: Resource file "**/*.resx" cannot be found.
error CS2001: Source file '**/*.cs' could not be found.
```

MSBuild treats `\` as a path separator, so an on-disk entry literally named `bin\Debug` corrupts the recursive `**` enumeration and `FileMatcher` falls back to returning the glob literally.

Bisected to be sure — none of these mattered:
- the two `<Content Include="..\..."/>` parent-dir items
- the `<Folder Include="Migrations\"/>` item
- `Microsoft.NET.Sdk.Worker` vs `Microsoft.NET.Sdk`
- the `Microsoft.EntityFrameworkCore.Design` reference

Deleting the stray `bin\Debug` folder fixed it outright. Only `Transcendence.Service` had the artifact (dated days before this work); `Service.Core` and `WebAPI` build clean standalone.

## Why CI never caught it

- A plain `rm -rf bin obj` doesn't remove it — that matches the folder *named* `bin`, not `bin\Debug`.
- The whole-solution build masks it, so CI (`dotnet build Transcendence.sln` + `dotnet ef … --no-build`) stays green while `dotnet build <csproj>` and a single-project `dotnet ef` break locally.

## Fix

There's no code defect to fix — the globs are correct. This PR documents the failure signature and the one-line cleanup in `DEVELOPMENT.md`:

```bash
rm -rf 'Transcendence.Service/bin\Debug'   # quote the backslash; it is part of the name
```

CI's solution-build path is intentionally left as-is (correct, and never sees the stray artifact).

## Verified after cleanup

- `dotnet build Transcendence.Service/Transcendence.Service.csproj -c Debug` → **Build succeeded**
- `dotnet ef migrations has-pending-model-changes --project Transcendence.Service --startup-project Transcendence.Service --no-build` → no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)