### PR TITLE
ops(db): declarative + version-controlled Postgres memory tuning (closes #71)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,16 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=changme
 REDIS_CONNECTION=redis:6379
 
+# Postgres memory tuning (passed to `postgres -c` by compose). Unset = Postgres defaults, which is
+# correct for local dev — do NOT raise these on a small Docker VM. PROD (the 16GB host) sets the
+# tuned values below in its Portainer stack.env to resolve the 2026-06-21 DB-saturation incident;
+# kept here as the canonical, version-controlled values. See scripts/ops/README.md.
+#   POSTGRES_SHARED_BUFFERS=4GB
+#   POSTGRES_WORK_MEM=24MB
+#   POSTGRES_EFFECTIVE_CACHE_SIZE=12GB
+#   POSTGRES_MAINTENANCE_WORK_MEM=512MB
+#   POSTGRES_SHM_SIZE=1gb
+
 # Riot API keys
 RIOT_API_KEY_LOL=RGAPI-CHANGE_ME
 RIOT_API_KEY_TFT=RGAPI-CHANGE_ME

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,23 @@ services:
     image: postgres:16-alpine
     container_name: transcendence-postgres
     restart: unless-stopped
+    # Memory tuning is declarative here so it survives a postgres_data volume rebuild and is
+    # version-controlled, rather than living only in ALTER SYSTEM / postgresql.auto.conf inside the
+    # volume (the 2026-06-21 DB-saturation incident fix). Defaults match Postgres/Docker out-of-box, so
+    # local `docker compose up` is unchanged; prod sets the tuned values in its stack.env — see
+    # .env.example and scripts/ops/README.md ("Postgres memory tuning"). Command-line -c options take
+    # precedence over postgresql.auto.conf, so these are authoritative once auto.conf is reset on prod.
+    command:
+      - "postgres"
+      - "-c"
+      - "shared_buffers=${POSTGRES_SHARED_BUFFERS:-128MB}"
+      - "-c"
+      - "work_mem=${POSTGRES_WORK_MEM:-4MB}"
+      - "-c"
+      - "effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-4GB}"
+      - "-c"
+      - "maintenance_work_mem=${POSTGRES_MAINTENANCE_WORK_MEM:-64MB}"
+    shm_size: "${POSTGRES_SHM_SIZE:-64mb}"
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -84,3 +84,42 @@ tail -f /root/trn-archive.log                                # run history
 incident** — the `COPY` of millions of rows saturates the HDD. Restore instructions are
 in each script's header. Deleted rows free pages for reuse inside Postgres; the file does
 not shrink without `VACUUM FULL` (intentionally avoided — it locks the table).
+
+## Postgres memory tuning (declarative)
+
+The 2026-06-21 DB-saturation incident was resolved by retuning Postgres
+(`shared_buffers` 128MB→4GB, `work_mem`→24MB, `effective_cache_size`→12GB,
+`maintenance_work_mem`→512MB) via `ALTER SYSTEM`, which writes `postgresql.auto.conf`
+**inside the `postgres_data` volume** — so it survives a restart but is lost if the volume
+is rebuilt, and is not version-controlled (#71).
+
+`compose.yml` now passes these as `postgres -c` flags sourced from env vars that default to
+Postgres's out-of-box values (local dev is unaffected — do **not** raise them on a small
+Docker VM). To make the tuning durable on **prod** (the 16GB host), set the values in the
+Portainer stack's `stack.env` (the canonical values are listed in `.env.example`):
+
+```sh
+# in the Portainer stack env (alongside POSTGRES_PASSWORD etc.)
+POSTGRES_SHARED_BUFFERS=4GB
+POSTGRES_WORK_MEM=24MB
+POSTGRES_EFFECTIVE_CACHE_SIZE=12GB
+POSTGRES_MAINTENANCE_WORK_MEM=512MB
+POSTGRES_SHM_SIZE=1gb
+```
+
+Then recreate **only** the postgres container in a quiet window (a restart drops all
+connections, ~seconds of downtime):
+
+```bash
+COMPOSE_DIR=/var/lib/docker/volumes/portainer_data/_data/compose/2   # poll-deploy.sh COMPOSE_DIR
+docker compose -p transcendence --env-file "$COMPOSE_DIR/stack.env" \
+  -f "$COMPOSE_DIR/docker-compose.yml" up -d postgres                # picks up the new -c flags + shm_size
+# verify:
+docker exec transcendence-postgres psql -U postgres -c 'SHOW shared_buffers; SHOW work_mem;'
+```
+
+`stack.env` lives in the Portainer compose dir (not the `postgres_data` volume), so the
+tuning now survives a DB volume rebuild. Command-line `-c` flags take precedence over
+`postgresql.auto.conf`; once verified, drop the old override so there is a single source of
+truth: `ALTER SYSTEM RESET shared_buffers; … RESET work_mem; …` then reload. `poll-deploy.sh`
+only redeploys the app containers, so it never touches postgres — this is a one-time manual step.


### PR DESCRIPTION
**Closes #71.** Makes the 2026-06-21 DB-saturation tuning durable and version-controlled without affecting local dev.

## Problem

The incident fix (`shared_buffers` 128MB→4GB, `work_mem`→24MB, `effective_cache_size`→12GB, `maintenance_work_mem`→512MB) was applied via `ALTER SYSTEM` → `postgresql.auto.conf` **inside the `postgres_data` volume**: survives a restart, but **lost on a volume rebuild**, and not version-controlled.

## Constraint that shaped the fix

`compose.yml` is the **local-dev Quick Start** (`docker compose up --build`), so hardcoding 4GB/12GB would break small Docker VMs. And prod runs a **Portainer-managed** copy of the stack; `poll-deploy.sh` only redeploys the app containers (never postgres).

## Approach

- `compose.yml` passes the tuning as `postgres -c` flags from env vars that **default to Postgres/Docker out-of-box values** → local dev is byte-for-byte unchanged (verified with `docker compose config`: `shared_buffers=128MB`, `shm_size=64MB` with no overrides).
- Prod sets the tuned values in its Portainer **`stack.env`**, which lives **outside** the `postgres_data` volume → the tuning now survives a DB volume rebuild (the actual #71 ask).
- Canonical prod values documented in `.env.example`; a **"Postgres memory tuning" runbook** added to `scripts/ops/README.md` (set `stack.env`, recreate only the postgres container in a quiet window, verify, then `ALTER SYSTEM RESET` so the `-c` flags are the single source of truth).

## Notes

- Command-line `-c` options take precedence over `postgresql.auto.conf`; the runbook still resets auto.conf to avoid a dual source.
- The prod apply is a one-time manual step (a postgres recreate drops connections for a few seconds) — intentionally not wired into `poll-deploy.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)