### PR TITLE
refactor(data): query-objects for analytics reads + data-access policy (P7.3)

### DIFF
--- a/Transcendence.Service.Core/Queries/MatchParticipantQueries.cs
+++ b/Transcendence.Service.Core/Queries/MatchParticipantQueries.cs
@@ -1,0 +1,45 @@
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Services.RiotApi;
+
+namespace Transcendence.Service.Core.Queries;
+
+/// <summary>
+/// Composable query-objects for the LoL analytics read surface — see the "Data access" policy in
+/// docs/ARCHITECTURE.md. Reusable predicates over <see cref="MatchParticipant"/> live here once and are
+/// chained onto an <see cref="IQueryable{T}"/>, instead of being copy-pasted across the analytics/stats
+/// services (the ranked-queue filter alone was duplicated 20+ times). Each method is a pure
+/// <c>Where(...)</c> that EF Core folds into a single SQL <c>WHERE</c>, so they commute and compose freely.
+/// </summary>
+public static class MatchParticipantQueries
+{
+    /// <summary>
+    /// Ranked Solo/Duo only. Tolerant of legacy rows that carry the queue as
+    /// (<c>QueueId == 0</c>, <c>QueueType == "420"</c>) rather than a populated <c>QueueId</c>.
+    /// </summary>
+    public static IQueryable<MatchParticipant> InRankedSoloQueue(this IQueryable<MatchParticipant> participants) =>
+        participants.Where(mp =>
+            mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
+            (mp.Match.QueueId == 0 &&
+             mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()));
+
+    /// <summary>Participants whose match is on the given patch.</summary>
+    public static IQueryable<MatchParticipant> OnPatch(this IQueryable<MatchParticipant> participants, string patch) =>
+        participants.Where(mp => mp.Match.Patch == patch);
+
+    /// <summary>Participants whose match was fully fetched (<see cref="FetchStatus.Success"/>).</summary>
+    public static IQueryable<MatchParticipant> FromSuccessfulMatches(this IQueryable<MatchParticipant> participants) =>
+        participants.Where(mp => mp.Match.Status == FetchStatus.Success);
+
+    /// <summary>
+    /// Restricts to a platform region (e.g. "NA1"). A null/blank region is a no-op — callers pass the
+    /// already-normalized region filter, so this absorbs the per-site "if region is set" guard.
+    /// </summary>
+    public static IQueryable<MatchParticipant> InPlatformRegion(this IQueryable<MatchParticipant> participants, string? platformRegion) =>
+        string.IsNullOrWhiteSpace(platformRegion)
+            ? participants
+            : participants.Where(mp => mp.Summoner.PlatformRegion == platformRegion);
+
+    /// <summary>Participants with an assigned lane/role (non-empty <c>TeamPosition</c>).</summary>
+    public static IQueryable<MatchParticipant> WithAssignedRole(this IQueryable<MatchParticipant> participants) =>
+        participants.Where(mp => mp.TeamPosition != null && mp.TeamPosition != "");
+}

--- a/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Hybrid;
 using Transcendence.Data;
+using Transcendence.Service.Core.Queries;
 using Transcendence.Service.Core.Services.Analysis.Exceptions;
 using Transcendence.Service.Core.Services.Analysis.Interfaces;
 using Transcendence.Service.Core.Services.Analysis.Models;
