### PR TITLE
feat(analytics): serve win-rates + tier list from precomputed stat tables (equivalent)

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
@@ -1,0 +1,282 @@
+using Microsoft.EntityFrameworkCore;
+using Transcendence.Data.Models.LoL.Analytics;
+using Transcendence.Service.Core.Services.Analytics.Models;
+
+namespace Transcendence.Service.Core.Services.Analytics.Implementations;
+
+/// <summary>
+/// Stats-backed read path: serves win-rates and the tier list from the precomputed aggregate tables
+/// (<see cref="ChampionRoleTierStat"/>, <see cref="ScopeMatchCountStat"/>, <see cref="ChampionBanScopeStat"/>)
+/// instead of scanning raw <c>MatchParticipants</c>. The atoms are rolled up to the requested scope in SQL
+/// (SUM over the regions/tiers in scope; distinct-match ban metrics by point lookup), then the identical
+/// downstream logic of the raw path (shared private helpers) produces the same DTOs. Falls back to the raw
+/// compute for any patch that has no aggregates yet (rollout / brand-new patch), so reads are always safe.
+/// </summary>
+public partial class ChampionAnalyticsComputeService
+{
+    public async Task<List<ChampionWinRateDto>> ComputeWinRatesFromStatsAsync(
+        int championId,
+        ChampionAnalyticsFilter filter,
+        string patch,
+        CancellationToken ct)
+    {
+        if (!await HasStatsAsync(patch, ct))
+            return await ComputeWinRatesAsync(championId, filter, patch, ct);
+
+        var minimumGamesRequired = await GetAdaptiveMinimumGamesRequiredAsync(patch, ct);
+        var rankTierScope = ParseRankTierScope(filter.RankTier);
+        var scopeToken = ScopeTokenOf(rankTierScope);
+        var tierFilter = RankTierCatalog.ResolveScopeTiers(scopeToken);
+        var region = filter.Region;                                  // already normalized to a platform or null (ALL)
+        var roleFilter = string.IsNullOrEmpty(filter.Role) ? null : filter.Role;
+
+        // Champion's per-(role, tier) Games/Wins, summed over the platform regions in scope.
+        var champQuery = _context.ChampionRoleTierStats.AsNoTracking()
+            .Where(x => x.Patch == patch && x.ChampionId == championId);
+        champQuery = ApplyStatScope(champQuery, region, tierFilter);
+        if (roleFilter != null)
+            champQuery = champQuery.Where(x => x.Role == roleFilter);
+
+        var champRows = await champQuery
+            .GroupBy(x => new { x.Role, x.RankTier })
+            .Select(g => new { g.Key.Role, g.Key.RankTier, Games = g.Sum(x => x.Games), Wins = g.Sum(x => x.Wins) })
+            .ToListAsync(ct);
+
+        var totalGames = champRows.Sum(x => x.Games);
+        if (totalGames == 0)
+            return [];
+
+        var effectiveMinimumGames = ResolveEffectiveSampleSize(minimumGamesRequired, totalGames, floor: 3);
+        var winRateData = champRows.Where(x => x.Games >= effectiveMinimumGames).ToList();
+        if (winRateData.Count == 0)
+            winRateData = champRows.Where(x => x.Games >= 1).ToList();
+
+        // Champion-level, role-independent ban rate by point lookup (matching the live BuildScopedMatchIdQuery,
+        // which never role-filters). Region=ALL reads the synthetic "ALL" row; never summed.
+        var banRate = await LookupBanRateAsync(patch, region, scopeToken, championId, ct);
+
+        // Standings (role-rank + pick-rate denominator): every champion in the same (role, tier) scope.
+        var relevantRoles = winRateData.Select(x => x.Role).Distinct().ToList();
+        var standingsQuery = ApplyStatScope(
+            _context.ChampionRoleTierStats.AsNoTracking().Where(x => x.Patch == patch && relevantRoles.Contains(x.Role)),
+            region, tierFilter);
+
+        var standingsRows = await standingsQuery
+            .GroupBy(x => new { x.Role, x.RankTier, x.ChampionId })
+            .Select(g => new { g.Key.Role, g.Key.RankTier, g.Key.ChampionId, Games = g.Sum(x => x.Games), Wins = g.Sum(x => x.Wins) })
+            .ToListAsync(ct);
+
+        var standingsByRoleTier = standingsRows
+            .GroupBy(x => (Role: x.Role, Tier: x.RankTier))
+            .ToDictionary(
+                g => g.Key,
+                g => new
+                {
+                    Ranked = g
+                        .OrderByDescending(x => x.Games > 0 ? (double)x.Wins / x.Games : 0.0)
+                        .ThenByDescending(x => x.Games)
+                        .ThenBy(x => x.ChampionId)
+                        .Select(x => x.ChampionId)
+                        .ToList(),
+                    TotalGames = g.Sum(x => x.Games)
+                });
+
+        var result = new List<ChampionWinRateDto>(winRateData.Count);
+        foreach (var data in winRateData)
+        {
+            var isUnranked = string.Equals(data.RankTier, RankTierCatalog.Unranked, StringComparison.OrdinalIgnoreCase);
+            standingsByRoleTier.TryGetValue((data.Role, data.RankTier), out var standing);
+            var roleTotalGames = standing?.TotalGames ?? 0;
+
+            int? roleRank = null;
+            int? rolePopulation = null;
+            if (!isUnranked && standing != null)
+            {
+                rolePopulation = standing.Ranked.Count;
+                var index = standing.Ranked.IndexOf(championId);
+                roleRank = index >= 0 ? index + 1 : null;
+            }
+
+            result.Add(new ChampionWinRateDto(
+                ChampionId: championId,
+                Role: data.Role,
+                RankTier: data.RankTier,
+                Games: data.Games,
+                Wins: data.Wins,
+                WinRate: data.Games > 0 ? (double)data.Wins / data.Games : 0.0,
+                PickRate: roleTotalGames > 0 ? (double)data.Games / roleTotalGames : 0.0,
+                BanRate: banRate,
+                RoleRank: roleRank,
+                RolePopulation: rolePopulation,
+                Patch: patch));
+        }
+
+        return result
+            .OrderByDescending(x => x.Games)
+            .ThenBy(x => x.Role, StringComparer.Ordinal)
+            .ThenBy(x => x.RankTier, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    public async Task<List<TierListEntry>> ComputeTierListFromStatsAsync(
+        string? role,
+        string? rankTier,
+        string? region,
+        string patch,
+        CancellationToken ct)
+    {
+        if (!await HasStatsAsync(patch, ct))
+            return await ComputeTierListAsync(role, rankTier, region, patch, ct);
+
+        var normalizedRole = string.IsNullOrWhiteSpace(role) ? "ALL" : role.ToUpperInvariant();
+        var isUnifiedRole = normalizedRole == "ALL";
+        var rankTierScope = ParseRankTierScope(rankTier);
+        var scopeToken = ScopeTokenOf(rankTierScope);
+        var tierFilter = RankTierCatalog.ResolveScopeTiers(scopeToken);
+        var minimumGamesRequired = await GetAdaptiveMinimumGamesRequiredAsync(patch, ct);
+        var regionFilter = AnalyticsRegionCatalog.NormalizeToFilter(region);
+
+        var query = ApplyStatScope(
+            _context.ChampionRoleTierStats.AsNoTracking().Where(x => x.Patch == patch),
+            regionFilter, tierFilter);
+        if (!isUnifiedRole)
+            query = query.Where(x => x.Role == normalizedRole);
+
+        // Aggregate per champion (unified) or per (champion, role), summed over the tiers/regions in scope.
+        List<(int ChampionId, string TeamPosition, int Games, int Wins)> aggregated;
+        if (isUnifiedRole)
+        {
+            aggregated = (await query
+                .GroupBy(x => x.ChampionId)
+                .Select(g => new { ChampionId = g.Key, Games = g.Sum(x => x.Games), Wins = g.Sum(x => x.Wins) })
+                .ToListAsync(ct))
+                .Select(g => (g.ChampionId, "ALL", g.Games, g.Wins))
+                .ToList();
+        }
+        else
+        {
+            aggregated = (await query
+                .GroupBy(x => new { x.ChampionId, x.Role })
+                .Select(g => new { g.Key.ChampionId, g.Key.Role, Games = g.Sum(x => x.Games), Wins = g.Sum(x => x.Wins) })
+                .ToListAsync(ct))
+                .Select(g => (g.ChampionId, g.Role, g.Games, g.Wins))
+                .ToList();
+        }
+
+        var totalParticipants = aggregated.Sum(x => x.Games);
+        if (totalParticipants == 0)
+            return [];
+
+        var effectiveMinimumGames = ResolveEffectiveSampleSize(minimumGamesRequired, totalParticipants, floor: 5);
+        var championStats = aggregated.Where(x => x.Games >= effectiveMinimumGames).ToList();
+        if (championStats.Count == 0)
+            championStats = aggregated.Where(x => x.Games >= 1).ToList();
+        if (championStats.Count == 0)
+            return [];
+
+        // Ban counts by champion — role-independent point lookup (consistent with the win-rate page).
+        var regionKey = regionFilter ?? PrecomputedAnalyticsRefresher.AllRegion;
+        var totalMatchesInScope = await _context.ScopeMatchCountStats.AsNoTracking()
+            .Where(x => x.Patch == patch && x.PlatformRegion == regionKey && x.RankScope == scopeToken)
+            .Select(x => (int?)x.TotalMatches)
+            .FirstOrDefaultAsync(ct) ?? 0;
+        var banCountsByChampion = totalMatchesInScope == 0
+            ? new Dictionary<int, int>()
+            : await _context.ChampionBanScopeStats.AsNoTracking()
+                .Where(x => x.Patch == patch && x.PlatformRegion == regionKey && x.RankScope == scopeToken)
+                .ToDictionaryAsync(x => x.ChampionId, x => x.BannedMatches, ct);
+
+        var withScores = championStats.Select(c => new
+        {
+            c.ChampionId,
+            c.TeamPosition,
+            c.Games,
+            WinRate = c.Games > 0 ? (double)c.Wins / c.Games : 0.0,
+            ConservativeWinRate = ComputeWilsonLowerBound(c.Wins, c.Games),
+            PickRate = totalParticipants > 0 ? (double)c.Games / totalParticipants : 0.0,
+            BanRate = totalMatchesInScope > 0
+                ? (double)banCountsByChampion.GetValueOrDefault(c.ChampionId) / totalMatchesInScope
+                : 0.0
+        })
+        .Select(c => new
+        {
+            c.ChampionId,
+            c.TeamPosition,
+            c.Games,
+            c.WinRate,
+            c.ConservativeWinRate,
+            c.PickRate,
+            c.BanRate,
+            CompositeScore = (c.ConservativeWinRate * 0.70) + (c.PickRate * 0.30)
+        })
+        .OrderByDescending(x => x.CompositeScore)
+        .ThenBy(x => x.ChampionId)
+        .ToList();
+
+        var total = withScores.Count;
+        return withScores.Select((entry, index) =>
+        {
+            var percentile = (double)index / total;
+            var tier = percentile switch
+            {
+                < 0.10 => TierGrade.S,
+                < 0.30 => TierGrade.A,
+                < 0.60 => TierGrade.B,
+                < 0.85 => TierGrade.C,
+                _ => TierGrade.D
+            };
+
+            return new TierListEntry(
+                entry.ChampionId,
+                entry.TeamPosition,
+                tier,
+                entry.CompositeScore,
+                entry.WinRate,
+                entry.PickRate,
+                entry.BanRate,
+                entry.Games,
+                null,
+                null);
+        }).ToList();
+    }
+
+    // ---- shared helpers for the stats path ----
+
+    private Task<bool> HasStatsAsync(string patch, CancellationToken ct) =>
+        _context.ChampionRoleTierStats.AsNoTracking().AnyAsync(x => x.Patch == patch, ct);
+
+    /// <summary>Applies the region (null = ALL → sum every platform) + tier-scope (null = all tiers) filters.</summary>
+    private static IQueryable<ChampionRoleTierStat> ApplyStatScope(
+        IQueryable<ChampionRoleTierStat> query, string? region, IReadOnlyList<string>? tierFilter)
+    {
+        if (region != null)
+            query = query.Where(x => x.PlatformRegion == region);
+        if (tierFilter != null)
+            query = query.Where(x => tierFilter.Contains(x.RankTier));
+        return query;
+    }
+
+    private async Task<double> LookupBanRateAsync(
+        string patch, string? region, string scopeToken, int championId, CancellationToken ct)
+    {
+        var regionKey = region ?? PrecomputedAnalyticsRefresher.AllRegion;
+        var totalMatchesInScope = await _context.ScopeMatchCountStats.AsNoTracking()
+            .Where(x => x.Patch == patch && x.PlatformRegion == regionKey && x.RankScope == scopeToken)
+            .Select(x => (int?)x.TotalMatches)
+            .FirstOrDefaultAsync(ct) ?? 0;
+        if (totalMatchesInScope == 0)
+            return 0.0;
+
+        var bannedMatches = await _context.ChampionBanScopeStats.AsNoTracking()
+            .Where(x => x.Patch == patch && x.PlatformRegion == regionKey && x.RankScope == scopeToken && x.ChampionId == championId)
+            .Select(x => (int?)x.BannedMatches)
+            .FirstOrDefaultAsync(ct) ?? 0;
+        return (double)bannedMatches / totalMatchesInScope;
+    }
+
+    /// <summary>The rank-scope token for the ban tables, derived from the parsed scope (see ParseRankTierScope).</summary>
+    private static string ScopeTokenOf(RankTierScope scope) =>
+        scope.IsEmeraldPlus
+            ? RankTierCatalog.EmeraldPlusScope
+            : string.IsNullOrWhiteSpace(scope.ExactTier) ? RankTierCatalog.AllScope : scope.ExactTier!;
+}

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
@@ -13,7 +13,7 @@ namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 /// <summary>
 /// Raw computation service for champion analytics using EF Core aggregation.
 /// </summary>
-public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
+public partial class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
 {
     private const int MinMatchupSampleSize = 30;
     private const int MatchupsToShow = 5;
@@ -236,6 +236,8 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
 
         return result
             .OrderByDescending(x => x.Games)
+            .ThenBy(x => x.Role, StringComparer.Ordinal)
+            .ThenBy(x => x.RankTier, StringComparer.Ordinal)
             .ToList();
     }
 
@@ -365,7 +367,10 @@ public class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
             // Composite: conservative win rate lower bound (70%) + pick rate (30%).
             CompositeScore = (c.ConservativeWinRate * 0.70) + (c.PickRate * 0.30)
         })
