### PR TITLE
fix(timeline): race-safe fetch-state upsert (ON CONFLICT) to kill 23505 dup-key (closes #72)

### DIFF
--- a/Transcendence.Service.Core/Services/Jobs/MatchTimelineIngestionJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/MatchTimelineIngestionJob.cs
@@ -53,19 +53,23 @@ public class MatchTimelineIngestionJob(
             return;
         }
 
+        // Race-safe get-or-create. The ingestion and backfill paths can target the same match
+        // concurrently; both would find no row and Add one, colliding on PK_MatchTimelineFetchStates
+        // (23505) at SaveChanges and burning a Hangfire retry. Insert idempotently first
+        // (ON CONFLICT DO NOTHING) so the row is guaranteed to exist, then load it tracked and fall
+        // through to the normal update path — the later field writes become last-writer-wins UPDATEs
+        // (benign) instead of a PK INSERT collision. The seeded columns are the non-nullable ones with
+        // no DB default; their values match `new MatchTimelineFetchState{}` (Unfetched / 0 / 0).
+        await db.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+             INSERT INTO "MatchTimelineFetchStates" ("MatchId", "Status", "RetryCount", "SchemaVersion")
+             VALUES ({match.Id}, 0, 0, 0)
+             ON CONFLICT ("MatchId") DO NOTHING
+             """, ct);
+
         var state = await db.MatchTimelineFetchStates
             .IgnoreQueryFilters()
-            .FirstOrDefaultAsync(x => x.MatchId == match.Id, ct);
-
-        if (state == null)
-        {
-            state = new MatchTimelineFetchState
-            {
-                MatchId = match.Id,
-                Match = match
-            };
-            db.MatchTimelineFetchStates.Add(state);
-        }
+            .FirstAsync(x => x.MatchId == match.Id, ct);
 
         var maxRetryAttempts = Math.Max(1, jobOptions.MaxRetryAttempts);
         if (state.Status == MatchTimelineFetchStatus.Success && state.SchemaVersion >= CurrentTimelineSchemaVersion)


### PR DESCRIPTION
**Closes #72.**

## Problem

`MatchTimelineIngestionJob` can be enqueued for the same match concurrently by the ingestion and backfill paths. Both ran a get-or-create — `FirstOrDefault` → null → `Add` a new `MatchTimelineFetchState` — so the second `SaveChanges` hit:

```
Npgsql.PostgresException 23505: duplicate key value violates unique constraint "PK_MatchTimelineFetchStates"
```

It self-heals via Hangfire retry (net Failed ≈ 0), but burns a retry, adds `DbUpdateException` log noise, and risks a permanent fail if both attempts keep racing.

## Fix

Replace the create branch with an idempotent insert, then load the now-guaranteed row tracked and fall through to the normal update path:

```sql
INSERT INTO "MatchTimelineFetchStates" ("MatchId", "Status", "RetryCount", "SchemaVersion")
VALUES ({match.Id}, 0, 0, 0)
ON CONFLICT ("MatchId") DO NOTHING
```

- Same `ON CONFLICT` idiom the repo already uses (`SummonerRepository`).
- The later field writes become **last-writer-wins UPDATEs** (benign) instead of a PK INSERT collision.
- Seeded columns are exactly the non-nullable ones without a DB default; values match `new MatchTimelineFetchState{}` (`Unfetched / 0 / 0`).
- The existing-row path already materialised `state` without the `Match` nav (never `Include`'d; no code reads `state.Match`), so loading instead of constructing is behaviour-preserving.

## Verification

- Build clean; Core suite green (**160**).
- No dedicated test: a deterministic concurrency repro needs a full job harness (db + Camille Riot context + rate gate + options) — disproportionate for a self-healing issue, and the fix is the established `ON CONFLICT` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)