### PR TITLE
feat(api): standardize error bodies on ProblemDetails (P7.2)

### DIFF
--- a/Transcendence.WebAPI/Errors/ProblemDetailsErrorBodyFilter.cs
+++ b/Transcendence.WebAPI/Errors/ProblemDetailsErrorBodyFilter.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Transcendence.WebAPI.Errors;
+
+/// <summary>
+/// Normalizes body-carrying client/server-error responses to RFC 7807 ProblemDetails so every error the
+/// API emits has one shape (P7.2). <c>[ApiController]</c> already maps <em>empty-body</em> 4xx/5xx results
+/// (e.g. <c>NotFound()</c>) and model-validation failures (<see cref="ValidationProblemDetails"/>) to
+/// ProblemDetails, and <see cref="ApiExceptionHandler"/> covers unhandled exceptions. The remaining gap is
+/// an action that returns a 4xx/5xx with a <em>string</em> body — e.g. <c>BadRequest("Invalid champion id.")</c>
+/// — which ships as a bare JSON string. This filter rewraps that string as the ProblemDetails <c>detail</c>.
+///
+/// Already-ProblemDetails bodies (including <see cref="ValidationProblemDetails"/>) are left untouched, as
+/// are structured object bodies (e.g. the admin endpoints' <c>{ message, detail }</c> shapes), which are
+/// already self-describing JSON.
+/// </summary>
+public sealed class ProblemDetailsErrorBodyFilter(ProblemDetailsFactory problemDetailsFactory) : IAlwaysRunResultFilter
+{
+    public void OnResultExecuting(ResultExecutingContext context)
+    {
+        if (context.Result is not ObjectResult { StatusCode: >= 400 and <= 599 } result)
+            return;
+
+        // Leave already-normalized bodies and structured payloads alone; only bare string bodies are the gap.
+        if (result.Value is not string detail)
+            return;
+
+        var statusCode = result.StatusCode!.Value;
+        var problemDetails = problemDetailsFactory.CreateProblemDetails(
+            context.HttpContext,
+            statusCode: statusCode,
+            detail: detail);
+
+        context.Result = new ObjectResult(problemDetails)
+        {
+            StatusCode = statusCode,
+            ContentTypes = { "application/problem+json" }
+        };
+    }
+
+    public void OnResultExecuted(ResultExecutedContext context)
+    {
+        // No-op: the response has already been written by the time this runs.
+    }
+}

