### PR TITLE
perf(analytics): batch the win-rate role-rank query (fix N+1) + dedupe rank tiers

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
@@ -80,12 +80,7 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
         if (rankTierScope.IsEmeraldPlus)
         {
             participantRanks = participantRanks
-                .Where(pr =>
-                    pr.RankTier == "EMERALD" ||
-                    pr.RankTier == "DIAMOND" ||
-                    pr.RankTier == "MASTER" ||
-                    pr.RankTier == "GRANDMASTER" ||
-                    pr.RankTier == "CHALLENGER");
+                .Where(pr => RankTierCatalog.EmeraldPlusTiers.Contains(pr.RankTier));
         }
         else if (!string.IsNullOrWhiteSpace(rankTierScope.ExactTier))
         {
@@ -143,16 +138,83 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
                 .CountAsync(ct);
         var banRate = totalMatchesInScope > 0 ? (double)bannedMatches / totalMatchesInScope : 0.0;
 
+        // Role rank + pick-rate denominator, batched. Previously each (role, tier) result row called
+        // ComputeRoleRankAsync, which re-scanned + re-grouped the entire (role, tier) champion population
+        // per row — an N+1 (5-10 full-population scans per champion, ×168 hourly in the warm job). Instead
+        // compute the standings for every (role, tier) this champion appears in ONCE: the same scope as
+        // participantRanks above but without the championId filter, grouped by (role, tier, champion).
+        var relevantRoles = winRateData.Select(x => x.Role).Distinct().ToList();
+
+        var populationRanks = from mp in _context.MatchParticipants
+                    .AsNoTracking()
+                    .OnPatch(patch)
+                    .FromSuccessfulMatches()
+                    .InRankedSoloQueue()
+                    .WithAssignedRole()
+                    .InPlatformRegion(filter.Region)
+                    .Where(mp => relevantRoles.Contains(mp.TeamPosition!))
+                join rank in _context.Ranks.AsNoTracking().Where(r => r.QueueType == "RANKED_SOLO_5x5")
+                    on mp.SummonerId equals rank.SummonerId into rankGroup
+                from soloRank in rankGroup.DefaultIfEmpty()
+                select new
+                {
+                    mp.TeamPosition,
+                    mp.ChampionId,
+                    mp.Win,
+                    RankTier = soloRank != null ? soloRank.Tier : "UNRANKED"
+                };
+
+        if (rankTierScope.IsEmeraldPlus)
+            populationRanks = populationRanks.Where(pr => RankTierCatalog.EmeraldPlusTiers.Contains(pr.RankTier));
+        else if (!string.IsNullOrWhiteSpace(rankTierScope.ExactTier))
+            populationRanks = populationRanks.Where(pr => pr.RankTier == rankTierScope.ExactTier);
+
+        var standingsRows = await populationRanks
+            .GroupBy(pr => new { pr.TeamPosition, pr.RankTier, pr.ChampionId })
+            .Select(g => new
+            {
+                g.Key.TeamPosition,
+                g.Key.RankTier,
+                g.Key.ChampionId,
+                Games = g.Count(),
+                Wins = g.Sum(x => x.Win ? 1 : 0)
+            })
+            .ToListAsync(ct);
+
+        // Per (role, tier): champions ranked by win rate (then games, then id) → this champion's rank +
+        // population; sum of games → the true pick-rate denominator. Identical to ComputeRoleRankAsync.
+        var standingsByRoleTier = standingsRows
+            .GroupBy(x => (Role: x.TeamPosition!, Tier: x.RankTier))
+            .ToDictionary(
+                g => g.Key,
+                g => new
+                {
+                    Ranked = g
+                        .OrderByDescending(x => x.Games > 0 ? (double)x.Wins / x.Games : 0.0)
+                        .ThenByDescending(x => x.Games)
+                        .ThenBy(x => x.ChampionId)
+                        .Select(x => x.ChampionId)
+                        .ToList(),
+                    TotalGames = g.Sum(x => x.Games)
+                });
+
         var result = new List<ChampionWinRateDto>(winRateData.Count);
         foreach (var data in winRateData)
         {
-            var roleRank = await ComputeRoleRankAsync(
-                championId,
-                data.Role,
-                data.RankTier,
-                patch,
-                filter.Region,
-                ct);
+            // No competitive rank within the UNRANKED bucket (preserves prior behaviour); the pick-rate
+            // denominator is still meaningful there.
+            var isUnranked = string.Equals(data.RankTier, "UNRANKED", StringComparison.OrdinalIgnoreCase);
+            standingsByRoleTier.TryGetValue((data.Role, data.RankTier), out var standing);
+            var roleTotalGames = standing?.TotalGames ?? 0;
+
+            int? roleRank = null;
+            int? rolePopulation = null;
+            if (!isUnranked && standing != null)
+            {
+                rolePopulation = standing.Ranked.Count;
+                var index = standing.Ranked.IndexOf(championId);
+                roleRank = index >= 0 ? index + 1 : null;
+            }
 
             result.Add(new ChampionWinRateDto(
                 ChampionId: championId,
@@ -162,14 +224,12 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
                 Wins: data.Wins,
                 WinRate: data.Games > 0 ? (double)data.Wins / data.Games : 0.0,
                 // P7.1: true pick rate — this champion's games in the (role, tier) over ALL champions'
-                // games in that same (role, tier) scope (roleRank.RoleTotalGames), matching
-                // ComputeTierListAsync's Games/totalParticipants. The previous denominator was this
-                // champion's OWN total games across roles, so the value was a role-distribution share
-                // (a one-role champ read ~100%), not a pick rate.
-                PickRate: roleRank.RoleTotalGames > 0 ? (double)data.Games / roleRank.RoleTotalGames : 0.0,
+                // games in that same (role, tier) (roleTotalGames), matching ComputeTierListAsync's
+                // Games/totalParticipants. (Was this champion's OWN total games — a role-distribution share.)
+                PickRate: roleTotalGames > 0 ? (double)data.Games / roleTotalGames : 0.0,
                 BanRate: banRate,
-                RoleRank: roleRank.RoleRank,
-                RolePopulation: roleRank.RolePopulation,
+                RoleRank: roleRank,
+                RolePopulation: rolePopulation,
                 Patch: patch
             ));
         }
@@ -389,11 +449,7 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             return query.Where(mp => ranks.Any(r =>
                 r.QueueType == "RANKED_SOLO_5x5" &&
                 r.SummonerId == mp.SummonerId &&
-                (r.Tier == "EMERALD" ||
-                 r.Tier == "DIAMOND" ||
-                 r.Tier == "MASTER" ||
-                 r.Tier == "GRANDMASTER" ||
-                 r.Tier == "CHALLENGER")));
+                RankTierCatalog.EmeraldPlusTiers.Contains(r.Tier)));
         }
 
         return query.Where(mp => ranks.Any(r =>
@@ -432,74 +488,6 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             "ALL" => [],
             _ => [region]
         };
-    }
-
-    private async Task<(int? RoleRank, int? RolePopulation, int RoleTotalGames)> ComputeRoleRankAsync(
-        int championId,
-        string role,
-        string rankTier,
-        string patch,
-        string? region,
-        CancellationToken ct)
-    {
-        // RoleTotalGames is the sum of every champion's games in this exact (role, tier) scope — the
-        // true pick-rate denominator, derived for free from the same standings we build for the role
-        // rank (no extra query). The (role, tier) population is the same one the per-row query already
-        // scans, so this only reuses work.
-        if (string.IsNullOrWhiteSpace(role))
-            return (null, null, 0);
-
-        var isUnranked = string.Equals(rankTier, "UNRANKED", StringComparison.OrdinalIgnoreCase);
-
-        var roleQuery = _context.MatchParticipants
-            .AsNoTracking()
-            .OnPatch(patch)
-            .FromSuccessfulMatches()
-            .InRankedSoloQueue()
-            .Where(mp => mp.TeamPosition == role);
-
-        roleQuery = roleQuery.InPlatformRegion(region);
-
-        // Match participantRanks' UNRANKED bucket = participants with no solo-queue rank, so the pick-rate
-        // denominator is well-defined for unranked rows too (e.g. the all-ranks view). The default
-        // Emerald+ view never produces UNRANKED rows, so the anti-join cost stays off the hot path.
-        roleQuery = isUnranked
-            ? roleQuery.Where(mp => !_context.Ranks.Any(r =>
-                r.QueueType == "RANKED_SOLO_5x5" &&
-                r.SummonerId == mp.SummonerId))
-            : roleQuery.Where(mp => _context.Ranks.Any(r =>
-                r.QueueType == "RANKED_SOLO_5x5" &&
-                r.SummonerId == mp.SummonerId &&
-                r.Tier == rankTier));
-
-        var standings = await roleQuery
-            .GroupBy(mp => mp.ChampionId)
-            .Select(g => new
-            {
-                ChampionId = g.Key,
-                Games = g.Count(),
-                WinRate = g.Count() > 0 ? (double)g.Count(x => x.Win) / g.Count() : 0.0
-            })
-            .OrderByDescending(x => x.WinRate)
-            .ThenByDescending(x => x.Games)
-            .ThenBy(x => x.ChampionId)
-            .ToListAsync(ct);
-
-        if (standings.Count == 0)
-            return (null, null, 0);
-
-        var roleTotalGames = standings.Sum(s => s.Games);
-
-        // Don't assign a competitive role rank within the UNRANKED bucket (preserves prior behaviour);
-        // the pick-rate denominator is still meaningful, so return it.
-        if (isUnranked)
-            return (null, null, roleTotalGames);
-
-        var rolePopulation = standings.Count;
-        var rank = standings.FindIndex(s => s.ChampionId == championId);
-        return rank >= 0
-            ? (rank + 1, rolePopulation, roleTotalGames)
-            : (null, rolePopulation, roleTotalGames);
     }
 
     private static int ResolveEffectiveSampleSize(int configuredMinimum, int availableGames, int floor)