+        // Deterministic tie-break: tiering is positional (percentile by index), so a stable order among
+        // equal composite scores is required for reproducible grades and to match the stats-backed path.
         .OrderByDescending(x => x.CompositeScore)
+        .ThenBy(x => x.ChampionId)
         .ToList();
 
         // Step 5: Assign percentile-based tiers.

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -93,10 +93,11 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         // Build cache key based on normalized filter parameters
         var cacheKey = BuildCacheKey(championId, normalizedFilter, currentPatch);
 
-        // Get or compute win rates with caching
+        // Serve from the precomputed aggregate tables (fast indexed scope roll-up; falls back to the raw
+        // compute for any patch without aggregates yet). HybridCache stays the hot tier in front.
         var winRates = await _cache.GetOrCreateAsync(
             cacheKey,
-            async cancel => await _computeService.ComputeWinRatesAsync(championId, normalizedFilter, currentPatch, cancel),
+            async cancel => await _computeService.ComputeWinRatesFromStatsAsync(championId, normalizedFilter, currentPatch, cancel),
             AnalyticsCacheOptions,
             tags: new[] { AnalyticsCacheTag, $"champion:{championId}", CacheTags.ForPatch(currentPatch) },
             cancellationToken: ct
@@ -142,10 +143,11 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         var cacheKey = $"{TierListCacheKeyPrefix}{normalizedRole}:{normalizedTier}:{normalizedRegion}:{currentPatch}";
         var tags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "tierlist" };
 