@@ -64,9 +65,7 @@ public class SummonerStatsService(
         var baseQuery = db.MatchParticipants
             .AsNoTracking()
             .Where(mp => mp.SummonerId == summonerId)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .InRankedSoloQueue()
             .Select(mp => new
             {
                 mp.Win,
@@ -104,9 +103,7 @@ public class SummonerStatsService(
         var recent = await db.MatchParticipants
             .AsNoTracking()
             .Where(mp => mp.SummonerId == summonerId)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .InRankedSoloQueue()
             .OrderByDescending(mp => mp.Match.MatchDate)
             .ThenByDescending(mp => mp.Match.MatchId)
             .Select(mp => new RecentPerformancePoint(
@@ -163,9 +160,7 @@ public class SummonerStatsService(
         var games = await db.MatchParticipants
             .AsNoTracking()
             .Where(mp => mp.SummonerId == summonerId)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .InRankedSoloQueue()
             .Select(mp => new
             {
                 mp.ChampionId,
@@ -230,9 +225,7 @@ public class SummonerStatsService(
         var rows = await db.MatchParticipants
             .AsNoTracking()
             .Where(mp => mp.SummonerId == summonerId)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .InRankedSoloQueue()
             .Select(mp => new { mp.TeamPosition, mp.Win })
             .ToListAsync(ct);
 

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Transcendence.Data;
 using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Queries;
 using Transcendence.Service.Core.Services.Analytics.Interfaces;
 using Transcendence.Service.Core.Services.Analytics.Models;
 using Transcendence.Service.Core.Services.RiotApi;
@@ -47,18 +48,13 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
         var baseQuery = _context.MatchParticipants
             .AsNoTracking()
             .Where(mp => mp.ChampionId == championId)
-            .Where(mp => mp.Match.Patch == patch)
-            .Where(mp => mp.Match.Status == FetchStatus.Success)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
-            .Where(mp => mp.TeamPosition != null && mp.TeamPosition != "");
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue()
+            .WithAssignedRole();
 
         // Apply region filter if specified
-        if (!string.IsNullOrEmpty(filter.Region))
-        {
-            baseQuery = baseQuery.Where(mp => mp.Summoner.PlatformRegion == filter.Region);
-        }
+        baseQuery = baseQuery.InPlatformRegion(filter.Region);
 
         // Apply role filter if specified
         if (!string.IsNullOrEmpty(filter.Role))
@@ -203,12 +199,10 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
         // Step 1: Build base query for match participants in this patch
         var baseQuery = _context.MatchParticipants
             .AsNoTracking()
-            .Where(mp => mp.Match.Patch == patch)
-            .Where(mp => mp.Match.Status == FetchStatus.Success)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
-            .Where(mp => mp.TeamPosition != null && mp.TeamPosition != "");
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue()
+            .WithAssignedRole();
 
         // Apply role filter (if not unified "ALL")
         if (!isUnifiedRole)
@@ -216,10 +210,7 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             baseQuery = baseQuery.Where(mp => mp.TeamPosition == normalizedRole);
         }
 
-        if (!string.IsNullOrWhiteSpace(regionFilter))
-        {
-            baseQuery = baseQuery.Where(mp => mp.Summoner.PlatformRegion == regionFilter);
-        }
+        baseQuery = baseQuery.InPlatformRegion(regionFilter);
 
         // Only apply rank join semantics when a tier filter is requested.
         // Unfiltered views intentionally keep unranked participants.
@@ -418,15 +409,12 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
     {
         var scope = _context.MatchParticipants
             .AsNoTracking()
-            .Where(mp => mp.Match.Patch == patch)
-            .Where(mp => mp.Match.Status == FetchStatus.Success)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
-            .Where(mp => mp.TeamPosition != null && mp.TeamPosition != "");
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue()
+            .WithAssignedRole();
 
-        if (!string.IsNullOrEmpty(region))
-            scope = scope.Where(mp => mp.Summoner.PlatformRegion == region);
+        scope = scope.InPlatformRegion(region);
 
         scope = ApplyRankTierScopeToParticipants(scope, rankTierScope, _context.Ranks.AsNoTracking());
 
@@ -465,15 +453,12 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
 
         var roleQuery = _context.MatchParticipants
             .AsNoTracking()
-            .Where(mp => mp.Match.Patch == patch)
-            .Where(mp => mp.Match.Status == FetchStatus.Success)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue()
             .Where(mp => mp.TeamPosition == role);
 
-        if (!string.IsNullOrWhiteSpace(region))
-            roleQuery = roleQuery.Where(mp => mp.Summoner.PlatformRegion == region);
+        roleQuery = roleQuery.InPlatformRegion(region);
 
         // Match participantRanks' UNRANKED bucket = participants with no solo-queue rank, so the pick-rate
         // denominator is well-defined for unranked rows too (e.g. the all-ranks view). The default
@@ -579,18 +564,12 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             .AsSplitQuery()
             .Include(mp => mp.Items)
             .Include(mp => mp.Runes)
-            .Where(mp => mp.ChampionId == championId
-                      && mp.Match.Patch == patch
-                      && mp.Match.Status == FetchStatus.Success
-                      && (mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                          (mp.Match.QueueId == 0 &&
-                           mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
-                      && mp.TeamPosition == role);
+            .Where(mp => mp.ChampionId == championId && mp.TeamPosition == role)
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue();
 
-        if (!string.IsNullOrWhiteSpace(regionFilter))
-        {
-            baseQuery = baseQuery.Where(mp => mp.Summoner.PlatformRegion == regionFilter);
-        }
+        baseQuery = baseQuery.InPlatformRegion(regionFilter);
 
         baseQuery = ApplyRankTierScopeToParticipants(baseQuery, rankTierScope, _context.Ranks.AsNoTracking());
 
@@ -851,11 +830,9 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             .Include(mp => mp.Runes)
             .Include(mp => mp.Summoner)
             .Where(mp => mp.ChampionId == championId)
-            .Where(mp => mp.Match.Patch == patch)
-            .Where(mp => mp.Match.Status == FetchStatus.Success)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue()
             .Where(mp => mp.Puuid != null && trackedPuuids.Contains(mp.Puuid));
 
         if (!string.Equals(normalizedRole, "ALL", StringComparison.Ordinal))
@@ -1066,11 +1043,9 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
 
         var rows = await _context.MatchParticipants
             .AsNoTracking()
-            .Where(mp => mp.Match.Patch == patch)
-            .Where(mp => mp.Match.Status == FetchStatus.Success)
-            .Where(mp => mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                         (mp.Match.QueueId == 0 &&
-                          mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString()))
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue()
             .Where(mp => mp.Puuid != null && trackedPuuids.Contains(mp.Puuid))
             .Select(mp => new { mp.ChampionId, mp.Win, mp.Puuid })
             .ToListAsync(ct);
@@ -1614,18 +1589,12 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
 
         var championQuery = _context.MatchParticipants
             .AsNoTracking()
-            .Where(mp => mp.ChampionId == championId
-                      && mp.TeamPosition == role
-                      && mp.Match.Patch == patch
-                      && mp.Match.Status == FetchStatus.Success
-                      && (mp.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
-                          (mp.Match.QueueId == 0 &&
-                           mp.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString())));
+            .Where(mp => mp.ChampionId == championId && mp.TeamPosition == role)
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue();
 
-        if (!string.IsNullOrWhiteSpace(regionFilter))
-        {
-            championQuery = championQuery.Where(mp => mp.Summoner.PlatformRegion == regionFilter);
-        }
+        championQuery = championQuery.InPlatformRegion(regionFilter);
 
         // Apply rank tier filter if specified
         championQuery = ApplyRankTierScopeToParticipants(

--- a/Transcendence.Service.Core/Services/Jobs/WarmDefaultChampionProfilesJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/WarmDefaultChampionProfilesJob.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Transcendence.Data;
 using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Queries;
 using Transcendence.Service.Core.Services.Analytics.Interfaces;
 using Transcendence.Service.Core.Services.Jobs.Configuration;
 
@@ -48,9 +49,9 @@ public class WarmDefaultChampionProfilesJob(
         var minGames = Math.Max(1, opts.MinimumGamesToWarm);
         var champions = await db.MatchParticipants
             .AsNoTracking()
-            .Where(mp => mp.Match.Patch == patch
-                      && mp.Match.Status == FetchStatus.Success
-                      && mp.TeamPosition != null)
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .Where(mp => mp.TeamPosition != null)
             .GroupBy(mp => mp.ChampionId)
             .Select(g => new { ChampionId = g.Key, Games = g.Count() })
             .Where(x => x.Games >= minGames)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -432,6 +432,32 @@ Backend uses a layered approach (see source and README):
 - Persistent storage (PostgreSQL) for canonical match/summoner data
 - Summoner stats cache entries are tagged per summoner (`summoner-stats:{summonerId}`) so refresh jobs can invalidate all related stats keys in one operation
 
+## Data Access
+
+The codebase deliberately does **not** route all persistence through a repository layer. EF Core's
+`DbContext` is already a unit-of-work + repository, and testability is provided by substituting the
+provider (`SqliteCompatibleTranscendenceContext` backs the analytics/service tests against a real
+in-memory schema, not repository mocks). The policy is therefore:
+
+1. **Direct EF Core by default.** Services and jobs query `TranscendenceContext` directly. Don't wrap
+   reads in a repository for its own sake — a generic `GetById`/`Add` CRUD wrapper adds indirection
+   without value.
+2. **Reusable read predicates are composable query-objects**, not copy-paste. A `Where(...)` clause used
+   in more than one place becomes an `IQueryable<T>` extension under `Transcendence.Service.Core/Queries`
+   — e.g. `MatchParticipantQueries`: `participants.InRankedSoloQueue().OnPatch(patch).FromSuccessfulMatches()`.
+   Each is a pure `Where` that EF folds into one SQL `WHERE`, so they commute and compose. (This replaced
+   the ranked-solo-queue predicate that had been duplicated 20+ times across the analytics/stats services.)
+   A genuinely single-use predicate stays inline — query-objects are for *reuse*, not premature abstraction.
+3. **Repositories wrap write operations that carry real logic** — e.g. `SummonerRepository`'s raw-SQL
+   upsert with unique-violation recovery, `UserAccountRepository`'s refresh-token rotation + family
+   revocation, `MatchRepository`. A repository must earn its place with behaviour beyond CRUD.
+4. **Testability comes from the substitutable `DbContext`**, so reads do not need a repository seam to be
+   testable; the write repositories are tested by mocking their interface where the surrounding logic
+   matters (e.g. `UserAuthServiceTests`).
+
+Rule of thumb: *query-object for a reused read predicate · repository for a write with logic · direct
+`DbContext` for everything else.*
+
 ## Change Tracking
 
 Future implementation work should live in GitHub issues or pull requests rather than long-lived planning docs committed under `docs/`.


### PR DESCRIPTION
**P7.3** (#77): decide + document the repository-boundary policy, then make the codebase consistent with it.

## The decision (Option 1)
The codebase mixed repositories with heavy direct-`DbContext` access (31 files) and had **no documented rule** — and the ranked-solo-queue predicate alone was copy-pasted **20+ times** across the analytics/stats services. Testability is already provided by the substitutable `DbContext` (SQLite test context), not repository mocks, so "repositories for testability" doesn't apply here.

**Policy** (`docs/ARCHITECTURE.md` → "Data access"):
- **Direct EF Core by default** — no generic-CRUD repository wrappers.
- **Reusable read predicates → composable `IQueryable` query-objects** under `Transcendence.Service.Core/Queries`.
- **Repositories only wrap write operations with real logic** (Summoner upsert, refresh-token family, Match).
- *query-object for a reused read predicate · repository for a write with logic · direct `DbContext` for the rest.*

## The refactor (consistent across the whole codebase)
New `MatchParticipantQueries`: `InRankedSoloQueue` / `OnPatch` / `FromSuccessfulMatches` / `InPlatformRegion` / `WithAssignedRole` — each a pure `Where()` EF folds into one SQL `WHERE`.

Applied at **every** duplication site:
- `ChampionAnalyticsComputeService` — queue ×6 + 2 combined-`Where` lambdas split, patch, status, role, **region ×6** (incl. unifying the `IsNullOrEmpty`/`IsNullOrWhiteSpace` guards via `InPlatformRegion`).
- `SummonerStatsService` — queue ×4.
- `WarmDefaultChampionProfilesJob` — patch + status.

Left inline **on purpose** (single-use ≠ duplication): `MatchTimelineBackfillJob`'s `Match`-level queue filter, `LiveGamePollingJob`'s `.AnyAsync(...)` predicate. The already-DRY rank-tier-scope helper stays.

## Verification
Behaviour-preserving — the SQLite-backed analytics tests (`ChampionAnalyticsComputeServiceTests`, `SummonerStatsServiceTests`) are the gate. Backend builds clean; **Core 164 + WebAPI 40** green, no analytics result changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)