### PR TITLE
ops(compose): reconcile postgres service with prod (pgautoupgrade PG18 + mount)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,15 +8,23 @@ x-app-env: &app-env
 
 services:
   postgres:
-    image: postgres:16-alpine
+    # Mirrors the prod stack so this file is a safe deploy source: pgautoupgrade (runs pg_upgrade across
+    # major versions in place) on Postgres 18, with the data volume mounted at /var/lib/postgresql —
+    # pgautoupgrade keeps PGDATA under /var/lib/postgresql/<major>/docker, NOT /var/lib/postgresql/data
+    # like the stock postgres image, so the mount path must match the image. NOTE: an existing local
+    # postgres:16 volume won't auto-migrate cleanly across this image+mount change — remove it first
+    # (`docker compose down -v`, or `docker volume rm transcendence_postgres_data`) for a clean PG18 init.
+    image: pgautoupgrade/pgautoupgrade:18.3-alpine
     container_name: transcendence-postgres
     restart: unless-stopped
-    # Memory tuning is declarative here so it survives a postgres_data volume rebuild and is
-    # version-controlled, rather than living only in ALTER SYSTEM / postgresql.auto.conf inside the
-    # volume (the 2026-06-21 DB-saturation incident fix). Defaults match Postgres/Docker out-of-box, so
-    # local `docker compose up` is unchanged; prod sets the tuned values in its stack.env — see
-    # .env.example and scripts/ops/README.md ("Postgres memory tuning"). Command-line -c options take
-    # precedence over postgresql.auto.conf, so these are authoritative once auto.conf is reset on prod.
+    # Memory tuning is declarative (passed as `postgres -c`) so it survives a postgres_data volume
+    # rebuild and is version-controlled, rather than living only in ALTER SYSTEM / postgresql.auto.conf
+    # inside the volume (the 2026-06-21 DB-saturation incident fix). Defaults match Postgres/Docker
+    # out-of-box, so local `docker compose up` is unchanged — do NOT raise them for a local DB on a small
+    # Docker VM. The prod stack pins the real values (shared_buffers=4GB etc.) directly in its Portainer
+    # compose command as a failsafe; a deploy of THIS file must set the POSTGRES_* vars (.env.example) or
+    # it falls back to Postgres defaults. See scripts/ops/README.md ("Postgres memory tuning"). -c options
+    # take precedence over postgresql.auto.conf, so they're authoritative once auto.conf is reset on prod.
     command:
       - "postgres"
       - "-c"
@@ -35,7 +43,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -93,33 +93,41 @@ The 2026-06-21 DB-saturation incident was resolved by retuning Postgres
 **inside the `postgres_data` volume** — so it survives a restart but is lost if the volume
 is rebuilt, and is not version-controlled (#71).
 
-`compose.yml` now passes these as `postgres -c` flags sourced from env vars that default to
-Postgres's out-of-box values (local dev is unaffected — do **not** raise them on a small
-Docker VM). To make the tuning durable on **prod** (the 16GB host), set the values in the
-Portainer stack's `stack.env` (the canonical values are listed in `.env.example`):
+The repo `compose.yml` passes these as `postgres -c` flags sourced from env vars that default
+to Postgres's out-of-box values (local dev is unaffected — do **not** raise them on a small
+Docker VM). The values live in the compose file / stack env, which sit outside the
+`postgres_data` volume, so the tuning survives a DB volume rebuild.
 