--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -45,7 +45,11 @@ if (bootstrapApiKeyDevOnly && !builder.Environment.IsDevelopment() && !string.Is
 
 // Add services to the container.
 
-builder.Services.AddControllers();
+builder.Services.AddControllers(options =>
+    // Normalize body-carrying error responses (e.g. BadRequest("...")) to ProblemDetails — see
+    // ProblemDetailsErrorBodyFilter. Empty-body 4xx/5xx + model validation are already ProblemDetails
+    // via [ApiController]; unhandled exceptions via ApiExceptionHandler.
+    options.Filters.Add<ProblemDetailsErrorBodyFilter>());
 builder.Services.AddProblemDetails();
 builder.Services.AddExceptionHandler<ApiExceptionHandler>();
 builder.Services.AddRateLimiter(options =>

--- a/apps/web/app/lol/summoners/[region]/[riotId]/page.tsx
+++ b/apps/web/app/lol/summoners/[region]/[riotId]/page.tsx
@@ -111,13 +111,17 @@ export default async function SummonerProfilePage({
   let initialBody: unknown = result.body;
 
   if (!result.ok && initialStatus !== 202) {
-    const messageFromBackend =
-      isRecord(result.body) &&
-      (typeof result.body.message === "string" || typeof result.body.title === "string")
-        ? (typeof result.body.message === "string"
+    // Backend errors are ProblemDetails (RFC 7807): `detail` is the specific message, `title` the
+    // generic one. Some admin-style bodies use `message`. Prefer the most specific available.
+    const messageFromBackend = isRecord(result.body)
+      ? (typeof result.body.detail === "string"
+          ? result.body.detail
+          : typeof result.body.message === "string"
             ? result.body.message
-            : result.body.title) as string
-        : null;
+            : typeof result.body.title === "string"
+              ? result.body.title
+              : null)
+      : null;
 
     const message =
       messageFromBackend ??

--- a/tests/Transcendence.WebAPI.Tests/ProblemDetailsErrorBodyFilterTests.cs
+++ b/tests/Transcendence.WebAPI.Tests/ProblemDetailsErrorBodyFilterTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Transcendence.WebAPI.Errors;
+
+namespace Transcendence.WebAPI.Tests;
+
+public class ProblemDetailsErrorBodyFilterTests
+{
+    private static (ProblemDetailsErrorBodyFilter filter, ServiceProvider services) Create()
+    {
+        var sc = new ServiceCollection();
+        sc.AddLogging();
+        sc.AddControllers();
+        sc.AddProblemDetails();
+        var services = sc.BuildServiceProvider();
+        var filter = new ProblemDetailsErrorBodyFilter(services.GetRequiredService<ProblemDetailsFactory>());
+        return (filter, services);
+    }
+
+    private static ResultExecutingContext Context(ServiceProvider services, IActionResult result)
+    {
+        var httpContext = new DefaultHttpContext { RequestServices = services };
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        return new ResultExecutingContext(actionContext, new List<IFilterMetadata>(), result, controller: new object());
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.Status400BadRequest)]
+    [InlineData(StatusCodes.Status404NotFound)]
+    [InlineData(StatusCodes.Status409Conflict)]
+    public void StringErrorBody_IsRewrappedAsProblemDetails(int statusCode)
+    {
+        var (filter, services) = Create();
+        var context = Context(services, new ObjectResult("Invalid champion id.") { StatusCode = statusCode });
+
+        filter.OnResultExecuting(context);
+
+        var result = context.Result.Should().BeOfType<ObjectResult>().Subject;
+        result.StatusCode.Should().Be(statusCode);
+        result.ContentTypes.Should().Contain("application/problem+json");
+        var problem = result.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problem.Status.Should().Be(statusCode);
+        problem.Detail.Should().Be("Invalid champion id.");
+        problem.Title.Should().NotBeNullOrWhiteSpace(); // filled from the status code
+    }
+
+    [Fact]
+    public void StructuredObjectBody_IsLeftUntouched()
+    {
+        var (filter, services) = Create();
+        var original = new BadRequestObjectResult(new { message = "Unsupported state." });
+        var context = Context(services, original);
+
+        filter.OnResultExecuting(context);
+
+        context.Result.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void AlreadyProblemDetailsBody_IsLeftUntouched()
+    {
+        var (filter, services) = Create();
+        var original = new ObjectResult(new ProblemDetails { Status = 400, Detail = "already" }) { StatusCode = 400 };
+        var context = Context(services, original);
+
+        filter.OnResultExecuting(context);
+
+        context.Result.Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void SuccessStringBody_IsLeftUntouched()
+    {
+        var (filter, services) = Create();
+        var original = new OkObjectResult("fine");
+        var context = Context(services, original);
+
+        filter.OnResultExecuting(context);
+
+        context.Result.Should().BeSameAs(original);
+    }
+}


### PR DESCRIPTION
First half of **P7.2** (#77): one shape for every error the API emits.

## State before
- ✅ Unhandled exceptions → ProblemDetails (`ApiExceptionHandler`)
- ✅ Empty-body 4xx/5xx (`NotFound()` etc.) + model validation → ProblemDetails / `ValidationProblemDetails` (`[ApiController]`, 13 controllers)
- ❌ Actions returning a 4xx/5xx with a **string** body — `BadRequest("Invalid champion id.")` (~40 sites) — shipped a bare JSON string

## Change
A global `ProblemDetailsErrorBodyFilter` (`IAlwaysRunResultFilter`) rewraps a body-carrying error `ObjectResult` whose value is a `string` into RFC 7807 ProblemDetails — the string becomes `detail`, title/status from the code, `application/problem+json`.

- **Centralized** (one filter) rather than editing ~40 call sites — and it enforces the convention for future controllers. The existing controller unit tests assert on the pre-pipeline `IActionResult`, so they're unaffected.
- Left untouched: already-ProblemDetails bodies (incl. `ValidationProblemDetails`) and the admin endpoints' structured `{ message, detail }` objects (self-describing JSON, internal UI — a follow-up if we want those normalized too).

**Frontend:** the summoner page's backend-error reader now prefers ProblemDetails `detail` (specific) over `message`/`title`.

## Verification
- 6 new filter tests (string body @ 400/404/409 → ProblemDetails with `detail`; object body, already-ProblemDetails, and 2xx string body all pass through). WebAPI **34 → 40** green.
- Web `eslint` + `tsc --noEmit` clean.
- Runtime-only — no controller/DTO signatures change, so the OpenAPI spec + generated TS client are unaffected (no `api:check` churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)