### PR TITLE
feat(analytics): precompute foundation — tabular-core stat tables + refresh aggregation

### DIFF
--- a/Transcendence.Data/Models/LoL/Analytics/ChampionBanScopeStat.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/ChampionBanScopeStat.cs
@@ -1,0 +1,32 @@
+namespace Transcendence.Data.Models.LoL.Analytics;
+
+/// <summary>
+/// Precomputed distinct banned-match count for one <c>(Patch, PlatformRegion, RankScope, ChampionId)</c> —
+/// the numerator for champion ban rate, paired with <see cref="ScopeMatchCountStat"/> as the denominator
+/// (<c>BanRate = BannedMatches / TotalMatches</c>).
+/// <para>
+/// Keyed by the rank-<i>scope</i> token, and read by <b>point lookup</b> (an explicit synthetic
+/// <see cref="PlatformRegion"/> = <c>"ALL"</c> row for region=ALL, a concrete platform row otherwise) —
+/// never summed over tiers or regions — for the same distinct-match non-additivity reasons documented on
+/// <see cref="ScopeMatchCountStat"/>. Role-independent (one row serves both the win-rate and tier-list pages).
+/// </para>
+/// </summary>
+public class ChampionBanScopeStat
+{
+    public Guid Id { get; set; }
+
+    public string Patch { get; set; } = "";
+
+    /// <summary>Concrete platform (e.g. "NA1") or the synthetic global <c>"ALL"</c> row.</summary>
+    public string PlatformRegion { get; set; } = "";
+
+    /// <summary>Rank-scope token: "ALL", "EMERALD_PLUS", or an exact tier (e.g. "DIAMOND").</summary>
+    public string RankScope { get; set; } = "";
+
+    public int ChampionId { get; set; }
+
+    /// <summary>Distinct matches in scope where this champion was banned.</summary>
+    public int BannedMatches { get; set; }
+
+    public DateTime ComputedAtUtc { get; set; }
+}

--- a/Transcendence.Data/Models/LoL/Analytics/ChampionRoleTierStat.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/ChampionRoleTierStat.cs
@@ -1,0 +1,37 @@
+namespace Transcendence.Data.Models.LoL.Analytics;
+
+/// <summary>
+/// Precomputed atomic win/games aggregate for one
+/// <c>(Patch, PlatformRegion, RankTier, ChampionId, Role)</c>. The refresh job UPSERTs these from raw
+/// <c>MatchParticipants</c>; the analytics read path rolls them up in SQL (summing over the regions and
+/// tiers in the requested scope) to serve win-rates, pick-rate, role-rank and the tier list as fast
+/// indexed lookups instead of scanning raw matches.
+/// <para>
+/// <see cref="RankTier"/> is the summoner's <i>current</i> solo-queue tier (re-derived each refresh from
+/// the <c>Ranks</c> table) or <c>"UNRANKED"</c>. <see cref="Games"/>/<see cref="Wins"/> are additive over
+/// region, tier, role and champion, which is what makes read-time scope roll-up exact.
+/// </para>
+/// </summary>
+public class ChampionRoleTierStat
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Game version, e.g. "15.12" — matches <c>Match.Patch</c>.</summary>
+    public string Patch { get; set; } = "";
+
+    /// <summary>Summoner platform region, e.g. "NA1"/"EUW1"/"KR" (from <c>Summoner.PlatformRegion</c>).</summary>
+    public string PlatformRegion { get; set; } = "";
+
+    /// <summary>Individual current solo-queue tier (IRON…CHALLENGER) or "UNRANKED".</summary>
+    public string RankTier { get; set; } = "";
+
+    public int ChampionId { get; set; }
+
+    /// <summary>Assigned lane/role: TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY.</summary>
+    public string Role { get; set; } = "";
+
+    public int Games { get; set; }
+    public int Wins { get; set; }
+
+    public DateTime ComputedAtUtc { get; set; }
+}

--- a/Transcendence.Data/Models/LoL/Analytics/ScopeMatchCountStat.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/ScopeMatchCountStat.cs
@@ -1,0 +1,44 @@
+namespace Transcendence.Data.Models.LoL.Analytics;
+
+/// <summary>
+/// Precomputed distinct-match count for one <c>(Patch, PlatformRegion, RankScope)</c> — the denominator
+/// for champion ban rate (paired with <see cref="ChampionBanScopeStat"/> as the numerator) and any other
+/// "share of matches in scope" metric.
+/// <para>
+/// Distinct-match counts are <b>not</b> additive over rank tiers — a single match spans up to ten players'
+/// tiers, so it belongs to several individual-tier buckets at once. This table is therefore keyed by the
+/// rank-<i>scope</i> token (<c>ALL</c>, <c>EMERALD_PLUS</c>, or an exact tier such as <c>DIAMOND</c>) rather
+/// than an individual tier.
+/// </para>
+/// <para>
+/// They are also <b>not</b> safely additive over platform region: a match's region is derived from a
+/// nullable <c>Summoner.PlatformRegion</c>, so a per-region SUM is not provably equal to the live global
+/// <c>COUNT(DISTINCT MatchId)</c>. The refresh therefore materializes an explicit synthetic
+/// <see cref="PlatformRegion"/> = <c>"ALL"</c> row (computed globally, with no region filter) alongside the
+/// per-platform rows; the read does a single <b>point lookup</b> — the <c>"ALL"</c> row for region=ALL, or
+/// a concrete platform row for a specific region — and never sums regions.
+/// </para>
+/// <para>
+/// Ban rate is <b>role-independent</b> (bans happen at champ select, before role assignment): a single
+/// scope row serves both the champion win-rate page and the tier list, which now agree on a champion's
+/// ban rate. (Previously the tier-list path role-scoped its denominator — an artifact inconsistent with the
+/// already role-independent win-rate path.)
+/// </para>
+/// </summary>
+public class ScopeMatchCountStat
+{
+    public Guid Id { get; set; }
+
+    public string Patch { get; set; } = "";
+
+    /// <summary>Concrete platform (e.g. "NA1") or the synthetic global <c>"ALL"</c> row.</summary>
+    public string PlatformRegion { get; set; } = "";
+
+    /// <summary>Rank-scope token: "ALL", "EMERALD_PLUS", or an exact tier (e.g. "DIAMOND").</summary>
+    public string RankScope { get; set; } = "";
+
+    /// <summary>Distinct ranked-solo matches in scope.</summary>
+    public int TotalMatches { get; set; }
+
+    public DateTime ComputedAtUtc { get; set; }
+}

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Transcendence.Data.Models.Auth;
 using Transcendence.Data.Models.LiveGame;
 using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Models.LoL.Analytics;
 using Transcendence.Data.Models.LoL.Match;
 using Transcendence.Data.Models.LoL.Static;
 using Transcendence.Data.Models.Service;
