### PR TITLE
feat(auth): refresh-token reuse detection (P8.1)

### DIFF
--- a/Transcendence.Data/Repositories/Implementations/UserAccountRepository.cs
+++ b/Transcendence.Data/Repositories/Implementations/UserAccountRepository.cs
@@ -71,11 +71,32 @@ public class UserAccountRepository(TranscendenceContext db) : IUserAccountReposi
                 x.ExpiresAtUtc > now, ct);
     }
 
+    public Task<UserRefreshToken?> GetRefreshTokenByHashAsync(string tokenHash, CancellationToken ct = default)
+    {
+        // Any state — revoked/expired included — so the refresh flow can distinguish "never existed"
+        // from "already rotated" (reuse). Includes the account + roles so an active hit can mint tokens.
+        return db.Set<UserRefreshToken>()
+            .Include(x => x.UserAccount)
+            .ThenInclude(x => x.Roles)
+            .FirstOrDefaultAsync(x => x.TokenHash == tokenHash, ct);
+    }
+
     public Task RevokeRefreshTokenAsync(UserRefreshToken token, string? replacedByTokenHash, CancellationToken ct = default)
     {
         token.RevokedAtUtc = DateTime.UtcNow;
         token.ReplacedByTokenHash = replacedByTokenHash;
         return Task.CompletedTask;
+    }
+
+    public async Task<int> RevokeAllActiveRefreshTokensForUserAsync(Guid userAccountId, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var tokens = await db.Set<UserRefreshToken>()
+            .Where(x => x.UserAccountId == userAccountId && x.RevokedAtUtc == null)
+            .ToListAsync(ct);
+        foreach (var token in tokens)
+            token.RevokedAtUtc = now;
+        return tokens.Count;
     }
 
     public async Task<bool> RevokeActiveRefreshTokenByHashAsync(string tokenHash, CancellationToken ct = default)

--- a/Transcendence.Data/Repositories/Interfaces/IUserAccountRepository.cs
+++ b/Transcendence.Data/Repositories/Interfaces/IUserAccountRepository.cs
@@ -13,7 +13,11 @@ public interface IUserAccountRepository
     Task<bool> HasRoleAsync(Guid userAccountId, string role, CancellationToken ct = default);
     Task AddRefreshTokenAsync(UserRefreshToken refreshToken, CancellationToken ct = default);
     Task<UserRefreshToken?> GetActiveRefreshTokenAsync(string tokenHash, CancellationToken ct = default);
+    /// <summary>Looks up a refresh token by hash regardless of its revoked/expired state (for reuse detection).</summary>
+    Task<UserRefreshToken?> GetRefreshTokenByHashAsync(string tokenHash, CancellationToken ct = default);
     Task RevokeRefreshTokenAsync(UserRefreshToken token, string? replacedByTokenHash, CancellationToken ct = default);
     Task<bool> RevokeActiveRefreshTokenByHashAsync(string tokenHash, CancellationToken ct = default);
+    /// <summary>Revokes every not-yet-revoked refresh token for a user (the whole family). Returns the count revoked.</summary>
+    Task<int> RevokeAllActiveRefreshTokensForUserAsync(Guid userAccountId, CancellationToken ct = default);
     Task SaveChangesAsync(CancellationToken ct = default);
 }