--- a/Transcendence.Service.Core/Services/Analytics/RankTierCatalog.cs
+++ b/Transcendence.Service.Core/Services/Analytics/RankTierCatalog.cs
@@ -1,0 +1,14 @@
+namespace Transcendence.Service.Core.Services.Analytics;
+
+/// <summary>
+/// Canonical rank-tier groupings shared across LoL + TFT analytics. The Emerald+ set is the default
+/// "high-elo" analytics scope; it was previously copy-pasted as an inline <c>|| </c>-chain in several
+/// places (ChampionAnalyticsComputeService, TftAnalyticsComputeService). Exposed as a list so EF Core
+/// translates <c>EmeraldPlusTiers.Contains(tier)</c> to a SQL <c>IN (...)</c> — equivalent to the chain.
+/// </summary>
+public static class RankTierCatalog
+{
+    /// <summary>Solo-queue tiers that make up the "Emerald and above" scope (used for ordering too: highest elo last).</summary>
+    public static readonly IReadOnlyList<string> EmeraldPlusTiers =
+        ["EMERALD", "DIAMOND", "MASTER", "GRANDMASTER", "CHALLENGER"];
+}

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
@@ -195,6 +195,58 @@ public class ChampionAnalyticsComputeServiceTests
     }
 
     [Fact]