@@ -29,6 +30,11 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<MatchParticipantTimelineSnapshot> MatchParticipantTimelineSnapshots { get; set; }
     public DbSet<MatchParticipantItemPurchase> MatchParticipantItemPurchases { get; set; }
     public DbSet<MatchParticipantSkillOrder> MatchParticipantSkillOrders { get; set; }
+
+    // Precomputed analytics aggregates (refreshed on a cadence; the read path rolls these up by scope)
+    public DbSet<ChampionRoleTierStat> ChampionRoleTierStats { get; set; }
+    public DbSet<ScopeMatchCountStat> ScopeMatchCountStats { get; set; }
+    public DbSet<ChampionBanScopeStat> ChampionBanScopeStats { get; set; }
 
     // Versioned static data
     public DbSet<Patch> Patches { get; set; }
@@ -613,6 +619,33 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
                 .HasForeignKey(x => x.SummonerId)
                 .OnDelete(DeleteBehavior.Cascade);
             entity.HasIndex(x => x.UpdatedAtUtc);
+        });
+
+        // Precomputed analytics aggregates. Keys double as the UPSERT conflict target and the read
+        // lookup; the secondary indexes serve the two read shapes (per-champion vs across-all-champions).
+        modelBuilder.Entity<ChampionRoleTierStat>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.Patch, x.PlatformRegion, x.RankTier, x.ChampionId, x.Role })
+                .IsUnique();
+            // Win-rate read: a single champion across its roles/tiers/regions.
+            entity.HasIndex(x => new { x.Patch, x.ChampionId, x.Role });
+            // Tier-list + role-rank/pick-rate population read: every champion in a role/tier/region scope.
+            entity.HasIndex(x => new { x.Patch, x.Role, x.RankTier });
+        });
+
+        modelBuilder.Entity<ScopeMatchCountStat>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.Patch, x.PlatformRegion, x.RankScope }).IsUnique();
+        });
+
+        modelBuilder.Entity<ChampionBanScopeStat>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            // Doubles as the UPSERT target and the point-lookup: a specific (region|"ALL", scope, champion).
+            // Its (Patch, PlatformRegion, RankScope) prefix also serves the tier-list all-champions read.
+            entity.HasIndex(x => new { x.Patch, x.PlatformRegion, x.RankScope, x.ChampionId }).IsUnique();
         });
     }
 }

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
@@ -1,0 +1,257 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Models.LoL.Analytics;
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Queries;
+using Transcendence.Service.Core.Services.Analytics.Interfaces;
+
+namespace Transcendence.Service.Core.Services.Analytics.Implementations;
+
+/// <summary>
+/// Rebuilds the tabular-core precomputed analytics aggregates from raw match data. See
+/// <see cref="IPrecomputedAnalyticsRefresher"/>. Every aggregation mirrors the filters of the live
+/// compute (<c>ChampionAnalyticsComputeService</c>) so the read path can roll these atoms up to the exact
+/// same numbers:
+/// <list type="bullet">
+/// <item><c>ChampionRoleTierStat</c>: a LEFT JOIN to the current solo rank gives each participant a tier
+/// ("UNRANKED" when absent); grouped by (region, tier, champion, role) → additive Games/Wins.</item>
+/// <item><c>ScopeMatchCountStat</c> / <c>ChampionBanScopeStat</c>: distinct-match denominators/numerators
+/// per rank-scope token. These are NOT additive over tier or region, so an explicit synthetic
+/// PlatformRegion="ALL" row is materialized (global, no region filter) for the region=ALL read, alongside
+/// per-platform rows; the read point-looks-up, never sums. Scope membership uses the same EXISTS form as
+/// the live <c>ApplyRankTierScopeToParticipants</c>.</item>
+/// </list>
+/// Region "ALL" is a reserved synthetic token; <see cref="AllRegion"/>. A null Summoner.PlatformRegion is
+/// coalesced to "" (a bucket only the region=ALL roll-up ever includes).
+/// </summary>
+public class PrecomputedAnalyticsRefresher : IPrecomputedAnalyticsRefresher
+{
+    /// <summary>Synthetic PlatformRegion value for the global (region-unfiltered) distinct-match rows.</summary>
+    public const string AllRegion = "ALL";
+
+    private const string RankedSoloQueueType = "RANKED_SOLO_5x5";
+
+    private readonly TranscendenceContext _context;
+    private readonly ILogger<PrecomputedAnalyticsRefresher> _logger;
+
+    public PrecomputedAnalyticsRefresher(
+        TranscendenceContext context,
+        ILogger<PrecomputedAnalyticsRefresher> logger)
+    {
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task<PrecomputedAnalyticsRefreshResult> RefreshTabularCoreAsync(string patch, CancellationToken ct)
+    {
+        var computedAt = DateTime.UtcNow;
+
+        var roleTierRows = await BuildRoleTierStatsAsync(patch, computedAt, ct);
+        var (scopeMatchRows, banRows) = await BuildScopeStatsAsync(patch, computedAt, ct);
+
+        await using var tx = await _context.Database.BeginTransactionAsync(ct);
+
+        // Replace this patch's rows transactionally: a reader sees either the whole previous snapshot or the
+        // whole new one, never a half-written patch.
+        await _context.ChampionRoleTierStats.Where(x => x.Patch == patch).ExecuteDeleteAsync(ct);
+        await _context.ScopeMatchCountStats.Where(x => x.Patch == patch).ExecuteDeleteAsync(ct);
+        await _context.ChampionBanScopeStats.Where(x => x.Patch == patch).ExecuteDeleteAsync(ct);
+
+        _context.ChampionRoleTierStats.AddRange(roleTierRows);
+        _context.ScopeMatchCountStats.AddRange(scopeMatchRows);
+        _context.ChampionBanScopeStats.AddRange(banRows);
+        await _context.SaveChangesAsync(ct);
+
+        await tx.CommitAsync(ct);
+
+        _logger.LogInformation(
+            "Precompute refresh (tabular core) patch {Patch}: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban rows",
+            patch, roleTierRows.Count, scopeMatchRows.Count, banRows.Count);
+
+        return new PrecomputedAnalyticsRefreshResult(roleTierRows.Count, scopeMatchRows.Count, banRows.Count);
+    }
+
+    // ---- ChampionRoleTierStat: per (region, current-tier, champion, role) Games/Wins (additive) ----
+
+    private async Task<List<ChampionRoleTierStat>> BuildRoleTierStatsAsync(
+        string patch, DateTime computedAt, CancellationToken ct)
+    {
+        var participants = BaseParticipants(patch);
+
+        var grouped = await (
+            from mp in participants
+            join rank in _context.Ranks.AsNoTracking().Where(r => r.QueueType == RankedSoloQueueType)
+                on mp.SummonerId equals rank.SummonerId into rankGroup
+            from soloRank in rankGroup.DefaultIfEmpty()
+            select new
+            {
+                Region = mp.Summoner.PlatformRegion,
+                Tier = soloRank != null ? soloRank.Tier : RankTierCatalog.Unranked,
+                mp.ChampionId,
+                Role = mp.TeamPosition!,
+                mp.Win
+            })
+            .GroupBy(x => new { x.Region, x.Tier, x.ChampionId, x.Role })
+            .Select(g => new
+            {
+                g.Key.Region,
+                g.Key.Tier,
+                g.Key.ChampionId,
+                g.Key.Role,
+                Games = g.Count(),
+                Wins = g.Sum(x => x.Win ? 1 : 0)
+            })
+            .ToListAsync(ct);
+
+        return grouped
+            .Select(g => new ChampionRoleTierStat
+            {
+                Patch = patch,
+                PlatformRegion = g.Region ?? "",
+                RankTier = g.Tier,
+                ChampionId = g.ChampionId,
+                Role = g.Role,
+                Games = g.Games,
+                Wins = g.Wins,
+                ComputedAtUtc = computedAt
+            })
+            .ToList();
+    }
+
+    // ---- ScopeMatchCountStat + ChampionBanScopeStat: distinct-match denominators/numerators per scope ----
+
+    private async Task<(List<ScopeMatchCountStat> ScopeMatches, List<ChampionBanScopeStat> Bans)> BuildScopeStatsAsync(
+        string patch, DateTime computedAt, CancellationToken ct)
+    {
+        var scopeMatchRows = new List<ScopeMatchCountStat>();
+        var banRows = new List<ChampionBanScopeStat>();
+
+        foreach (var scope in RankTierCatalog.RankScopeTokens)
+        {
+            var scoped = ApplyScope(BaseParticipants(patch), scope);
+
+            // (region, matchId) distinct pairs in scope — region from the participant's summoner.
+            var regionMatches = scoped
+                .Select(mp => new { Region = mp.Summoner.PlatformRegion, mp.MatchId })
+                .Distinct();
+
+            // Per-platform distinct-match counts.
+            var perRegion = await regionMatches
+                .GroupBy(x => x.Region)
+                .Select(g => new { Region = g.Key, Total = g.Count() })
+                .ToListAsync(ct);
+
+            foreach (var r in perRegion)
+            {
+                scopeMatchRows.Add(new ScopeMatchCountStat
+                {
+                    Patch = patch,
+                    PlatformRegion = r.Region ?? "",
+                    RankScope = scope,
+                    TotalMatches = r.Total,
+                    ComputedAtUtc = computedAt
+                });
+            }
+
+            // Global (region=ALL): distinct over the scope ignoring region — NOT the per-region sum, since a
+            // match whose participants span regions would be counted once globally but once per region.
+            var allTotal = await scoped.Select(mp => mp.MatchId).Distinct().CountAsync(ct);
+            if (allTotal > 0)
+            {
+                scopeMatchRows.Add(new ScopeMatchCountStat
+                {
+                    Patch = patch,
+                    PlatformRegion = AllRegion,
+                    RankScope = scope,
+                    TotalMatches = allTotal,
+                    ComputedAtUtc = computedAt
+                });
+            }
+
+            // Ban numerator per (region, champion): distinct banned matches among the scope's matches.
+            var bansPerRegion = await (
+                from rm in regionMatches
+                join b in _context.MatchBans.AsNoTracking() on rm.MatchId equals b.MatchId
+                group rm by new { rm.Region, b.ChampionId } into g
+                select new
+                {
+                    g.Key.Region,
+                    g.Key.ChampionId,
+                    Banned = g.Select(x => x.MatchId).Distinct().Count()
+                })
+                .ToListAsync(ct);
+
+            foreach (var b in bansPerRegion)
+            {
+                banRows.Add(new ChampionBanScopeStat
+                {
+                    Patch = patch,
+                    PlatformRegion = b.Region ?? "",
+                    RankScope = scope,
+                    ChampionId = b.ChampionId,
+                    BannedMatches = b.Banned,
+                    ComputedAtUtc = computedAt
+                });
+            }
+
+            // Global (region=ALL) ban numerator: distinct banned matches over the scope ignoring region.
+            var scopedMatchIds = scoped.Select(mp => mp.MatchId).Distinct();
+            var bansAll = await _context.MatchBans.AsNoTracking()
+                .Where(b => scopedMatchIds.Contains(b.MatchId))
+                .GroupBy(b => b.ChampionId)
+                .Select(g => new { ChampionId = g.Key, Banned = g.Select(x => x.MatchId).Distinct().Count() })
+                .ToListAsync(ct);
+
+            foreach (var b in bansAll)
+            {
+                banRows.Add(new ChampionBanScopeStat
+                {
+                    Patch = patch,
+                    PlatformRegion = AllRegion,
+                    RankScope = scope,
+                    ChampionId = b.ChampionId,
+                    BannedMatches = b.Banned,
+                    ComputedAtUtc = computedAt
+                });
+            }
+        }
+
+        return (scopeMatchRows, banRows);
+    }
+
+    private IQueryable<MatchParticipant> BaseParticipants(string patch) =>
+        _context.MatchParticipants
+            .AsNoTracking()
+            .OnPatch(patch)
+            .FromSuccessfulMatches()
+            .InRankedSoloQueue()
+            .WithAssignedRole();
+
+    /// <summary>
+    /// Restricts participants to those whose <i>own</i> current solo rank is in the scope, mirroring the
+    /// live <c>ApplyRankTierScopeToParticipants</c> EXISTS form. "ALL" applies no filter (includes unranked).
+    /// </summary>
+    private IQueryable<MatchParticipant> ApplyScope(IQueryable<MatchParticipant> query, string scope)
+    {
+        if (scope == RankTierCatalog.AllScope)
+            return query;
+
+        var ranks = _context.Ranks.AsNoTracking();
+
+        if (scope == RankTierCatalog.EmeraldPlusScope)
+        {
+            return query.Where(mp => ranks.Any(r =>
+                r.QueueType == RankedSoloQueueType &&
+                r.SummonerId == mp.SummonerId &&
+                RankTierCatalog.EmeraldPlusTiers.Contains(r.Tier)));
+        }
+
+        // Exact tier.
+        return query.Where(mp => ranks.Any(r =>
+            r.QueueType == RankedSoloQueueType &&
+            r.SummonerId == mp.SummonerId &&
+            r.Tier == scope));
+    }
+}

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
@@ -1,0 +1,23 @@
+namespace Transcendence.Service.Core.Services.Analytics.Interfaces;
+
+/// <summary>
+/// Recomputes the precomputed analytics aggregate tables (<c>ChampionRoleTierStat</c>,
+/// <c>ScopeMatchCountStat</c>, <c>ChampionBanScopeStat</c>) for a patch from the raw match data. The heavy
+/// GROUP BY/distinct-match work that the analytics read surface used to do per request now runs here, on a
+/// cadence, off the request path; reads roll these atoms up by scope as fast indexed lookups.
+/// </summary>
+public interface IPrecomputedAnalyticsRefresher
+{
+    /// <summary>
+    /// Rebuilds the tabular-core aggregates (win-rate/pick-rate/role-rank source + ban-rate
+    /// numerator/denominator) for <paramref name="patch"/>, replacing that patch's rows transactionally so
+    /// reads never observe a partially-written patch.
+    /// </summary>
+    Task<PrecomputedAnalyticsRefreshResult> RefreshTabularCoreAsync(string patch, CancellationToken ct);
+}
+
+/// <summary>Row counts written per table, for logging/observability.</summary>
+public sealed record PrecomputedAnalyticsRefreshResult(
+    int RoleTierRows,
+    int ScopeMatchCountRows,
+    int BanScopeRows);

--- a/Transcendence.Service.Core/Services/Analytics/RankTierCatalog.cs
+++ b/Transcendence.Service.Core/Services/Analytics/RankTierCatalog.cs
@@ -11,4 +11,40 @@ public static class RankTierCatalog
     /// <summary>Solo-queue tiers that make up the "Emerald and above" scope (used for ordering too: highest elo last).</summary>
     public static readonly IReadOnlyList<string> EmeraldPlusTiers =
         ["EMERALD", "DIAMOND", "MASTER", "GRANDMASTER", "CHALLENGER"];
+
+    /// <summary>All individual competitive solo-queue tiers, low → high.</summary>
+    public static readonly IReadOnlyList<string> AllTiers =
+        ["IRON", "BRONZE", "SILVER", "GOLD", "EMERALD", "DIAMOND", "MASTER", "GRANDMASTER", "CHALLENGER"];
+
+    /// <summary>Sentinel <c>RankTier</c> for a participant with no current solo-queue rank row.</summary>
+    public const string Unranked = "UNRANKED";
+
+    /// <summary>Unfiltered rank scope (includes unranked participants/matches).</summary>
+    public const string AllScope = "ALL";
+
+    /// <summary>High-elo composite scope token.</summary>
+    public const string EmeraldPlusScope = "EMERALD_PLUS";
+
+    /// <summary>
+    /// Rank-scope tokens the analytics surface can request — and that the refresh job precomputes the
+    /// distinct-match (ban-rate) denominators for: the unfiltered <see cref="AllScope"/>, the high-elo
+    /// <see cref="EmeraldPlusScope"/> composite, and every exact tier. Mirrors <c>ParseRankTierScope</c>
+    /// in ChampionAnalyticsComputeService (which normalizes "EMERALD+" → "EMERALD_PLUS").
+    /// </summary>
+    public static readonly IReadOnlyList<string> RankScopeTokens =
+        [AllScope, EmeraldPlusScope, .. AllTiers];
+
+    /// <summary>
+    /// The individual <c>RankTier</c> values a scope token covers, for rolling up
+    /// <c>ChampionRoleTierStat</c> rows. <see cref="AllScope"/> returns <c>null</c> (no tier filter —
+    /// includes <see cref="Unranked"/>); <see cref="EmeraldPlusScope"/> returns the high tiers; an exact
+    /// tier returns just itself.
+    /// </summary>
+    public static IReadOnlyList<string>? ResolveScopeTiers(string scopeToken) =>
+        scopeToken switch
+        {
+            AllScope => null,
+            EmeraldPlusScope => EmeraldPlusTiers,
+            _ => [scopeToken],
+        };
 }

