### PR TITLE
fix(analytics): true pick rate on the champion page + compact role-scoped win-rate table (closes #76)

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
@@ -165,7 +165,12 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
                 Games: data.Games,
                 Wins: data.Wins,
                 WinRate: data.Games > 0 ? (double)data.Wins / data.Games : 0.0,
-                PickRate: totalGames > 0 ? (double)data.Games / totalGames : 0.0,
+                // P7.1: true pick rate — this champion's games in the (role, tier) over ALL champions'
+                // games in that same (role, tier) scope (roleRank.RoleTotalGames), matching
+                // ComputeTierListAsync's Games/totalParticipants. The previous denominator was this
+                // champion's OWN total games across roles, so the value was a role-distribution share
+                // (a one-role champ read ~100%), not a pick rate.
+                PickRate: roleRank.RoleTotalGames > 0 ? (double)data.Games / roleRank.RoleTotalGames : 0.0,
                 BanRate: banRate,
                 RoleRank: roleRank.RoleRank,
                 RolePopulation: roleRank.RolePopulation,
@@ -441,7 +446,7 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
         };
     }
 
-    private async Task<(int? RoleRank, int? RolePopulation)> ComputeRoleRankAsync(
+    private async Task<(int? RoleRank, int? RolePopulation, int RoleTotalGames)> ComputeRoleRankAsync(
         int championId,
         string role,
         string rankTier,
@@ -449,8 +454,14 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
         string? region,
         CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(role) || string.Equals(rankTier, "UNRANKED", StringComparison.OrdinalIgnoreCase))
-            return (null, null);
+        // RoleTotalGames is the sum of every champion's games in this exact (role, tier) scope — the
+        // true pick-rate denominator, derived for free from the same standings we build for the role
+        // rank (no extra query). The (role, tier) population is the same one the per-row query already
+        // scans, so this only reuses work.
+        if (string.IsNullOrWhiteSpace(role))
+            return (null, null, 0);
+
+        var isUnranked = string.Equals(rankTier, "UNRANKED", StringComparison.OrdinalIgnoreCase);
 
         var roleQuery = _context.MatchParticipants
             .AsNoTracking()
@@ -464,10 +475,17 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
         if (!string.IsNullOrWhiteSpace(region))
             roleQuery = roleQuery.Where(mp => mp.Summoner.PlatformRegion == region);
 
-        roleQuery = roleQuery.Where(mp => _context.Ranks.Any(r =>
-            r.QueueType == "RANKED_SOLO_5x5" &&
-            r.SummonerId == mp.SummonerId &&
-            r.Tier == rankTier));
+        // Match participantRanks' UNRANKED bucket = participants with no solo-queue rank, so the pick-rate
+        // denominator is well-defined for unranked rows too (e.g. the all-ranks view). The default
+        // Emerald+ view never produces UNRANKED rows, so the anti-join cost stays off the hot path.
+        roleQuery = isUnranked
+            ? roleQuery.Where(mp => !_context.Ranks.Any(r =>
+                r.QueueType == "RANKED_SOLO_5x5" &&
+                r.SummonerId == mp.SummonerId))
+            : roleQuery.Where(mp => _context.Ranks.Any(r =>
+                r.QueueType == "RANKED_SOLO_5x5" &&
+                r.SummonerId == mp.SummonerId &&
+                r.Tier == rankTier));
 
         var standings = await roleQuery
             .GroupBy(mp => mp.ChampionId)
@@ -483,11 +501,20 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             .ToListAsync(ct);
 
         if (standings.Count == 0)
-            return (null, null);
+            return (null, null, 0);
+
+        var roleTotalGames = standings.Sum(s => s.Games);
+
+        // Don't assign a competitive role rank within the UNRANKED bucket (preserves prior behaviour);
+        // the pick-rate denominator is still meaningful, so return it.
+        if (isUnranked)
+            return (null, null, roleTotalGames);
 
         var rolePopulation = standings.Count;
         var rank = standings.FindIndex(s => s.ChampionId == championId);
-        return rank >= 0 ? (rank + 1, rolePopulation) : (null, rolePopulation);
+        return rank >= 0
+            ? (rank + 1, rolePopulation, roleTotalGames)
+            : (null, rolePopulation, roleTotalGames);
     }
 
     private static int ResolveEffectiveSampleSize(int configuredMinimum, int availableGames, int floor)