+    public async Task ComputeWinRatesAsync_RoleRankAndPopulation_RankChampionsByWinRate()
+    {
+        // Role rank/population is computed for every (role, tier) in one batched query (was an N+1 that
+        // re-scanned the whole (role, tier) population per result row). Three EMERALD TOP champions with
+        // distinct win rates (100% > 67% > 33%) → the queried champion (200, 67%) ranks #2 of 3.
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<TranscendenceContext>().UseSqlite(connection).Options;
+        await using var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Patches.Add(new Patch
+        {
+            Version = "15.2",
+            ReleaseDate = DateTime.UtcNow.AddDays(-2),
+            DetectedAt = DateTime.UtcNow.AddDays(-2),
+            IsActive = true
+        });
+
+        void SeedRanked(int champ, int idx, bool win) =>
+            SeedMatch(db, "15.2", $"NA1_{champ}_{idx}", summonerName: $"P{champ}_{idx}",
+                championId: champ, role: "TOP", win: win, rankTier: "EMERALD");
+
+        // 100: 3-0 (100%), 200: 2-1 (67%), 300: 1-2 (33%)
+        SeedRanked(100, 0, true); SeedRanked(100, 1, true); SeedRanked(100, 2, true);
+        SeedRanked(200, 0, true); SeedRanked(200, 1, true); SeedRanked(200, 2, false);
+        SeedRanked(300, 0, true); SeedRanked(300, 1, false); SeedRanked(300, 2, false);
+        await db.SaveChangesAsync();
+
+        var service = new ChampionAnalyticsComputeService(
+            db,
+            Options.Create(new ChampionAnalyticsComputeOptions
+            {
+                MinimumGamesRequired = 1,
+                EarlyPatchMinimumGamesRequired = 1,
+                BootstrapPatchMinimumGamesRequired = 1,
+                BootstrapWindowHours = 24,
+                ProvisionalWindowHours = 96,
+                MaturingWindowHours = 240
+            }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+
+        var result = await service.ComputeWinRatesAsync(
+            200, new ChampionAnalyticsFilter { RankTier = "EMERALD_PLUS" }, "15.2", CancellationToken.None);
+
+        var row = result.Single(r => r is { Role: "TOP", RankTier: "EMERALD" });
+        row.RoleRank.Should().Be(2);        // 2nd of 3 by win rate
+        row.RolePopulation.Should().Be(3);
+        row.WinRate.Should().BeApproximately(2.0 / 3.0, 0.0001);
+    }
+
+    [Fact]
     public async Task ComputeProChampionPlayrateAsync_RanksChampionsAndHonorsScope()
     {
         await using var connection = new SqliteConnection("Data Source=:memory:");
@@ -516,7 +568,8 @@ public class ChampionAnalyticsComputeServiceTests
         string summonerName,
         int championId,
         string role,
-        bool win)
+        bool win,
+        string? rankTier = null)
     {
         var summoner = new Summoner
         {
@@ -529,6 +582,17 @@ public class ChampionAnalyticsComputeServiceTests
             SummonerName = summonerName,
             RiotSummonerId = Guid.NewGuid().ToString("N")
         };
+
+        if (rankTier != null)
+        {
+            db.Ranks.Add(new Rank
+            {
+                Id = Guid.NewGuid(),
+                SummonerId = summoner.Id,
+                QueueType = "RANKED_SOLO_5x5",
+                Tier = rankTier
+            });
+        }
 
         var match = new Transcendence.Data.Models.LoL.Match.Match
         {


### PR DESCRIPTION
The win-rate path's other hotspot (from the matchup-query investigation): `ComputeWinRatesAsync` looped over each `(role, tier)` result row and called `ComputeRoleRankAsync`, which **re-scanned + re-grouped the entire `(role, tier)` champion population per row** — an N+1 (5–10 full-population grouped scans per champion, ×~168 every hour in the warm job).

## Fix
Compute the standings for every `(role, tier)` the champion appears in **once**: the same scope as `participantRanks` (minus the championId filter), grouped by `(role, tier, champion)`; then rank each champion **in-memory** (win rate → games → id) for `RoleRank` + `RolePopulation`, and sum games for the true pick-rate denominator. Exactly equivalent to the per-row method (incl. UNRANKED handling), which is removed.

## Dedup
`RankTierCatalog.EmeraldPlusTiers` replaces the copy-pasted EMERALD+ `||`-chain in `ComputeWinRatesAsync` + `ApplyRankTierScopeToParticipants` (EF translates `.Contains` → `IN`, identical results).

## Tests
- New `ComputeWinRatesAsync_RoleRankAndPopulation_RankChampionsByWinRate` — three EMERALD TOP champions at 100/67/33% → the queried champ ranks **#2 of 3** (first direct `RoleRank`/`RolePopulation` assertion; `SeedMatch` gained an optional `rankTier`).
- The pick-rate denominator tests already gated the shared standings. **Core 165 + WebAPI 40 green.**

## Follow-ups (noted, not here)
TFT's identical EMERALD+ list → `RankTierCatalog` (cross-surface namespace); minor polish (`QueueCatalog "RANKED_SOLO_5x5"` const, `ResolvePlatformsForRegion` move, named `0.48`/`0.52` matchup thresholds, Match-level `InRankedSoloQueue`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)