--- a/Transcendence.Service.Core/Services/Auth/Implementations/UserAuthService.cs
+++ b/Transcendence.Service.Core/Services/Auth/Implementations/UserAuthService.cs
@@ -76,8 +76,31 @@ public class UserAuthService(
             return null;
 
         var tokenHash = jwtService.HashRefreshToken(request.RefreshToken);
-        var currentToken = await userAccountRepository.GetActiveRefreshTokenAsync(tokenHash, ct);
+        var currentToken = await userAccountRepository.GetRefreshTokenByHashAsync(tokenHash, ct);
         if (currentToken == null) return null;
+
+        if (currentToken.RevokedAtUtc != null)
+        {
+            // Refresh-token reuse detection: a token that was already ROTATED (revoked with a successor)
+            // is being presented again — the legitimate client would be using the successor, so this
+            // signals the token was stolen. Revoke the whole family so neither the attacker nor a
+            // possibly-compromised client can keep refreshing; the user must re-authenticate. A token
+            // revoked by logout (no successor) is just replayed/stale — fail without nuking a fresh session.
+            if (currentToken.ReplacedByTokenHash != null)
+            {
+                var revokedCount = await userAccountRepository
+                    .RevokeAllActiveRefreshTokensForUserAsync(currentToken.UserAccountId, ct);
+                await userAccountRepository.SaveChangesAsync(ct);
+                logger.LogWarning(
+                    "Refresh-token reuse detected for user {UserAccountId}; revoked {Count} active token(s) in the family.",
+                    currentToken.UserAccountId, revokedCount);
+            }
+
+            return null;
+        }
+
+        if (currentToken.ExpiresAtUtc <= DateTime.UtcNow)
+            return null;
 
         var user = currentToken.UserAccount;
         var newRefreshToken = jwtService.GenerateRefreshToken();

--- a/tests/Transcendence.Service.Core.Tests/UserAuthServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/UserAuthServiceTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using Transcendence.Data.Models.Auth;
 using Transcendence.Data.Repositories.Interfaces;
 using Transcendence.Service.Core.Services.Auth.Implementations;
 using Transcendence.Service.Core.Services.Auth.Interfaces;
@@ -56,6 +57,113 @@ public class UserAuthServiceTests
 
         await act.Should().ThrowAsync<ArgumentException>()
             .WithMessage("*at least 12 characters*");
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenRotatedTokenReused_RevokesFamilyAndReturnsNull()
+    {
+        var repo = new Mock<IUserAccountRepository>();
+        var jwt = new Mock<IJwtService>();
+        var userId = Guid.NewGuid();
+        jwt.Setup(x => x.HashRefreshToken("stolen-raw")).Returns("stolen-hash");
+        repo.Setup(x => x.GetRefreshTokenByHashAsync("stolen-hash", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserRefreshToken
+            {
+                Id = Guid.NewGuid(),
+                UserAccountId = userId,
+                TokenHash = "stolen-hash",
+                ExpiresAtUtc = DateTime.UtcNow.AddDays(1),
+                RevokedAtUtc = DateTime.UtcNow.AddMinutes(-5), // already rotated
+                ReplacedByTokenHash = "successor-hash"
+            });
+        repo.Setup(x => x.RevokeAllActiveRefreshTokensForUserAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var service = BuildService(repo.Object, jwt.Object);
+
+        var result = await service.RefreshAsync(new RefreshRequest("stolen-raw"), CancellationToken.None);
+
+        result.Should().BeNull();
+        repo.Verify(x => x.RevokeAllActiveRefreshTokensForUserAsync(userId, It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(x => x.AddRefreshTokenAsync(It.IsAny<UserRefreshToken>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenLoggedOutTokenReplayed_ReturnsNullWithoutFamilyRevoke()
+    {
+        var repo = new Mock<IUserAccountRepository>();
+        var jwt = new Mock<IJwtService>();
+        jwt.Setup(x => x.HashRefreshToken("loggedout-raw")).Returns("loggedout-hash");
+        repo.Setup(x => x.GetRefreshTokenByHashAsync("loggedout-hash", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserRefreshToken
+            {
+                Id = Guid.NewGuid(),
+                UserAccountId = Guid.NewGuid(),
+                TokenHash = "loggedout-hash",
+                ExpiresAtUtc = DateTime.UtcNow.AddDays(1),
+                RevokedAtUtc = DateTime.UtcNow.AddMinutes(-5), // revoked by logout
+                ReplacedByTokenHash = null                     // no successor
+            });
+
+        var service = BuildService(repo.Object, jwt.Object);
+
+        var result = await service.RefreshAsync(new RefreshRequest("loggedout-raw"), CancellationToken.None);
+
+        result.Should().BeNull();
+        repo.Verify(x => x.RevokeAllActiveRefreshTokensForUserAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenActiveToken_RotatesAndIssuesTokens()
+    {
+        var repo = new Mock<IUserAccountRepository>();
+        var jwt = new Mock<IJwtService>();
+        var userId = Guid.NewGuid();
+        jwt.Setup(x => x.HashRefreshToken("active-raw")).Returns("active-hash");
+        jwt.Setup(x => x.GenerateRefreshToken()).Returns("new-raw");
+        jwt.Setup(x => x.HashRefreshToken("new-raw")).Returns("new-hash");
+        jwt.Setup(x => x.GenerateAccessToken(It.IsAny<UserAccount>())).Returns("access-jwt");
+        jwt.Setup(x => x.GetAccessTokenExpirationUtc()).Returns(DateTime.UtcNow.AddMinutes(15));
+        var current = new UserRefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserAccountId = userId,
+            TokenHash = "active-hash",
+            ExpiresAtUtc = DateTime.UtcNow.AddDays(1),
+            RevokedAtUtc = null,
+            UserAccount = new UserAccount { Id = userId }
+        };
+        repo.Setup(x => x.GetRefreshTokenByHashAsync("active-hash", It.IsAny<CancellationToken>())).ReturnsAsync(current);
+
+        var service = BuildService(repo.Object, jwt.Object);
+
+        var result = await service.RefreshAsync(new RefreshRequest("active-raw"), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.AccessToken.Should().Be("access-jwt");
+        result.RefreshToken.Should().Be("new-raw");
+        repo.Verify(x => x.RevokeRefreshTokenAsync(current, "new-hash", It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(x => x.AddRefreshTokenAsync(
+            It.Is<UserRefreshToken>(t => t.TokenHash == "new-hash"), It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(x => x.RevokeAllActiveRefreshTokensForUserAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_WhenTokenNotFound_ReturnsNull()
+    {
+        var repo = new Mock<IUserAccountRepository>();
+        var jwt = new Mock<IJwtService>();
+        jwt.Setup(x => x.HashRefreshToken("nope-raw")).Returns("nope-hash");
+        repo.Setup(x => x.GetRefreshTokenByHashAsync("nope-hash", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserRefreshToken?)null);
+
+        var service = BuildService(repo.Object, jwt.Object);
+
+        var result = await service.RefreshAsync(new RefreshRequest("nope-raw"), CancellationToken.None);
+
+        result.Should().BeNull();
     }
 
     private static UserAuthService BuildService(IUserAccountRepository repo, IJwtService jwt)


### PR DESCRIPTION
**P8.1** (#77) — detect refresh-token theft and lock it out.

## Before

Rotation already existed (each refresh revokes the presented token, sets `ReplacedByTokenHash` → successor, issues a new one). But `RefreshAsync` looked the token up via `GetActiveRefreshTokenAsync`, so presenting an **already-rotated** token was indistinguishable from "not found" — it just failed, and the legitimate (now-compromised) session kept running. No theft signal acted on.

## Change

`RefreshAsync` now looks the token up in **any** state (`GetRefreshTokenByHashAsync`) and branches:

| Presented token | Action |
|---|---|
| **Rotated** (revoked + has successor) | **Reuse → revoke the whole token family** for that user + log a security warning; return null. The real client would be using the successor, so this is theft. |
| Revoked by **logout** (no successor) | Stale replay → fail, **no** family revoke (don't nuke a fresh post-logout session). |
| **Expired**, unrevoked | Fail. |
| **Active** | Rotate + issue new tokens (unchanged). |
| Not found | Fail. |

Family revocation logs out all the user's sessions — the standard conservative response to a compromise (there's no per-device family id; revoking all active tokens is the safe choice). The user re-authenticates.

Two new repo methods: `GetRefreshTokenByHashAsync` (any-state lookup incl. account + roles) and `RevokeAllActiveRefreshTokensForUserAsync` (family revoke, returns count).

## Tests

+4 in `UserAuthServiceTests`: rotated-token reuse → family revoked + null + no new token; logged-out replay → null + no family revoke; active token → rotates + issues; not-found → null. **Core 160 → 164**, WebAPI **40** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)