### PR TITLE
perf(analytics): covering indexes for the matchup self-join + champ scan

### DIFF
--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -157,7 +157,6 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
 
             // Common filter/index fields
             entity.HasIndex(p => p.SummonerId);
-            entity.HasIndex(p => p.ChampionId);
             // Covering index for the dominant champion-analytics query
             // (ChampionAnalyticsComputeService.ComputeWinRatesAsync): seek by ChampionId and read
             // the join + aggregate payload (MatchId for the Match join, SummonerId for the Ranks
@@ -167,14 +166,21 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             // project references only EF.Relational, so they live in the raw-SQL migration; the model
             // declares the bare (ChampionId) shape under the same name. Built CONCURRENTLY on the hot
             // MatchParticipants table out-of-band — see docs/DEVELOPMENT.md "Applying index migrations
-            // to hot tables". The named overload keeps the plain ChampionId index alongside it.
+            // to hot tables". This also covers a plain (ChampionId) seek, so no separate index is kept.
             entity.HasIndex(p => p.ChampionId, "IX_MatchParticipants_ChampionId_Covering");
-            entity.HasIndex(p => new
-            {
-                p.ChampionId,
-                p.TeamPosition
-            });
-            entity.HasIndex(p => p.MatchId);
+            // Covering index for the champion-side scan of the matchup query
+            // (ChampionAnalyticsComputeService.ComputeMatchupsAsync): seek by (ChampionId, TeamPosition)
+            // and read MatchId/ParticipantId/Win/TeamId from the leaf so the scan is index-only (prod
+            // EXPLAIN: it was a ~50k-cost bitmap heap scan). Bare shape in the model; INCLUDE in the
+            // raw-SQL migration. Replaces the plain non-covering (ChampionId, TeamPosition) index.
+            entity.HasIndex(p => new { p.ChampionId, p.TeamPosition },
+                "IX_MatchParticipants_ChampionId_TeamPosition_Covering");
+            // Covering index for the lane-pairs self-join of the matchup query (the opponent lookup):
+            // seek by MatchId and read TeamPosition/TeamId/ChampionId/ParticipantId from the leaf so the
+            // self-join is index-only (prod EXPLAIN: the single biggest cost, ~+72k of heap fetches).
+            // Also serves the MatchId FK and every MatchId lookup (the hottest index, ~131M scans/day).
+            // Bare (MatchId) shape in the model; INCLUDE in the raw-SQL migration. Replaces the plain index.
+            entity.HasIndex(p => p.MatchId, "IX_MatchParticipants_MatchId_Covering");
             entity.HasIndex(p => new { p.MatchId, p.ParticipantId });
         });
 