-        // Get or compute tier list with caching
+        // Serve from the precomputed aggregate tables (falls back to the raw compute until a patch's
+        // aggregates exist). HybridCache stays the hot tier in front.
         var entries = await _cache.GetOrCreateAsync(
             cacheKey,
-            async cancel => await _computeService.ComputeTierListAsync(
+            async cancel => await _computeService.ComputeTierListFromStatsAsync(
                 normalizedRole,
                 tierFilter,
                 normalizedRegion,
@@ -404,7 +406,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             Patch: currentPatch);
         var winKey = BuildCacheKey(championId, winFilter, currentPatch);
         var winTags = new[] { AnalyticsCacheTag, $"champion:{championId}", CacheTags.ForPatch(currentPatch) };
-        var winRates = await _computeService.ComputeWinRatesAsync(championId, winFilter, currentPatch, ct);
+        var winRates = await _computeService.ComputeWinRatesFromStatsAsync(championId, winFilter, currentPatch, ct);
         await _cache.SetAsync(winKey, winRates, AnalyticsCacheOptions, winTags, ct);
 
         // Resolve the most-played lane EXACTLY like ChampionAnalyticsController.GetProfile so the
@@ -420,7 +422,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
                 Role: null,
                 Patch: currentPatch);
             var fallbackKey = BuildCacheKey(championId, fallbackFilter, currentPatch);
-            var fallbackWinRates = await _computeService.ComputeWinRatesAsync(championId, fallbackFilter, currentPatch, ct);
+            var fallbackWinRates = await _computeService.ComputeWinRatesFromStatsAsync(championId, fallbackFilter, currentPatch, ct);
             await _cache.SetAsync(fallbackKey, fallbackWinRates, AnalyticsCacheOptions, winTags, ct);
             effectiveRole = PickMostPlayedLane(fallbackWinRates);
         }

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
@@ -30,6 +30,30 @@ public interface IChampionAnalyticsComputeService
         CancellationToken ct);
 
     /// <summary>