-```sh
-# in the Portainer stack env (alongside POSTGRES_PASSWORD etc.)
-POSTGRES_SHARED_BUFFERS=4GB
-POSTGRES_WORK_MEM=24MB
-POSTGRES_EFFECTIVE_CACHE_SIZE=12GB
-POSTGRES_MAINTENANCE_WORK_MEM=512MB
-POSTGRES_SHM_SIZE=1gb
+**Current prod state (applied 2026-06-21, zero downtime).** The **Portainer** compose's
+`postgres` service now hardcodes the values directly in its `command` (failsafe — they can't
+silently fall back to the 128MB default), added without restarting the container:
+
+```yaml
+# in <COMPOSE_DIR>/docker-compose.yml, postgres service
+command: ["postgres","-c","shared_buffers=4GB","-c","work_mem=24MB","-c","effective_cache_size=12GB","-c","maintenance_work_mem=512MB"]
 ```
 
-Then recreate **only** the postgres container in a quiet window (a restart drops all
-connections, ~seconds of downtime):
+The running container was **not** restarted: the values are already live via `postgresql.auto.conf`,
+and the new `-c` flags take effect on the next deliberate postgres restart (and on a fresh volume).
+After that restart, single-source them by dropping the auto.conf override — do **not** do this
+before the restart, since the reloadable params would drop live:
+
+```bash
+docker exec transcendence-postgres psql -U postgres -d transcendence \
+  -c "ALTER SYSTEM RESET shared_buffers;  ALTER SYSTEM RESET work_mem;" \
+  -c "ALTER SYSTEM RESET effective_cache_size; ALTER SYSTEM RESET maintenance_work_mem;"
+docker exec transcendence-postgres psql -U postgres -c 'SHOW shared_buffers; SHOW work_mem;'  # verify
+```
+
+To recreate postgres deliberately (a restart drops connections, ~seconds of downtime):
 
 ```bash
 COMPOSE_DIR=/var/lib/docker/volumes/portainer_data/_data/compose/2   # poll-deploy.sh COMPOSE_DIR
 docker compose -p transcendence --env-file "$COMPOSE_DIR/stack.env" \
-  -f "$COMPOSE_DIR/docker-compose.yml" up -d postgres                # picks up the new -c flags + shm_size
-# verify:
-docker exec transcendence-postgres psql -U postgres -c 'SHOW shared_buffers; SHOW work_mem;'
+  -f "$COMPOSE_DIR/docker-compose.yml" up -d postgres
 ```
 
-`stack.env` lives in the Portainer compose dir (not the `postgres_data` volume), so the
-tuning now survives a DB volume rebuild. Command-line `-c` flags take precedence over
-`postgresql.auto.conf`; once verified, drop the old override so there is a single source of
-truth: `ALTER SYSTEM RESET shared_buffers; … RESET work_mem; …` then reload. `poll-deploy.sh`
-only redeploys the app containers, so it never touches postgres — this is a one-time manual step.
+`poll-deploy.sh` only redeploys the app containers, so it never touches postgres — this is a
+one-time manual step. **Note:** prod postgres is `pgautoupgrade/pgautoupgrade:18.3-alpine` (PG 18),
+data volume mounted at `/var/lib/postgresql` (PGDATA under `/var/lib/postgresql/18/docker`); the
+repo `compose.yml` mirrors this so it's a safe deploy source.


### PR DESCRIPTION
Reconciles the repo `compose.yml` postgres service with prod, which had drifted into an **unsafe deploy source**.

## The drift

| | repo (before) | prod (actual) |
|---|---|---|
| image | `postgres:16-alpine` | `pgautoupgrade/pgautoupgrade:18.3-alpine` (PG 18) |
| volume mount | `/var/lib/postgresql/data` | `/var/lib/postgresql` |
| PGDATA | `/var/lib/postgresql/data` | `/var/lib/postgresql/18/docker` |

Deploying the repo file to prod would have changed **both** the image and the mount path → Postgres couldn't find its data dir.

## Changes

- `image` → `pgautoupgrade/pgautoupgrade:18.3-alpine`
- volume mount → `/var/lib/postgresql`
- Comment documents the pgautoupgrade/PGDATA layout and that switching an existing local `postgres:16` volume needs a clean reset (`docker compose down -v`) — the image+mount change won't auto-migrate in place.
- The env-var-defaulted `-c` tuning is kept (local → Postgres defaults; prod pins the real values).
- `scripts/ops/README.md` updated to match what's **actually live on prod**: the Portainer compose hardcodes the tuning in `command` (failsafe — can't fall back to the 128MB incident value), added zero-downtime with no restart (values stay live via `auto.conf`, `-c` applies on the next restart), `auto.conf` RESET deferred until after that restart.

## Verified

`docker compose config` renders `image: pgautoupgrade/pgautoupgrade:18.3-alpine` and mount `/var/lib/postgresql`, no errors.

> Note: prod's DB tuning is hardcoded in its Portainer `command` (failsafe), so this file's env-var defaults are not relied on by prod; the README warns that a deploy of *this* file must set the `POSTGRES_*` vars or it falls back to Postgres defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)