--- a/Transcendence.Service/Migrations/20260623033837_AddMatchParticipantMatchupCoveringIndexes.Designer.cs
+++ b/Transcendence.Service/Migrations/20260623033837_AddMatchParticipantMatchupCoveringIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260623033837_AddMatchParticipantMatchupCoveringIndexes")]
+    partial class AddMatchParticipantMatchupCoveringIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260623033837_AddMatchParticipantMatchupCoveringIndexes.cs
+++ b/Transcendence.Service/Migrations/20260623033837_AddMatchParticipantMatchupCoveringIndexes.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMatchParticipantMatchupCoveringIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Hot table (MatchParticipants, ~3.6M rows, continuously written by ingestion). All builds run
+            // CONCURRENTLY so they never hold a write-blocking SHARE lock; CONCURRENTLY cannot run inside a
+            // transaction, hence suppressTransaction. Raw SQL (not CreateIndex) because the INCLUDE payload is
+            // Npgsql-specific and Transcendence.Data references only EF.Relational, so the model carries the
+            // bare (cols) shape and the INCLUDE lives here. **Apply out-of-band on prod** in a top-of-hour gap
+            // (NOT via `database update`) — see docs/DEVELOPMENT.md "Applying index migrations to hot tables":
+            // build each *_Covering first, verify indisvalid='t', then drop the plain index it replaces.
+            //
+            // These turn the matchup query's (ComputeMatchupsAsync) two remaining heap-fetch bottlenecks into
+            // index-only scans — the prod EXPLAIN had the lane-pairs self-join at ~+72k and the champion-side
+            // scan at ~50k, both heap fetches on non-covering indexes (#69 already made the timeline joins
+            // index-only).
+
+            // Lane-pairs self-join (opponent lookup): seek by MatchId, read TeamPosition/TeamId/ChampionId/
+            // ParticipantId from the leaf. Also serves the MatchId FK + every MatchId lookup (hottest index).
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_MatchParticipants_MatchId_Covering\" " +
+                "ON \"MatchParticipants\" (\"MatchId\") " +
+                "INCLUDE (\"TeamPosition\", \"TeamId\", \"ChampionId\", \"ParticipantId\");",
+                suppressTransaction: true);
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_MatchParticipants_MatchId\";",
+                suppressTransaction: true);
+
+            // Champion-side scan: seek by (ChampionId, TeamPosition), read MatchId/ParticipantId/Win/TeamId.
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_MatchParticipants_ChampionId_TeamPosition_Covering\" " +
+                "ON \"MatchParticipants\" (\"ChampionId\", \"TeamPosition\") " +
+                "INCLUDE (\"MatchId\", \"ParticipantId\", \"Win\", \"TeamId\");",
+                suppressTransaction: true);
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_MatchParticipants_ChampionId_TeamPosition\";",
+                suppressTransaction: true);
+
+            // Drop the redundant plain (ChampionId) index — 0 scans on prod; IX_..._ChampionId_Covering
+            // (which leads with ChampionId) already serves any ChampionId seek. Offsets the INCLUDE growth.
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_MatchParticipants_ChampionId\";",
+                suppressTransaction: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_MatchParticipants_ChampionId\" " +
+                "ON \"MatchParticipants\" (\"ChampionId\");",
+                suppressTransaction: true);
+
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_MatchParticipants_ChampionId_TeamPosition\" " +
+                "ON \"MatchParticipants\" (\"ChampionId\", \"TeamPosition\");",
+                suppressTransaction: true);
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_MatchParticipants_ChampionId_TeamPosition_Covering\";",
+                suppressTransaction: true);
+
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_MatchParticipants_MatchId\" " +
+                "ON \"MatchParticipants\" (\"MatchId\");",
+                suppressTransaction: true);
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_MatchParticipants_MatchId_Covering\";",
+                suppressTransaction: true);
+        }
+    }
+}


### PR DESCRIPTION
Completes the matchup-query fix started by #69. After #69 made the timeline joins index-only, a prod `EXPLAIN` (champ 235 BOTTOM, patch 16.12, 32k games) showed the ~24s cost had **shifted to heap fetches on two non-covering indexes**:

| Node | Cost | Fix |
|---|---|---|
| lane-pairs self-join (`opp`) | **+72k** (biggest) | `IX_MatchParticipants_MatchId` → covering `INCLUDE (TeamPosition, TeamId, ChampionId, ParticipantId)` |
| champion-side scan | ~50k | `IX_..._ChampionId_TeamPosition` → covering `INCLUDE (MatchId, ParticipantId, Win, TeamId)` |
| timeline joins | cheap | already index-only via #69 ✓ |

With both covering, the matchup query becomes **all index-only scans**. Also **drops the redundant plain `IX_MatchParticipants_ChampionId`** (0 scans on prod, 175MB — `IX_..._ChampionId_Covering` already serves a ChampionId seek), offsetting the INCLUDE growth so net index size is ~neutral.

## Recipe
Same hot-table pattern as #69/P5.1: raw-SQL `CREATE INDEX CONCURRENTLY ... INCLUDE` (build covering, then drop plain, `suppressTransaction`); the model declares the bare named shapes, INCLUDE lives in the migration (`Transcendence.Data` references only EF.Relational).

⚠️ **Prod apply is out-of-band** (NOT `database update`): build each `*_Covering` CONCURRENTLY in a top-of-hour gap, verify `indisvalid='t'`, then drop the plain index, record in `__EFMigrationsHistory`. Then re-run the worst-case `EXPLAIN` and confirm the self-join + champ scan are `Index Only Scan`.

## Verification
- `has-pending-model-changes`: no drift. `check-migrations.sh`: raw SQL, not flagged.
- Analytics/stats tests green (39).

(The win-rate N+1 + the analytics dedup the investigation surfaced ship as a follow-up PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)