+    /// Win rates served from the precomputed <c>ChampionRoleTierStat</c>/ban aggregate tables (a fast
+    /// indexed scope roll-up instead of a raw-match scan), falling back to <see cref="ComputeWinRatesAsync"/>
+    /// when no aggregates exist for the patch yet. Produces DTOs identical to the raw path.
+    /// </summary>
+    Task<List<ChampionWinRateDto>> ComputeWinRatesFromStatsAsync(
+        int championId,
+        ChampionAnalyticsFilter filter,
+        string patch,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Tier list served from the precomputed aggregate tables, falling back to
+    /// <see cref="ComputeTierListAsync"/> when no aggregates exist for the patch yet. Tiering/ordering and
+    /// win/pick rates are identical to the raw path; ban rate is role-independent (a deliberate consistency
+    /// fix — see <c>ScopeMatchCountStat</c>) so it matches the unified tier list and the win-rate page.
+    /// </summary>
+    Task<List<TierListEntry>> ComputeTierListFromStatsAsync(
+        string? role,
+        string? rankTier,
+        string? region,
+        string patch,
+        CancellationToken ct);
+
+    /// <summary>
     /// Computes top 3 builds for a champion with items and runes bundled.
     /// Core items (70%+ appearance) distinguished from situational.
     /// Uses only completed, build-impact items for build quality calculations.

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
@@ -51,7 +51,7 @@ public class ChampionAnalyticsServiceTests
         await using var harness = await Harness.CreateAsync();
         harness.SetActivePatch("15.1", DateTime.UtcNow.AddHours(-2));
         harness.ComputeService
-            .Setup(x => x.ComputeWinRatesAsync(
+            .Setup(x => x.ComputeWinRatesFromStatsAsync(
                 103,
                 It.IsAny<ChampionAnalyticsFilter>(),
                 "15.1",
@@ -82,7 +82,7 @@ public class ChampionAnalyticsServiceTests
         await using var harness = await Harness.CreateAsync();
         harness.SetActivePatch("15.1", DateTime.UtcNow.AddHours(-300));
         harness.ComputeService
-            .Setup(x => x.ComputeWinRatesAsync(
+            .Setup(x => x.ComputeWinRatesFromStatsAsync(
                 266,
                 It.IsAny<ChampionAnalyticsFilter>(),
                 "15.1",
@@ -112,7 +112,7 @@ public class ChampionAnalyticsServiceTests
         await using var harness = await Harness.CreateAsync();
         harness.SetActivePatch("15.2", DateTime.UtcNow.AddHours(-180));
         harness.ComputeService
-            .Setup(x => x.ComputeWinRatesAsync(
+            .Setup(x => x.ComputeWinRatesFromStatsAsync(
                 103,
                 It.IsAny<ChampionAnalyticsFilter>(),
                 "15.2",
@@ -142,7 +142,7 @@ public class ChampionAnalyticsServiceTests
         harness.SetActivePatch("15.2", DateTime.UtcNow.AddHours(-2));
         harness.SetInactivePatch("15.1", DateTime.UtcNow.AddHours(-400));
         harness.ComputeService
-            .Setup(x => x.ComputeWinRatesAsync(
+            .Setup(x => x.ComputeWinRatesFromStatsAsync(
                 103,
                 It.Is<ChampionAnalyticsFilter>(filter => filter.Patch == "15.1"),
                 "15.1",
@@ -163,7 +163,7 @@ public class ChampionAnalyticsServiceTests
         result.Sample!.PatchPhase.Should().Be(AnalyticsPatchPhase.Steady);
         result.Sample.IsProvisional.Should().BeFalse();
         result.Sample.IsEarlyPatchWindow.Should().BeFalse();
-        harness.ComputeService.Verify(x => x.ComputeWinRatesAsync(
+        harness.ComputeService.Verify(x => x.ComputeWinRatesFromStatsAsync(
             103,
             It.Is<ChampionAnalyticsFilter>(filter => filter.Patch == "15.1"),
             "15.1",
@@ -177,7 +177,7 @@ public class ChampionAnalyticsServiceTests
         harness.SetActivePatch("15.2", DateTime.UtcNow.AddHours(-2));
         harness.SetInactivePatch("15.1", DateTime.UtcNow.AddHours(-400));
         harness.ComputeService
-            .Setup(x => x.ComputeWinRatesAsync(
+            .Setup(x => x.ComputeWinRatesFromStatsAsync(
                 103,
                 It.IsAny<ChampionAnalyticsFilter>(),
                 "15.2",
@@ -187,7 +187,7 @@ public class ChampionAnalyticsServiceTests
                 new ChampionWinRateDto(103, "MIDDLE", "EMERALD_PLUS", 5, 3, 0.6, 0.12, 0.01, 1, 40, "15.2")
             ]);
         harness.ComputeService
-            .Setup(x => x.ComputeWinRatesAsync(
+            .Setup(x => x.ComputeWinRatesFromStatsAsync(
                 103,
                 It.IsAny<ChampionAnalyticsFilter>(),
                 "15.1",
@@ -209,12 +209,12 @@ public class ChampionAnalyticsServiceTests
 
         activeResult.Patch.Should().Be("15.2");
         historicalResult.Patch.Should().Be("15.1");
-        harness.ComputeService.Verify(x => x.ComputeWinRatesAsync(
+        harness.ComputeService.Verify(x => x.ComputeWinRatesFromStatsAsync(
             103,
             It.IsAny<ChampionAnalyticsFilter>(),
             "15.2",
             It.IsAny<CancellationToken>()), Times.Once);
-        harness.ComputeService.Verify(x => x.ComputeWinRatesAsync(
+        harness.ComputeService.Verify(x => x.ComputeWinRatesFromStatsAsync(
             103,
             It.IsAny<ChampionAnalyticsFilter>(),
             "15.1",
@@ -230,7 +230,7 @@ public class ChampionAnalyticsServiceTests
 
         await harness.Service.GetTierListAsync("ALL", null, "OCE1", null, CancellationToken.None);
 
-        harness.ComputeService.Verify(x => x.ComputeTierListAsync(
+        harness.ComputeService.Verify(x => x.ComputeTierListFromStatsAsync(
             "ALL",
             null,
             "ALL",
@@ -245,7 +245,7 @@ public class ChampionAnalyticsServiceTests
         harness.SetActivePatch("15.1", DateTime.UtcNow.AddHours(-300));
 
         harness.ComputeService
-            .Setup(x => x.ComputeWinRatesAsync(103, It.IsAny<ChampionAnalyticsFilter>(), "15.1", It.IsAny<CancellationToken>()))
+            .Setup(x => x.ComputeWinRatesFromStatsAsync(103, It.IsAny<ChampionAnalyticsFilter>(), "15.1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(
             [
                 new ChampionWinRateDto(103, "MIDDLE", "EMERALD_PLUS", 200, 110, 0.55, 0.2, 0.02, 1, 50, "15.1"),
@@ -281,7 +281,7 @@ public class ChampionAnalyticsServiceTests
         await harness.Service.GetProBuildsAsync(103, null, "MIDDLE", null, null, CancellationToken.None);
 
         harness.ComputeService.Verify(
-            x => x.ComputeWinRatesAsync(103, It.IsAny<ChampionAnalyticsFilter>(), "15.1", It.IsAny<CancellationToken>()),
+            x => x.ComputeWinRatesFromStatsAsync(103, It.IsAny<ChampionAnalyticsFilter>(), "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ComputeService.Verify(
             x => x.ComputeBuildsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
@@ -336,7 +336,7 @@ public class ChampionAnalyticsServiceTests
 
             var compute = new Mock<IChampionAnalyticsComputeService>();
             compute
-            .Setup(x => x.ComputeTierListAsync(
+            .Setup(x => x.ComputeTierListFromStatsAsync(
                     It.IsAny<string>(),
                     It.IsAny<string?>(),
                     It.IsAny<string?>(),

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsStatsEquivalenceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsStatsEquivalenceTests.cs
@@ -1,0 +1,233 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Services.Analytics.Implementations;
+using Transcendence.Service.Core.Services.Analytics.Models;
+using Transcendence.Service.Core.Tests.Support;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// The correctness gate for the stats-backed read path: for a rich seeded dataset, the precomputed
+/// aggregates (built by <see cref="PrecomputedAnalyticsRefresher"/>) must reproduce the raw compute's DTOs
+/// EXACTLY across every scope/region/tier/role combination — win rate, pick rate, role rank/population,
+/// ban rate, conservative win rate, composite score, tier grade and ordering.
+/// </summary>
+public class ChampionAnalyticsStatsEquivalenceTests
+{
+    private const string Patch = "15.2";
+    private static readonly string?[] Regions = [null, "NA1", "EUW1"];                 // null = ALL
+    private static readonly string?[] WinRateTiers = [null, "ALL", "EMERALD_PLUS", "EMERALD", "DIAMOND"];
+    private static readonly string?[] WinRateRoles = [null, "TOP", "MIDDLE"];
+
+    [Fact]
+    public async Task WinRates_StatsPath_EqualsRawCompute_AcrossAllScopes()
+    {
+        await using var ctx = await SeededAsync();
+        await Refresh(ctx.Db);
+        var svc = Service(ctx.Db);
+
+        foreach (var champ in new[] { 100, 200, 300 })
+        foreach (var region in Regions)
+        foreach (var tier in WinRateTiers)
+        foreach (var role in WinRateRoles)
+        {
+            var filter = new ChampionAnalyticsFilter(RankTier: tier, Region: region, Role: role);
+            var raw = await svc.ComputeWinRatesAsync(champ, filter, Patch, CancellationToken.None);
+            var stats = await svc.ComputeWinRatesFromStatsAsync(champ, filter, Patch, CancellationToken.None);
+
+            stats.Should().BeEquivalentTo(raw, o => o.WithStrictOrdering(),
+                $"win rates for champ {champ} tier={tier ?? "ALL"} region={region ?? "ALL"} role={role ?? "ALL"}");
+        }
+    }
+
+    [Fact]
+    public async Task TierList_UnifiedRole_StatsPath_EqualsRawCompute_IncludingBanRate()
+    {
+        await using var ctx = await SeededAsync();
+        await Refresh(ctx.Db);
+        var svc = Service(ctx.Db);
+
+        foreach (var region in Regions)
+        foreach (var tier in new string?[] { null, "ALL", "EMERALD_PLUS", "EMERALD" })
+        {
+            var raw = await svc.ComputeTierListAsync(null, tier, region, Patch, CancellationToken.None);
+            var stats = await svc.ComputeTierListFromStatsAsync(null, tier, region, Patch, CancellationToken.None);
+
+            // Unified tier list: live's ban denominator is also role-independent, so EVERYTHING matches.
+            stats.Should().BeEquivalentTo(raw, o => o.WithStrictOrdering(),
+                $"unified tier list tier={tier ?? "ALL"} region={region ?? "ALL"}");
+        }
+    }
+
+    [Fact]
+    public async Task TierList_RoleFiltered_StatsPath_EqualsRawCompute_ExceptIntentionallyRoleIndependentBanRate()
+    {
+        await using var ctx = await SeededAsync();
+        await Refresh(ctx.Db);
+        var svc = Service(ctx.Db);
+
+        foreach (var role in new[] { "TOP", "MIDDLE" })
+        foreach (var region in Regions)
+        foreach (var tier in new string?[] { null, "EMERALD_PLUS", "EMERALD" })
+        {
+            var raw = await svc.ComputeTierListAsync(role, tier, region, Patch, CancellationToken.None);
+            var stats = await svc.ComputeTierListFromStatsAsync(role, tier, region, Patch, CancellationToken.None);
+
+            // Tiering/ordering/win/pick rates match exactly; BanRate is deliberately role-independent now
+            // (it no longer role-scopes the denominator), so it is excluded from the equivalence assertion.
+            stats.Should().BeEquivalentTo(raw, o => o.WithStrictOrdering().Excluding(e => e.BanRate),
+                $"role-filtered tier list role={role} tier={tier ?? "ALL"} region={region ?? "ALL"}");
+        }
+    }
+
+    [Fact]
+    public async Task StatsPath_FallsBackToRawCompute_WhenNoAggregatesForPatch()
+    {
+        await using var ctx = await SeededAsync();
+        // Deliberately do NOT refresh — no aggregate rows exist.
+        var svc = Service(ctx.Db);
+
+        var filter = new ChampionAnalyticsFilter(RankTier: "EMERALD_PLUS", Region: "NA1", Role: "TOP");
+        var raw = await svc.ComputeWinRatesAsync(100, filter, Patch, CancellationToken.None);
+        var stats = await svc.ComputeWinRatesFromStatsAsync(100, filter, Patch, CancellationToken.None);
+        stats.Should().BeEquivalentTo(raw, o => o.WithStrictOrdering());
+
+        var rawTl = await svc.ComputeTierListAsync("TOP", "EMERALD_PLUS", "NA1", Patch, CancellationToken.None);
+        var statsTl = await svc.ComputeTierListFromStatsAsync("TOP", "EMERALD_PLUS", "NA1", Patch, CancellationToken.None);
+        statsTl.Should().BeEquivalentTo(rawTl, o => o.WithStrictOrdering());
+    }
+
+    // ---- harness ----
+
+    private static ChampionAnalyticsComputeService Service(TranscendenceContext db) =>
+        new(db,
+            Options.Create(new ChampionAnalyticsComputeOptions
+            {
+                MinimumGamesRequired = 1,
+                EarlyPatchMinimumGamesRequired = 1,
+                BootstrapPatchMinimumGamesRequired = 1,
+                BootstrapWindowHours = 24,
+                ProvisionalWindowHours = 96,
+                MaturingWindowHours = 240
+            }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+
+    private static async Task Refresh(TranscendenceContext db) =>
+        await new PrecomputedAnalyticsRefresher(db, NullLogger<PrecomputedAnalyticsRefresher>.Instance)
+            .RefreshTabularCoreAsync(Patch, CancellationToken.None);
+
+    private static async Task<SeededContext> SeededAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<TranscendenceContext>().UseSqlite(connection).Options;
+        var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        // (region, tier, champion, role): N wins + M losses → multiple champions per (role, tier) so role-rank
+        // ordering (winRate desc, games desc, id asc) and pick-rate denominators are non-trivial.
+        AddGames(db, "NA1", "EMERALD", 100, "TOP", wins: 3, losses: 1);
+        AddGames(db, "NA1", "EMERALD", 200, "TOP", wins: 1, losses: 1);
+        AddGames(db, "NA1", "EMERALD", 300, "TOP", wins: 2, losses: 0);
+        AddGames(db, "NA1", "EMERALD", 100, "MIDDLE", wins: 1, losses: 0);
+        AddGames(db, "NA1", "EMERALD", 200, "MIDDLE", wins: 2, losses: 1);
+        AddGames(db, "NA1", "DIAMOND", 100, "TOP", wins: 1, losses: 1);
+        AddGames(db, "NA1", "DIAMOND", 300, "TOP", wins: 1, losses: 0);
+        AddGames(db, "NA1", null, 100, "TOP", wins: 1, losses: 0);        // UNRANKED
+        AddGames(db, "EUW1", "EMERALD", 100, "TOP", wins: 1, losses: 0);
+        AddGames(db, "EUW1", "EMERALD", 300, "TOP", wins: 0, losses: 1);
+        AddGames(db, "EUW1", "GOLD", 200, "TOP", wins: 1, losses: 1);
+
+        // Bans across regions/tiers (champ 999 never played; champ 100 also banned somewhere).
+        var banA = AddGames(db, "NA1", "EMERALD", 400, "JUNGLE", wins: 1, losses: 0).Single();
+        var banB = AddGames(db, "NA1", "EMERALD", 400, "JUNGLE", wins: 0, losses: 1).Single();
+        var banC = AddGames(db, "EUW1", "EMERALD", 400, "JUNGLE", wins: 1, losses: 0).Single();
+        var banD = AddGames(db, "NA1", "DIAMOND", 400, "JUNGLE", wins: 1, losses: 0).Single();
+        SeedBan(db, banA, 999);
+        SeedBan(db, banB, 999);
+        SeedBan(db, banC, 999);
+        SeedBan(db, banD, 100);
+
+        await db.SaveChangesAsync();
+        return new SeededContext(connection, db);
+    }
+
+    private static List<Transcendence.Data.Models.LoL.Match.Match> AddGames(
+        TranscendenceContext db, string region, string? tier, int champ, string role, int wins, int losses)
+    {
+        var matches = new List<Transcendence.Data.Models.LoL.Match.Match>();
+        for (var i = 0; i < wins + losses; i++)
+            matches.Add(AddGame(db, region, tier, champ, role, win: i < wins));
+        return matches;
+    }
+
+    private static Transcendence.Data.Models.LoL.Match.Match AddGame(
+        TranscendenceContext db, string region, string? tier, int champ, string role, bool win)
+    {
+        var summoner = new Summoner
+        {
+            Id = Guid.NewGuid(),
+            PlatformRegion = region,
+            Region = "americas",
+            GameName = Guid.NewGuid().ToString("N")[..8],
+            TagLine = region,
+            Puuid = Guid.NewGuid().ToString("N"),
+            SummonerName = "s",
+            RiotSummonerId = Guid.NewGuid().ToString("N")
+        };
+        if (tier != null)
+            db.Ranks.Add(new Rank { Id = Guid.NewGuid(), SummonerId = summoner.Id, QueueType = "RANKED_SOLO_5x5", Tier = tier });
+
+        var match = new Transcendence.Data.Models.LoL.Match.Match
+        {
+            Id = Guid.NewGuid(),
+            MatchId = Guid.NewGuid().ToString("N"),
+            MatchDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Duration = 1800,
+            Patch = Patch,
+            QueueId = 420,
+            QueueFamily = "RANKED_SOLO_DUO",
+            QueueType = "420",
+            Status = FetchStatus.Success,
+            PlatformRegion = region,
+            FetchedAt = DateTime.UtcNow
+        };
+
+        db.Summoners.Add(summoner);
+        db.Matches.Add(match);
+        db.MatchParticipants.Add(new MatchParticipant
+        {
+            Id = Guid.NewGuid(),
+            MatchId = match.Id,
+            Match = match,
+            SummonerId = summoner.Id,
+            Summoner = summoner,
+            Puuid = summoner.Puuid,
+            ParticipantId = 1,
+            TeamId = 100,
+            ChampionId = champ,
+            TeamPosition = role,
+            Win = win
+        });
+        return match;
+    }
+
+    private static void SeedBan(TranscendenceContext db, Transcendence.Data.Models.LoL.Match.Match match, int championId) =>
+        db.MatchBans.Add(new MatchBan { MatchId = match.Id, Match = match, TeamId = 200, PickTurn = 1, ChampionId = championId });
+
+    private sealed class SeededContext(SqliteConnection connection, TranscendenceContext db) : IAsyncDisposable
+    {
+        public TranscendenceContext Db { get; } = db;
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
Second increment of the structured precomputed-analytics layer. Cuts the **champion win-rate** and **tier-list** reads over to the aggregate tables landed in #90. Reads become fast indexed scope roll-ups over small structured tables instead of raw `MatchParticipants` scans; HybridCache stays the hot tier in front, and the path **falls back to the raw compute** for any patch without aggregates yet (rollout-safe + brand-new patches).

### How
- New `ComputeWinRatesFromStatsAsync` / `ComputeTierListFromStatsAsync` on `IChampionAnalyticsComputeService`, implemented in a **partial file** that reuses the raw path's private helpers (adaptive threshold, Wilson lower bound, scope parsing) — so the downstream DTO assembly is byte-identical. Atoms roll up in SQL (`SUM` over the regions/tiers in scope); the distinct-match ban metrics are **point-looked-up** (the synthetic `"ALL"` region row for region=ALL), never summed.
- `ChampionAnalyticsService` serves win-rates + the tier list (and the default-profile warm path) from the stats methods.
- **Deterministic tie-breaks** added to *both* paths (win-rate: Games desc, Role, RankTier; tier list: composite score then ChampionId). The tier list grade is positional, so a stable order is required for reproducible grades — and so the two paths match.

Ban rate is now **role-independent on the tier list too** (the win-rate path already was) — a champion's ban rate now agrees across both pages.

### Correctness gate
**Gold equivalence tests**: for a rich seeded dataset, the stats path equals the raw compute **exactly** across every champion × rank-scope × region × role combination — win rate, pick rate, role rank/population, ban rate, conservative win rate, composite score, tier grade, ordering. Unified tier list matches incl. ban rate; role-filtered matches except the intentionally role-independent ban rate; the no-aggregates fallback is verified. Existing service tests updated to mock the new methods. Full Service.Core (174) + WebAPI (40) suites green. No schema change.

### Rollout
Reads serve from the tables once a patch's aggregates exist; until then (and in prod before the refresh job is scheduled) they transparently fall back to the raw compute, so this is safe to merge ahead of the job. Next: **PR3** schedules the refresh job + applies the migration to prod + observes the data, then matchups/builds and the "updated N min ago" freshness UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)