--- a/apps/web/app/lol/champions/[championId]/page.tsx
+++ b/apps/web/app/lol/champions/[championId]/page.tsx
@@ -368,7 +368,13 @@ async function ChampionSections({
   const matchups = profile.matchups ?? null;
   const effectiveRole =
     normalizeRole(profile.effectiveRole) ?? explicitRole ?? pickMostPlayedRole(winrates) ?? "MIDDLE";
-  const winrateRows = winrates?.byRoleTier ?? [];
+  // Show only the active role's win rates (broken down by rank) so the table stays compact and
+  // doesn't dominate the page — other roles are reachable via the role filter. When a role is in the
+  // URL the backend already returns just that role, so this is a no-op there; on the default view it
+  // narrows the multi-role result to the most-played role (effectiveRole).
+  const winrateRows = (winrates?.byRoleTier ?? []).filter(
+    (w) => (w.role ?? "").toUpperCase() === effectiveRole.toUpperCase()
+  );
   const buildRows = builds?.builds ?? [];
   const globalCoreItems = builds?.globalCoreItems ?? [];
   const counters = matchups?.counters ?? [];
@@ -403,7 +409,8 @@ async function ChampionSections({
       {/* ── Win Rates Table ── */}
       <Card className="p-5">
         <h2 className="type-section">
-          Win Rates
+          Win Rate by Rank
+          <span className="ml-2 type-overline text-muted">{roleDisplayLabel(effectiveRole)}</span>
         </h2>
         {!winrates ? (
           <div className="mt-2">
@@ -417,7 +424,6 @@ async function ChampionSections({
             <table className="w-full text-left text-sm">
               <thead className="type-overline text-muted">
                 <tr className="border-b border-border/30">
-                  <th className="py-2 pr-4">Role</th>
                   <th className="py-2 pr-4">Tier</th>
                   <th className="py-2 pr-4 text-right">Win Rate</th>
                   <th className="py-2 pr-4 text-right">Pick Rate</th>
@@ -433,10 +439,7 @@ async function ChampionSections({
                       key={`${w.role ?? "ALL"}-${w.rankTier ?? "all"}`}
                       className="border-t border-border/40 transition hover:bg-surface-2/40"
                     >
-                      <td className="py-2.5 pr-4 font-medium">
-                        {roleDisplayLabel(w.role ?? "ALL")}
-                      </td>
-                      <td className="py-2.5 pr-4 text-muted">
+                      <td className="py-2.5 pr-4 font-medium text-muted">
                         {rankTierDisplayLabel(w.rankTier ?? "all")}
                       </td>
                       <td className="py-2.5 pr-4 text-right">

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
@@ -137,6 +137,64 @@ public class ChampionAnalyticsComputeServiceTests
     }
 
     [Fact]
+    public async Task ComputeWinRatesAsync_PickRateIsShareOfAllPicksInRoleTier_NotChampionRoleShare()
+    {
+        // P7.1: pick rate must be this champion's games in a (role, tier) over ALL champions' games in
+        // that same (role, tier) — not the champion's own role distribution. Seed two TOP champions so
+        // the two semantics diverge: champ 266 plays TOP twice, champ 999 plays TOP eight times. The
+        // true pick rate for 266 is 2/10 = 0.2; the old role-share denominator (266's own 2 games)
+        // would have read 2/2 = 1.0.
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<TranscendenceContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Patches.Add(new Patch
+        {
+            Version = "15.2",
+            ReleaseDate = DateTime.UtcNow.AddDays(-2),
+            DetectedAt = DateTime.UtcNow.AddDays(-2),
+            IsActive = true
+        });
+
+        SeedMatch(db, "15.2", "NA1_266_1", summonerName: "P266a", championId: 266, role: "TOP", win: true);
+        SeedMatch(db, "15.2", "NA1_266_2", summonerName: "P266b", championId: 266, role: "TOP", win: false);
+        for (var i = 0; i < 8; i++)
+        {
+            SeedMatch(db, "15.2", $"NA1_999_{i}", summonerName: $"P999_{i}", championId: 999, role: "TOP", win: i % 2 == 0);
+        }
+        await db.SaveChangesAsync();
+
+        var service = new ChampionAnalyticsComputeService(
+            db,
+            Options.Create(new ChampionAnalyticsComputeOptions
+            {
+                MinimumGamesRequired = 1,
+                EarlyPatchMinimumGamesRequired = 1,
+                BootstrapPatchMinimumGamesRequired = 1,
+                BootstrapWindowHours = 24,
+                ProvisionalWindowHours = 96,
+                MaturingWindowHours = 240
+            }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+
+        var result = await service.ComputeWinRatesAsync(
+            266, new ChampionAnalyticsFilter(), "15.2", CancellationToken.None);
+
+        result.Should().ContainSingle();
+        var row = result[0];
+        row.Role.Should().Be("TOP");
+        row.Games.Should().Be(2);
+        // 2 of the 10 TOP picks in scope — a true pick rate, not the champion's own role share (1.0).
+        row.PickRate.Should().BeApproximately(0.2, 0.0001);
+    }
+
+    [Fact]
     public async Task ComputeProChampionPlayrateAsync_RanksChampionsAndHonorsScope()
     {
         await using var connection = new SqliteConnection("Data Source=:memory:");


### PR DESCRIPTION
Finishes **P7.1**. **Closes #76.**

## Backend — pick rate is now a *true* pick rate

`ComputeWinRatesAsync` reported `PickRate` as this champion's games in a `(role, tier)` ÷ the champion's **own** total games across roles — a role-distribution *share*, so a one-role champion read **~100%** on the champion page's "Pick Rate" column (display-only; it feeds no score). Now it's:

```
champ's games in (role, tier)  ÷  ALL champions' games in that same (role, tier)
```

matching `ComputeTierListAsync`'s `Games / totalParticipants`. The denominator is **reused for free** from `ComputeRoleRankAsync`'s standings (sum of every champion's games in that role+tier — no extra query for ranked rows). Made that method UNRANKED-aware (no-rank anti-join) so the all-ranks view gets a real denominator too; the default **Emerald+ view never yields UNRANKED rows, so the anti-join stays off the hot path**. `RoleRank`/`RolePopulation` behaviour is unchanged.

### Audit of the other surfaces (the rest of #76)
- **Tier list** — already a true pick rate. ✅
- **Pro analytics** — returns raw counts (`Games`, `UniquePlayers`), no ratio. ✅
- **Summoner stats / matchups** — expose no pick/ban rate. ✅
- **Ban rate** — already corrected in the P7.1 first pass. ✅

So the only real denominator bug was the win-rate table's pick rate.

## Frontend — the win-rate table no longer dominates

Per the ask on the issue: the table listed **every** `(role, tier)` row, so a multi-role champion's table dominated the page. Now it:
- shows **only the active role's** per-rank rows (`effectiveRole`; switch roles via the existing role filter),
- drops the now-redundant **Role** column,
- is retitled **"Win Rate by Rank"** with the role shown inline.

The hero `StatsBar` and this table now render the corrected true pick rate.

## Tests / checks
- Core **160** green. Added a two-champion case where the semantics diverge: 266 plays TOP 2×, 999 plays TOP 8× → true pick rate **0.2** (old role-share would be **1.0**). The pre-existing single-champion case still asserts **1.0** (a sole-occupant role *is* 100% of picks).
- WebAPI **34** green. `ChampionWinRateDto` is unchanged (same field, corrected value) → no OpenAPI/client regen.
- Web `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)