--- a/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ public static class ServiceCollectionExtensions
         // Analytics services
         services.AddScoped<IChampionAnalyticsComputeService, ChampionAnalyticsComputeService>();
         services.AddScoped<IChampionAnalyticsService, ChampionAnalyticsService>();
+        services.AddScoped<IPrecomputedAnalyticsRefresher, PrecomputedAnalyticsRefresher>();
         services.AddScoped<ITftSummonerReadService, TftSummonerReadService>();
         services.AddScoped<ITftStaticDataService, TftStaticDataService>();
         services.AddScoped<ITftAnalyticsComputeService, TftAnalyticsComputeService>();

--- a/Transcendence.Service/Migrations/20260624043250_AddPrecomputedAnalyticsStatTables.Designer.cs
+++ b/Transcendence.Service/Migrations/20260624043250_AddPrecomputedAnalyticsStatTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260624043250_AddPrecomputedAnalyticsStatTables")]
+    partial class AddPrecomputedAnalyticsStatTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260624043250_AddPrecomputedAnalyticsStatTables.cs
+++ b/Transcendence.Service/Migrations/20260624043250_AddPrecomputedAnalyticsStatTables.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPrecomputedAnalyticsStatTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChampionBanScopeStats",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Patch = table.Column<string>(type: "text", nullable: false),
+                    PlatformRegion = table.Column<string>(type: "text", nullable: false),
+                    RankScope = table.Column<string>(type: "text", nullable: false),
+                    ChampionId = table.Column<int>(type: "integer", nullable: false),
+                    BannedMatches = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChampionBanScopeStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChampionRoleTierStats",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Patch = table.Column<string>(type: "text", nullable: false),
+                    PlatformRegion = table.Column<string>(type: "text", nullable: false),
+                    RankTier = table.Column<string>(type: "text", nullable: false),
+                    ChampionId = table.Column<int>(type: "integer", nullable: false),
+                    Role = table.Column<string>(type: "text", nullable: false),
+                    Games = table.Column<int>(type: "integer", nullable: false),
+                    Wins = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChampionRoleTierStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ScopeMatchCountStats",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Patch = table.Column<string>(type: "text", nullable: false),
+                    PlatformRegion = table.Column<string>(type: "text", nullable: false),
+                    RankScope = table.Column<string>(type: "text", nullable: false),
+                    TotalMatches = table.Column<int>(type: "integer", nullable: false),
+                    ComputedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScopeMatchCountStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionBanScopeStats_Patch_PlatformRegion_RankScope_Champi~",
+                table: "ChampionBanScopeStats",
+                columns: new[] { "Patch", "PlatformRegion", "RankScope", "ChampionId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionRoleTierStats_Patch_ChampionId_Role",
+                table: "ChampionRoleTierStats",
+                columns: new[] { "Patch", "ChampionId", "Role" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionRoleTierStats_Patch_PlatformRegion_RankTier_Champio~",
+                table: "ChampionRoleTierStats",
+                columns: new[] { "Patch", "PlatformRegion", "RankTier", "ChampionId", "Role" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionRoleTierStats_Patch_Role_RankTier",
+                table: "ChampionRoleTierStats",
+                columns: new[] { "Patch", "Role", "RankTier" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScopeMatchCountStats_Patch_PlatformRegion_RankScope",
+                table: "ScopeMatchCountStats",
+                columns: new[] { "Patch", "PlatformRegion", "RankScope" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChampionBanScopeStats");
+
+            migrationBuilder.DropTable(
+                name: "ChampionRoleTierStats");
+
+            migrationBuilder.DropTable(
+                name: "ScopeMatchCountStats");
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/PrecomputedAnalyticsRefresherTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/PrecomputedAnalyticsRefresherTests.cs
@@ -1,0 +1,265 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Services.Analytics.Implementations;
+using Transcendence.Service.Core.Tests.Support;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// Validates the precompute aggregation (<see cref="PrecomputedAnalyticsRefresher"/>) against a hand-computed
+/// fixture — especially the parts the adversarial equivalence review flagged as risky: the non-additive
+/// distinct-match ban denominator/numerator and the explicit global PlatformRegion="ALL" rows.
+/// </summary>
+public class PrecomputedAnalyticsRefresherTests
+{
+    private const string Patch = "15.2";
+
+    [Fact]
+    public async Task RefreshTabularCore_RoleTierStats_AggregateGamesAndWinsPerRegionTierChampionRole()
+    {
+        await using var ctx = await SeededAsync();
+        await Refresh(ctx.Db);
+
+        var rows = await ctx.Db.ChampionRoleTierStats.AsNoTracking().ToListAsync();
+
+        // One row per (region, tier, champion, role); Games/Wins are the additive atoms.
+        Stat(rows, "NA1", "EMERALD", 100, "TOP").Should().Be((2, 1));   // M1 win, M2 loss
+        Stat(rows, "NA1", "DIAMOND", 100, "TOP").Should().Be((1, 1));   // M3 win
+        Stat(rows, "NA1", "EMERALD", 100, "MIDDLE").Should().Be((1, 1)); // M4 win
+        Stat(rows, "NA1", "EMERALD", 200, "TOP").Should().Be((1, 0));   // M5 loss
+        Stat(rows, "NA1", "UNRANKED", 100, "TOP").Should().Be((1, 1));  // M6 win, no rank
+        Stat(rows, "EUW1", "EMERALD", 100, "TOP").Should().Be((1, 1));  // M7 win
+        Stat(rows, "EUW1", "GOLD", 100, "TOP").Should().Be((1, 0));     // M8 loss
+
+        rows.Should().HaveCount(7);
+        rows.Should().OnlyContain(r => r.Patch == Patch);
+    }
+
+    [Fact]
+    public async Task RefreshTabularCore_ScopeMatchCounts_PerRegionAndExplicitGlobalAll()
+    {
+        await using var ctx = await SeededAsync();
+        await Refresh(ctx.Db);
+
+        var rows = await ctx.Db.ScopeMatchCountStats.AsNoTracking().ToListAsync();
+
+        // ALL scope = every ranked match (each fixture match has one assigned-role participant).
+        Total(rows, "NA1", "ALL").Should().Be(6);   // M1..M6
+        Total(rows, "EUW1", "ALL").Should().Be(2);  // M7, M8
+        Total(rows, "ALL", "ALL").Should().Be(8);   // global, NOT necessarily the per-region sum
+
+        // EMERALD_PLUS = EMERALD + DIAMOND (+ master/gm/chall, none here).
+        Total(rows, "NA1", "EMERALD_PLUS").Should().Be(5); // M1,M2,M4,M5 + M3
+        Total(rows, "EUW1", "EMERALD_PLUS").Should().Be(1); // M7
+        Total(rows, "ALL", "EMERALD_PLUS").Should().Be(6);
+
+        // Exact tiers.
+        Total(rows, "NA1", "EMERALD").Should().Be(4);
+        Total(rows, "ALL", "EMERALD").Should().Be(5);
+        Total(rows, "NA1", "DIAMOND").Should().Be(1);
+        Total(rows, "EUW1", "GOLD").Should().Be(1);
+
+        // Empty scopes (IRON/BRONZE/SILVER/MASTER/...) produce no rows at all.
+        rows.Should().NotContain(r => r.RankScope == "IRON");
+        rows.Should().NotContain(r => r.TotalMatches == 0);
+    }
+
+    [Fact]
+    public async Task RefreshTabularCore_BanCounts_DistinctPerScopeWithGlobalAllRow()
+    {
+        await using var ctx = await SeededAsync();
+        await Refresh(ctx.Db);
+
+        var rows = await ctx.Db.ChampionBanScopeStats.AsNoTracking().Where(r => r.ChampionId == 999).ToListAsync();
+
+        // Champ 999 banned in M1 (NA1, EMERALD), M3 (NA1, DIAMOND), M7 (EUW1, EMERALD).
+        Banned(rows, "NA1", "ALL").Should().Be(2);          // M1, M3
+        Banned(rows, "EUW1", "ALL").Should().Be(1);         // M7
+        Banned(rows, "ALL", "ALL").Should().Be(3);          // M1, M3, M7 (global distinct)
+
+        Banned(rows, "NA1", "EMERALD_PLUS").Should().Be(2); // M1, M3
+        Banned(rows, "EUW1", "EMERALD_PLUS").Should().Be(1);// M7
+        Banned(rows, "ALL", "EMERALD_PLUS").Should().Be(3);
+
+        Banned(rows, "NA1", "EMERALD").Should().Be(1);      // M1
+        Banned(rows, "EUW1", "EMERALD").Should().Be(1);     // M7
+        Banned(rows, "ALL", "EMERALD").Should().Be(2);      // M1, M7
+
+        Banned(rows, "NA1", "DIAMOND").Should().Be(1);      // M3
+        Banned(rows, "ALL", "DIAMOND").Should().Be(1);
+
+        // Not banned in the GOLD match (M8) → no GOLD ban rows for 999.
+        rows.Should().NotContain(r => r.RankScope == "GOLD");
+    }
+
+    [Fact]
+    public async Task RefreshTabularCore_DerivedBanRate_MatchesHandComputed()
+    {
+        await using var ctx = await SeededAsync();
+        await Refresh(ctx.Db);
+
+        // The read derives BanRate = BannedMatches / TotalMatches by point-looking-up the same (region, scope).
+        double BanRate(string region, string scope)
+        {
+            var total = ctx.Db.ScopeMatchCountStats.Single(r => r.PlatformRegion == region && r.RankScope == scope).TotalMatches;
+            var banned = ctx.Db.ChampionBanScopeStats.SingleOrDefault(r => r.ChampionId == 999 && r.PlatformRegion == region && r.RankScope == scope)?.BannedMatches ?? 0;
+            return (double)banned / total;
+        }
+
+        BanRate("NA1", "EMERALD").Should().BeApproximately(1.0 / 4, 1e-9);
+        BanRate("ALL", "EMERALD").Should().BeApproximately(2.0 / 5, 1e-9);
+        BanRate("ALL", "ALL").Should().BeApproximately(3.0 / 8, 1e-9);
+    }
+
+    [Fact]
+    public async Task RefreshTabularCore_IsIdempotent_ReplacesPatchRowsWithoutDuplicating()
+    {
+        await using var ctx = await SeededAsync();
+
+        await Refresh(ctx.Db);
+        var firstRoleTier = await ctx.Db.ChampionRoleTierStats.AsNoTracking().CountAsync();
+        var firstBans = await ctx.Db.ChampionBanScopeStats.AsNoTracking().CountAsync();
+
+        await Refresh(ctx.Db);
+        var secondRoleTier = await ctx.Db.ChampionRoleTierStats.AsNoTracking().CountAsync();
+        var secondBans = await ctx.Db.ChampionBanScopeStats.AsNoTracking().CountAsync();
+
+        secondRoleTier.Should().Be(firstRoleTier);
+        secondBans.Should().Be(firstBans);
+    }
+
+    // ---- helpers ----
+
+    private static async Task Refresh(TranscendenceContext db)
+    {
+        var refresher = new PrecomputedAnalyticsRefresher(db, NullLogger<PrecomputedAnalyticsRefresher>.Instance);
+        await refresher.RefreshTabularCoreAsync(Patch, CancellationToken.None);
+    }
+
+    private static (int Games, int Wins) Stat(IEnumerable<Transcendence.Data.Models.LoL.Analytics.ChampionRoleTierStat> rows,
+        string region, string tier, int champ, string role)
+    {
+        var r = rows.Single(x => x.PlatformRegion == region && x.RankTier == tier && x.ChampionId == champ && x.Role == role);
+        return (r.Games, r.Wins);
+    }
+
+    private static int Total(IEnumerable<Transcendence.Data.Models.LoL.Analytics.ScopeMatchCountStat> rows, string region, string scope) =>
+        rows.Single(x => x.PlatformRegion == region && x.RankScope == scope).TotalMatches;
+
+    private static int Banned(IEnumerable<Transcendence.Data.Models.LoL.Analytics.ChampionBanScopeStat> rows, string region, string scope) =>
+        rows.Single(x => x.PlatformRegion == region && x.RankScope == scope).BannedMatches;
+
+    /// <summary>Seeds the shared fixture (M1..M8 + bans) and returns an open in-memory context.</summary>
+    private static async Task<SeededContext> SeededAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<TranscendenceContext>().UseSqlite(connection).Options;
+        var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        var m1 = SeedOne(db, "NA1_1", "NA1", champ: 100, role: "TOP", win: true, tier: "EMERALD");
+        SeedOne(db, "NA1_2", "NA1", champ: 100, role: "TOP", win: false, tier: "EMERALD");
+        var m3 = SeedOne(db, "NA1_3", "NA1", champ: 100, role: "TOP", win: true, tier: "DIAMOND");
+        SeedOne(db, "NA1_4", "NA1", champ: 100, role: "MIDDLE", win: true, tier: "EMERALD");
+        SeedOne(db, "NA1_5", "NA1", champ: 200, role: "TOP", win: false, tier: "EMERALD");
+        SeedOne(db, "NA1_6", "NA1", champ: 100, role: "TOP", win: true, tier: null); // UNRANKED
+        var m7 = SeedOne(db, "EUW1_7", "EUW1", champ: 100, role: "TOP", win: true, tier: "EMERALD");
+        SeedOne(db, "EUW1_8", "EUW1", champ: 100, role: "TOP", win: false, tier: "GOLD");
+
+        SeedBan(db, m1, championId: 999);
+        SeedBan(db, m3, championId: 999);
+        SeedBan(db, m7, championId: 999);
+
+        await db.SaveChangesAsync();
+        return new SeededContext(connection, db);
+    }
+
+    private static Transcendence.Data.Models.LoL.Match.Match SeedOne(
+        TranscendenceContext db, string matchId, string region, int champ, string role, bool win, string? tier)
+    {
+        var summoner = new Summoner
+        {
+            Id = Guid.NewGuid(),
+            PlatformRegion = region,
+            Region = "americas",
+            GameName = matchId,
+            TagLine = region,
+            Puuid = Guid.NewGuid().ToString("N"),
+            SummonerName = matchId,
+            RiotSummonerId = Guid.NewGuid().ToString("N")
+        };
+
+        if (tier != null)
+        {
+            db.Ranks.Add(new Rank
+            {
+                Id = Guid.NewGuid(),
+                SummonerId = summoner.Id,
+                QueueType = "RANKED_SOLO_5x5",
+                Tier = tier
+            });
+        }
+
+        var match = new Transcendence.Data.Models.LoL.Match.Match
+        {
+            Id = Guid.NewGuid(),
+            MatchId = matchId,
+            MatchDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Duration = 1800,
+            Patch = Patch,
+            QueueId = 420,
+            QueueFamily = "RANKED_SOLO_DUO",
+            QueueType = "420",
+            Status = FetchStatus.Success,
+            PlatformRegion = region,
+            FetchedAt = DateTime.UtcNow
+        };
+
+        db.Summoners.Add(summoner);
+        db.Matches.Add(match);
+        db.MatchParticipants.Add(new MatchParticipant
+        {
+            Id = Guid.NewGuid(),
+            MatchId = match.Id,
+            Match = match,
+            SummonerId = summoner.Id,
+            Summoner = summoner,
+            Puuid = summoner.Puuid,
+            ParticipantId = 1,
+            TeamId = 100,
+            ChampionId = champ,
+            TeamPosition = role,
+            Win = win
+        });
+        return match;
+    }
+
+    private static void SeedBan(TranscendenceContext db, Transcendence.Data.Models.LoL.Match.Match match, int championId)
+    {
+        db.MatchBans.Add(new MatchBan
+        {
+            MatchId = match.Id,
+            Match = match,
+            TeamId = 200,
+            PickTurn = 1,
+            ChampionId = championId
+        });
+    }
+
+    private sealed class SeededContext(SqliteConnection connection, TranscendenceContext db) : IAsyncDisposable
+    {
+        public TranscendenceContext Db { get; } = db;
+
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
First increment of the **structured precomputed-analytics layer** that replaces compute-on-read for the LoL analytics surface (champion win-rates, tier list, pick/ban — matchups & builds follow in later PRs). This PR is the **foundation only**: durable aggregate tables + the refresh job that fills them. **No read-path or schedule change — inert in production, zero behavior change.**

### Why
Today every analytics page scans raw `MatchParticipants` on a cache miss (the matchup query was ~24s before this session's index work), and only the default Emerald+ scope is warmed. The leaders (u.gg/lolalytics) precompute aggregates from ranked games and refresh hourly; pages render from precomputed data for *any* filter combo. This lands the precompute substrate.

### Tables (`Transcendence.Data/Models/LoL/Analytics`)
- **`ChampionRoleTierStat`** `(Patch, PlatformRegion, RankTier, ChampionId, Role) → Games, Wins` — the additive atomic grain behind win-rates, pick-rate, role-rank and the tier list. Reads roll it up by scope (SUM over the tiers/regions in the requested scope).
- **`ScopeMatchCountStat`** + **`ChampionBanScopeStat`** — the distinct-match ban denominator/numerator. Distinct-match counts are **not additive over tier *or* region**, so these are keyed by rank-**scope** token and carry an explicit synthetic **`PlatformRegion="ALL"`** row (computed globally, no region filter); the read **point-looks-up**, never sums. Ban rate is now **role-independent** — one row serves both the win-rate and tier-list pages, which previously disagreed on a champion's ban rate (an artifact: the win-rate path was already role-independent).

### Refresh
`PrecomputedAnalyticsRefresher` rebuilds a patch's rows **transactionally** (a reader sees the whole previous snapshot or the whole new one, never a half-written patch). Every aggregation **mirrors the live compute's filters** (`OnPatch`/`FromSuccessfulMatches`/`InRankedSoloQueue`/`WithAssignedRole`, the current-rank `LEFT JOIN`, and the EXISTS-form scope membership) so the read path can derive identical numbers.

### Correctness
The schema + the non-additive distinct-match handling were designed against an **adversarial equivalence review** of all six analytics read methods (it caught the region=ALL ban non-additivity and the role-scoped-vs-independent ban inconsistency). **5 SQLite-harness tests** validate the aggregation against a hand-computed fixture: per-region + global distinct-match counts, derived ban rate, idempotent patch replacement. Full Service.Core suite green (170 tests).

New **empty** tables → plain migration (no hot-table CONCURRENTLY recipe). Migration applied to prod manually post-merge per the standard no-auto-migrate flow.

### Next
PR 2 schedules the refresh job (populates prod, observe correctness); PR 3 adds the stats-backed reader + equivalence-vs-live tests and cuts the read over (with live fallback); then matchups, builds, and the "updated N min ago" freshness UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)