### PR TITLE
feat(analytics): precompute champion matchups (ChampionMatchupStat + refresh + read)

### DIFF
--- a/Transcendence.Data/Models/LoL/Analytics/ChampionMatchupStat.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/ChampionMatchupStat.cs
@@ -1,0 +1,48 @@
+namespace Transcendence.Data.Models.LoL.Analytics;
+
+/// <summary>
+/// Precomputed lane-matchup aggregate for one <c>(Patch, RankTier, ChampionId, Role, OpponentChampionId)</c>
+/// — the structured replacement for the live lane-pair self-join + timeline-diff scan in
+/// <c>ComputeMatchupsAsync</c>, at the global (all-region) scope.
+/// <para>
+/// <see cref="RankTier"/> is the <i>champion</i> side's current solo tier ("UNRANKED" when absent) — the
+/// matchup read only scopes the champion side; the opponent is never filtered. Every measure is additive
+/// over tier/role (Games is a lane-PAIR count, not a distinct-match count, so it sums freely), so the read
+/// rolls the requested rank scope up with <c>SUM</c> (and <c>MAX</c> for <see cref="LatestTimelineAtUtc"/>).
+/// Rank scope "all" includes the UNRANKED rows; EMERALD_PLUS / exact-tier reads sum only their tiers
+/// (mirroring the live EXISTS-on-current-rank filter, which excludes unranked players).
+/// </para>
+/// <para>
+/// Region is intentionally NOT a key column: matchups are stored only at the all-region scope (the default
+/// and dominant case). The much rarer region-filtered matchup read falls back to the live compute — keeping
+/// this table ~10× smaller (the full region×tier grain would be 1–2M rows/patch, too heavy to rebuild hourly).
+/// </para>
+/// </summary>
+public class ChampionMatchupStat
+{
+    public Guid Id { get; set; }
+
+    public string Patch { get; set; } = "";
+    public string RankTier { get; set; } = "";
+    public int ChampionId { get; set; }
+    public string Role { get; set; } = "";
+    public int OpponentChampionId { get; set; }
+
+    /// <summary>Lane-pair count (one per champion-side player vs their lane opponent). Additive.</summary>
+    public int Games { get; set; }
+    public int Wins { get; set; }
+
+    /// <summary>Lane pairs where BOTH players have a minute-15 timeline snapshot (the avg-diff denominator).</summary>
+    public int TimelineGames { get; set; }
+
+    /// <summary>SUM over both-present pairs of (champion gold − opponent gold) at 15. Read avg = Sum / TimelineGames.</summary>
+    public long SumGoldDiffAt15 { get; set; }
+
+    /// <summary>SUM over both-present pairs of (champion xp − opponent xp) at 15.</summary>
+    public long SumXpDiffAt15 { get; set; }
+
+    /// <summary>MAX over champion-side-present pairs of the snapshot's DerivedAtUtc (timeline freshness).</summary>
+    public DateTime? LatestTimelineAtUtc { get; set; }
+
+    public DateTime ComputedAtUtc { get; set; }
+}

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -35,6 +35,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<ChampionRoleTierStat> ChampionRoleTierStats { get; set; }
     public DbSet<ScopeMatchCountStat> ScopeMatchCountStats { get; set; }
     public DbSet<ChampionBanScopeStat> ChampionBanScopeStats { get; set; }
+    public DbSet<ChampionMatchupStat> ChampionMatchupStats { get; set; }
 
     // Versioned static data
     public DbSet<Patch> Patches { get; set; }
@@ -646,6 +647,15 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             // Doubles as the UPSERT target and the point-lookup: a specific (region|"ALL", scope, champion).
             // Its (Patch, PlatformRegion, RankScope) prefix also serves the tier-list all-champions read.
             entity.HasIndex(x => new { x.Patch, x.PlatformRegion, x.RankScope, x.ChampionId }).IsUnique();
+        });
+
+        modelBuilder.Entity<ChampionMatchupStat>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.HasIndex(x => new { x.Patch, x.RankTier, x.ChampionId, x.Role, x.OpponentChampionId })
+                .IsUnique();
+            // Matchup read: one champion+role, rolled up over the tiers in scope.
+            entity.HasIndex(x => new { x.Patch, x.ChampionId, x.Role });
         });
     }
 }

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
@@ -240,10 +240,68 @@ public partial class ChampionAnalyticsComputeService
         }).ToList();
     }
 
+    public async Task<ChampionMatchupsResponse> ComputeMatchupsFromStatsAsync(
+        int championId,
+        string role,
+        string? rankTier,
+        string? region,
+        string patch,
+        CancellationToken ct)
+    {
+        var regionFilter = AnalyticsRegionCatalog.NormalizeToFilter(region);
+        // Only the all-region scope is precomputed; a specific region or an un-refreshed patch falls back
+        // to the raw self-join compute.
+        if (regionFilter != null || !await HasMatchupStatsAsync(patch, ct))
+            return await ComputeMatchupsAsync(championId, role, rankTier, region, patch, ct);
+
+        var rankTierScope = ParseRankTierScope(rankTier);
+        var scopeToken = ScopeTokenOf(rankTierScope);
+        var tierFilter = RankTierCatalog.ResolveScopeTiers(scopeToken);
+        var normalizedRegion = AnalyticsRegionCatalog.NormalizeOrDefault(region);
+
+        var query = _context.ChampionMatchupStats.AsNoTracking()
+            .Where(x => x.Patch == patch && x.ChampionId == championId && x.Role == role);
+        if (tierFilter != null)
+            query = query.Where(x => tierFilter.Contains(x.RankTier));
+
+        // Roll the champion-tier atoms up to the requested rank scope (SUM the additive measures; MAX the
+        // timeline freshness). Avg diffs are derived from the summed diff and the timeline-pair count.
+        var rolled = await query
+            .GroupBy(x => x.OpponentChampionId)
+            .Select(g => new
+            {
+                OpponentChampionId = g.Key,
+                Games = g.Sum(x => x.Games),
+                Wins = g.Sum(x => x.Wins),
+                TimelineGames = g.Sum(x => x.TimelineGames),
+                SumGoldDiff = g.Sum(x => x.SumGoldDiffAt15),
+                SumXpDiff = g.Sum(x => x.SumXpDiffAt15),
+                LatestTimelineAtUtc = g.Max(x => x.LatestTimelineAtUtc)
+            })
+            .ToListAsync(ct);
+
+        var aggregates = rolled
+            .Select(m => new MatchupAggregate(
+                m.OpponentChampionId,
+                m.Games,
+                m.Wins,
+                m.Games - m.Wins,
+                m.TimelineGames,
+                m.TimelineGames > 0 ? (double?)((double)m.SumGoldDiff / m.TimelineGames) : null,
+                m.TimelineGames > 0 ? (double?)((double)m.SumXpDiff / m.TimelineGames) : null,
+                m.LatestTimelineAtUtc))
+            .ToList();
+
+        return BuildMatchupsResponse(championId, role, rankTierScope, normalizedRegion, patch, aggregates);
+    }
+
     // ---- shared helpers for the stats path ----
 
     private Task<bool> HasStatsAsync(string patch, CancellationToken ct) =>
         _context.ChampionRoleTierStats.AsNoTracking().AnyAsync(x => x.Patch == patch, ct);
+
+    private Task<bool> HasMatchupStatsAsync(string patch, CancellationToken ct) =>
+        _context.ChampionMatchupStats.AsNoTracking().AnyAsync(x => x.Patch == patch, ct);
 
     /// <summary>Applies the region (null = ALL → sum every platform) + tier-scope (null = all tiers) filters.</summary>
     private static IQueryable<ChampionRoleTierStat> ApplyStatScope(

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.cs
@@ -1651,6 +1651,43 @@ public partial class ChampionAnalyticsComputeService : IChampionAnalyticsCompute
                 })
             .ToListAsync(ct);
 
+        var aggregates = matchupData
+            .Select(m => new MatchupAggregate(
+                m.OpponentChampionId, m.Games, m.Wins, m.Losses, m.TimelineGames,
+                m.AvgGoldDiffAt15, m.AvgXpDiffAt15, m.LatestTimelineAtUtc))
+            .ToList();
+
+        return BuildMatchupsResponse(championId, role, rankTierScope, normalizedRegion, patch, aggregates);
+    }
+
+    /// <summary>Per-opponent matchup aggregate — the shared shape both the raw self-join and the stats roll-up
+    /// feed into <see cref="BuildMatchupsResponse"/>. <c>AvgGoldDiffAt15</c>/<c>AvgXpDiffAt15</c> are null when
+    /// no both-present timeline pairs contributed.</summary>
+    internal readonly record struct MatchupAggregate(
+        int OpponentChampionId,
+        int Games,
+        int Wins,
+        int Losses,
+        int TimelineGames,
+        double? AvgGoldDiffAt15,
+        double? AvgXpDiffAt15,
+        DateTime? LatestTimelineAtUtc);
+
+    /// <summary>
+    /// Shared post-aggregation for matchups (threshold + graceful degradation, counters/favorable selection,
+    /// ordering, response assembly). Used by BOTH <see cref="ComputeMatchupsAsync"/> (raw self-join) and
+    /// <see cref="ComputeMatchupsFromStatsAsync"/> (precomputed roll-up), so the two produce identical DTOs.
+    /// Counters/favorable carry a <c>ThenBy(OpponentChampionId)</c> tie-break so the selected five are
+    /// deterministic under equal win rates.
+    /// </summary>
+    private static ChampionMatchupsResponse BuildMatchupsResponse(
+        int championId,
+        string role,
+        RankTierScope rankTierScope,
+        string normalizedRegion,
+        string patch,
+        List<MatchupAggregate> matchupData)
+    {
         var totalMatchupGames = matchupData.Sum(m => m.Games);
         var totalTimelineGames = matchupData.Sum(m => m.TimelineGames);
         var timelineCoverage = totalMatchupGames > 0
@@ -1663,44 +1700,27 @@ public partial class ChampionAnalyticsComputeService : IChampionAnalyticsCompute
 
         var effectiveMatchupSampleSize = ResolveEffectiveSampleSize(MinMatchupSampleSize, totalMatchupGames, floor: 2);
 
+        static MatchupEntryDto ToEntry(MatchupAggregate m) => new()
+        {
+            OpponentChampionId = m.OpponentChampionId,
+            Games = m.Games,
+            Wins = m.Wins,
+            Losses = m.Losses,
+            WinRate = m.Games > 0 ? (double)m.Wins / m.Games : 0.0,
+            AvgGoldDiffAt15 = m.AvgGoldDiffAt15,
+            AvgXpDiffAt15 = m.AvgXpDiffAt15
+        };
+
         var matchups = matchupData
             .Where(m => m.Games >= effectiveMatchupSampleSize)
-            .Select(g => new
-            {
-                g.OpponentChampionId,
-                g.Games,
-                g.Wins,
-                g.Losses,
-                WinRate = g.Games > 0 ? (double)g.Wins / g.Games : 0.0,
-                g.AvgGoldDiffAt15,
-                g.AvgXpDiffAt15
-            })
-            .Select(m => new MatchupEntryDto
-            {
-                OpponentChampionId = m.OpponentChampionId,
-                Games = m.Games,
-                Wins = m.Wins,
-                Losses = m.Losses,
-                WinRate = m.Games > 0 ? (double)m.Wins / m.Games : 0.0,
-                AvgGoldDiffAt15 = m.AvgGoldDiffAt15,
-                AvgXpDiffAt15 = m.AvgXpDiffAt15
-            })
+            .Select(ToEntry)
             .ToList();
 
         if (matchups.Count == 0)
         {
             matchups = matchupData
                 .Where(m => m.Games >= 1)
-                .Select(m => new MatchupEntryDto
-                {
-                    OpponentChampionId = m.OpponentChampionId,
-                    Games = m.Games,
-                    Wins = m.Wins,
-                    Losses = m.Losses,
-                    WinRate = m.Games > 0 ? (double)m.Wins / m.Games : 0.0,
-                    AvgGoldDiffAt15 = m.AvgGoldDiffAt15,
-                    AvgXpDiffAt15 = m.AvgXpDiffAt15
-                })
+                .Select(ToEntry)
                 .ToList();
         }
 
@@ -1710,16 +1730,19 @@ public partial class ChampionAnalyticsComputeService : IChampionAnalyticsCompute
             .ThenBy(m => m.OpponentChampionId)
             .ToList();
 
-        // Separate counters (low win rate) and favorable (high win rate)
+        // Separate counters (low win rate) and favorable (high win rate). The ThenBy(OpponentChampionId)
+        // tie-break makes the Take(5) deterministic when opponents share a win rate.
         var counters = matchups
             .Where(m => m.WinRate < 0.48)
             .OrderBy(m => m.WinRate)
+            .ThenBy(m => m.OpponentChampionId)
             .Take(MatchupsToShow)
             .ToList();
 
         var favorable = matchups
             .Where(m => m.WinRate > 0.52)
             .OrderByDescending(m => m.WinRate)
+            .ThenBy(m => m.OpponentChampionId)
             .Take(MatchupsToShow)
             .ToList();
 

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -348,9 +348,11 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         var cacheKey = $"{MatchupsCacheKeyPrefix}{championId}:{normalizedRole}:{normalizedTier}:{normalizedRegion}:{selectedPatch}";
         var tags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(selectedPatch), "matchups" };
 
+        // Serve from the precomputed matchup aggregates (all-region scope; falls back to the raw self-join
+        // for a specific region or an un-refreshed patch). HybridCache stays the hot tier in front.
         var response = await _cache.GetOrCreateAsync(
             cacheKey,
-            async cancel => await _computeService.ComputeMatchupsAsync(
+            async cancel => await _computeService.ComputeMatchupsFromStatsAsync(
                 championId,
                 normalizedRole,
                 normalizedTier == "all" ? null : normalizedTier,
@@ -438,7 +440,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
         var matchupsKey = $"{MatchupsCacheKeyPrefix}{championId}:{effectiveRole}:{normalizedTier}:{normalizedRegion}:{currentPatch}";
         var matchupsTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "matchups" };
-        var matchups = await _computeService.ComputeMatchupsAsync(
+        var matchups = await _computeService.ComputeMatchupsFromStatsAsync(
             championId, effectiveRole, tierForCompute, normalizedRegion, currentPatch, ct);
         await _cache.SetAsync(matchupsKey, matchups, AnalyticsCacheOptions, matchupsTags, ct);
 

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
@@ -73,6 +73,125 @@ public class PrecomputedAnalyticsRefresher : IPrecomputedAnalyticsRefresher
         return new PrecomputedAnalyticsRefreshResult(roleTierRows.Count, scopeMatchRows.Count, banRows.Count);
     }
 
+    // ---- ChampionMatchupStat: all-region lane-pair aggregates per (champion-tier, champion, role, opponent) ----
+
+    public async Task<int> RefreshMatchupsAsync(string patch, CancellationToken ct)
+    {
+        const int minuteMark = 15;
+        var computedAt = DateTime.UtcNow;
+
+        // Champion side: every ranked-solo participant with an assigned role, tagged with its current solo
+        // tier (LEFT JOIN -> "UNRANKED"). Mirrors ComputeMatchupsAsync's champion side, aggregated over all
+        // champions/roles at once. EF global query filters (Match/MatchParticipant/TimelineSnapshot status)
+        // apply via the DbSets, matching the live read.
+        var championSide =
+            from mp in BaseParticipants(patch)
+            join rank in _context.Ranks.AsNoTracking().Where(r => r.QueueType == RankedSoloQueueType)
+                on mp.SummonerId equals rank.SummonerId into rankGroup
+            from soloRank in rankGroup.DefaultIfEmpty()
+            select new
+            {
+                mp.MatchId,
+                mp.Win,
+                mp.ChampionId,
+                Role = mp.TeamPosition!,
+                mp.TeamId,
+                mp.ParticipantId,
+                Tier = soloRank != null ? soloRank.Tier : RankTierCatalog.Unranked
+            };
+
+        // Lane pair: same lane (TeamPosition), opposite team. Opponent side is unfiltered (it inherits
+        // patch/status/queue transitively via the shared MatchId).
+        var lanePairs =
+            from champion in championSide
+            join opponent in _context.MatchParticipants.AsNoTracking()
+                on champion.MatchId equals opponent.MatchId
+            where champion.Role == opponent.TeamPosition && champion.TeamId != opponent.TeamId
+            select new
+            {
+                champion.MatchId,
+                champion.Win,
+                champion.ChampionId,
+                champion.Role,
+                champion.Tier,
+                ChampionParticipantId = champion.ParticipantId,
+                OpponentChampionId = opponent.ChampionId,
+                OpponentParticipantId = opponent.ParticipantId
+            };
+
+        var timeline = _context.MatchParticipantTimelineSnapshots.AsNoTracking()
+            .Where(s => s.MinuteMark == minuteMark);
+
+        var grouped = await (
+            from pair in lanePairs
+            join championTimelineRow in timeline
+                on new { pair.MatchId, ParticipantId = pair.ChampionParticipantId }
+                equals new { championTimelineRow.MatchId, championTimelineRow.ParticipantId }
+                into championTimelineRows
+            from championTimeline in championTimelineRows.DefaultIfEmpty()
+            join opponentTimelineRow in timeline
+                on new { pair.MatchId, ParticipantId = pair.OpponentParticipantId }
+                equals new { opponentTimelineRow.MatchId, opponentTimelineRow.ParticipantId }
+                into opponentTimelineRows
+            from opponentTimeline in opponentTimelineRows.DefaultIfEmpty()
+            group new { pair, championTimeline, opponentTimeline } by new
+            {
+                pair.Tier,
+                pair.ChampionId,
+                pair.Role,
+                pair.OpponentChampionId
+            }
+            into g
+            select new
+            {
+                g.Key.Tier,
+                g.Key.ChampionId,
+                g.Key.Role,
+                g.Key.OpponentChampionId,
+                Games = g.Count(),
+                Wins = g.Sum(x => x.pair.Win ? 1 : 0),
+                TimelineGames = g.Count(x => x.championTimeline != null && x.opponentTimeline != null),
+                SumGoldDiffAt15 = g
+                    .Where(x => x.championTimeline != null && x.opponentTimeline != null)
+                    .Select(x => (long)(x.championTimeline!.Gold - x.opponentTimeline!.Gold))
+                    .Sum(),
+                SumXpDiffAt15 = g
+                    .Where(x => x.championTimeline != null && x.opponentTimeline != null)
+                    .Select(x => (long)(x.championTimeline!.Xp - x.opponentTimeline!.Xp))
+                    .Sum(),
+                LatestTimelineAtUtc = g
+                    .Where(x => x.championTimeline != null)
+                    .Select(x => (DateTime?)x.championTimeline!.DerivedAtUtc)
+                    .Max()
+            })
+            .ToListAsync(ct);
+
+        var rows = grouped.Select(g => new ChampionMatchupStat
+        {
+            Patch = patch,
+            RankTier = g.Tier,
+            ChampionId = g.ChampionId,
+            Role = g.Role,
+            OpponentChampionId = g.OpponentChampionId,
+            Games = g.Games,
+            Wins = g.Wins,
+            TimelineGames = g.TimelineGames,
+            SumGoldDiffAt15 = g.SumGoldDiffAt15,
+            SumXpDiffAt15 = g.SumXpDiffAt15,
+            LatestTimelineAtUtc = g.LatestTimelineAtUtc,
+            ComputedAtUtc = computedAt
+        }).ToList();
+
+        await using var tx = await _context.Database.BeginTransactionAsync(ct);
+        await _context.ChampionMatchupStats.Where(x => x.Patch == patch).ExecuteDeleteAsync(ct);
+        _context.ChampionMatchupStats.AddRange(rows);
+        await _context.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        _logger.LogInformation("Precompute refresh (matchups) patch {Patch}: {Rows} rows", patch, rows.Count);
+        return rows.Count;
+    }
+
     // ---- ChampionRoleTierStat: per (region, current-tier, champion, role) Games/Wins (additive) ----
 
     private async Task<List<ChampionRoleTierStat>> BuildRoleTierStatsAsync(

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
@@ -102,4 +102,17 @@ public interface IChampionAnalyticsComputeService
         string? region,
         string patch,
         CancellationToken ct);
+
+    /// <summary>
+    /// Matchups served from the precomputed <c>ChampionMatchupStat</c> aggregates (all-region scope), rolled
+    /// up to the requested rank scope. Falls back to <see cref="ComputeMatchupsAsync"/> for a specific region
+    /// (only the all-region scope is precomputed) or a patch without aggregates yet. Identical DTOs otherwise.
+    /// </summary>
+    Task<ChampionMatchupsResponse> ComputeMatchupsFromStatsAsync(
+        int championId,
+        string role,
+        string? rankTier,
+        string? region,
+        string patch,
+        CancellationToken ct);
 }

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
@@ -14,6 +14,13 @@ public interface IPrecomputedAnalyticsRefresher
     /// reads never observe a partially-written patch.
     /// </summary>
     Task<PrecomputedAnalyticsRefreshResult> RefreshTabularCoreAsync(string patch, CancellationToken ct);
+
+    /// <summary>
+    /// Rebuilds the all-region lane-matchup aggregates (<c>ChampionMatchupStat</c>) for
+    /// <paramref name="patch"/> — one big lane-pair self-join + timeline-diff aggregation grouped over every
+    /// champion at once — replacing the patch's rows transactionally. Returns the row count written.
+    /// </summary>
+    Task<int> RefreshMatchupsAsync(string patch, CancellationToken ct);
 }
 
 /// <summary>Row counts written per table, for logging/observability.</summary>

--- a/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
@@ -39,9 +39,10 @@ public class RefreshPrecomputedAnalyticsJob(
         }
 
         var result = await refresher.RefreshTabularCoreAsync(patch, ct);
+        var matchupRows = await refresher.RefreshMatchupsAsync(patch, ct);
 
         logger.LogInformation(
-            "Precompute refresh patch {Patch} completed in {ElapsedMs}ms: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban rows.",
-            patch, stopwatch.ElapsedMilliseconds, result.RoleTierRows, result.ScopeMatchCountRows, result.BanScopeRows);
+            "Precompute refresh patch {Patch} completed in {ElapsedMs}ms: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban, {Matchup} matchup rows.",
+            patch, stopwatch.ElapsedMilliseconds, result.RoleTierRows, result.ScopeMatchCountRows, result.BanScopeRows, matchupRows);
     }
 }

--- a/Transcendence.Service/Migrations/20260625034619_AddChampionMatchupStat.Designer.cs
+++ b/Transcendence.Service/Migrations/20260625034619_AddChampionMatchupStat.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260625034619_AddChampionMatchupStat")]
+    partial class AddChampionMatchupStat
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260625034619_AddChampionMatchupStat.cs
+++ b/Transcendence.Service/Migrations/20260625034619_AddChampionMatchupStat.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChampionMatchupStat : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChampionMatchupStats",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Patch = table.Column<string>(type: "text", nullable: false),
+                    RankTier = table.Column<string>(type: "text", nullable: false),
+                    ChampionId = table.Column<int>(type: "integer", nullable: false),
+                    Role = table.Column<string>(type: "text", nullable: false),
+                    OpponentChampionId = table.Column<int>(type: "integer", nullable: false),
+                    Games = table.Column<int>(type: "integer", nullable: false),
+                    Wins = table.Column<int>(type: "integer", nullable: false),
+                    TimelineGames = table.Column<int>(type: "integer", nullable: false),
+                    SumGoldDiffAt15 = table.Column<long>(type: "bigint", nullable: false),
+                    SumXpDiffAt15 = table.Column<long>(type: "bigint", nullable: false),
+                    LatestTimelineAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ComputedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChampionMatchupStats", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionMatchupStats_Patch_ChampionId_Role",
+                table: "ChampionMatchupStats",
+                columns: new[] { "Patch", "ChampionId", "Role" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionMatchupStats_Patch_RankTier_ChampionId_Role_Opponen~",
+                table: "ChampionMatchupStats",
+                columns: new[] { "Patch", "RankTier", "ChampionId", "Role", "OpponentChampionId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChampionMatchupStats");
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
@@ -255,7 +255,7 @@ public class ChampionAnalyticsServiceTests
             .Setup(x => x.ComputeBuildsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChampionBuildsResponse(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", [], []));
         harness.ComputeService
-            .Setup(x => x.ComputeMatchupsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
+            .Setup(x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChampionMatchupsResponse
             {
                 ChampionId = 103,
@@ -287,7 +287,7 @@ public class ChampionAnalyticsServiceTests
             x => x.ComputeBuildsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ComputeService.Verify(
-            x => x.ComputeMatchupsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
+            x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ComputeService.Verify(
             x => x.ComputeProBuildsAsync(103, "ALL", "MIDDLE", "all", "15.1", It.IsAny<CancellationToken>()),

--- a/tests/Transcendence.Service.Core.Tests/ChampionMatchupStatsEquivalenceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionMatchupStatsEquivalenceTests.cs
@@ -1,0 +1,192 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Services.Analytics.Implementations;
+using Transcendence.Service.Core.Services.Analytics.Models;
+using Transcendence.Service.Core.Tests.Support;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// Correctness gate for the precomputed matchups: for a seeded lane-pair + timeline dataset, the stats-backed
+/// read (rolling the per-tier <c>ChampionMatchupStat</c> atoms up to a rank scope) must reproduce the live
+/// lane-pair self-join compute EXACTLY across rank scopes — counters, favorable, all-matchups (set + order),
+/// win rates, avg gold/xp diffs, timeline coverage/sample/freshness.
+/// </summary>
+public class ChampionMatchupStatsEquivalenceTests
+{
+    private const string Patch = "15.2";
+    private static readonly DateTime T0 = new(2026, 6, 24, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task Matchups_StatsPath_EqualsRawCompute_AcrossRankScopes()
+    {
+        await using var ctx = await SeededAsync();
+        await new PrecomputedAnalyticsRefresher(ctx.Db, NullLogger<PrecomputedAnalyticsRefresher>.Instance)
+            .RefreshMatchupsAsync(Patch, CancellationToken.None);
+        var svc = Service(ctx.Db);
+
+        foreach (var tier in new string?[] { null, "ALL", "EMERALD_PLUS", "EMERALD", "DIAMOND" })
+        {
+            // region null = ALL (the only precomputed scope); both paths see the same seeded data.
+            var raw = await svc.ComputeMatchupsAsync(100, "MIDDLE", tier, null, Patch, CancellationToken.None);
+            var stats = await svc.ComputeMatchupsFromStatsAsync(100, "MIDDLE", tier, null, Patch, CancellationToken.None);
+
+            stats.Should().BeEquivalentTo(raw, o => o.WithStrictOrdering(),
+                $"matchups for champ 100 MIDDLE scope={tier ?? "ALL"}");
+        }
+    }
+
+    [Fact]
+    public async Task Matchups_SpecificRegion_FallsBackToRawCompute()
+    {
+        await using var ctx = await SeededAsync();
+        await new PrecomputedAnalyticsRefresher(ctx.Db, NullLogger<PrecomputedAnalyticsRefresher>.Instance)
+            .RefreshMatchupsAsync(Patch, CancellationToken.None);
+        var svc = Service(ctx.Db);
+
+        // A specific region isn't precomputed → must equal the raw region-scoped compute.
+        var raw = await svc.ComputeMatchupsAsync(100, "MIDDLE", "EMERALD_PLUS", "NA1", Patch, CancellationToken.None);
+        var stats = await svc.ComputeMatchupsFromStatsAsync(100, "MIDDLE", "EMERALD_PLUS", "NA1", Patch, CancellationToken.None);
+        stats.Should().BeEquivalentTo(raw, o => o.WithStrictOrdering());
+    }
+
+    private static ChampionAnalyticsComputeService Service(TranscendenceContext db) =>
+        new(db,
+            Options.Create(new ChampionAnalyticsComputeOptions
+            {
+                MinimumGamesRequired = 1,
+                EarlyPatchMinimumGamesRequired = 1,
+                BootstrapPatchMinimumGamesRequired = 1,
+                BootstrapWindowHours = 24,
+                ProvisionalWindowHours = 96,
+                MaturingWindowHours = 240
+            }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+
+    private static async Task<SeededContext> SeededAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<TranscendenceContext>().UseSqlite(connection).Options;
+        var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        // champ 100 MIDDLE vs 200 — a counter (champ behind). 3 EMERALD games (0W) + 1 DIAMOND game (1W).
+        SeedLanePair(db, "m1", 100, "EMERALD", "MIDDLE", win: false, opponent: 200, (cg: 4000, cx: 5000, og: 5200, ox: 6000, at: T0));
+        SeedLanePair(db, "m2", 100, "EMERALD", "MIDDLE", win: false, opponent: 200, (cg: 4200, cx: 5200, og: 5000, ox: 5800, at: T0.AddMinutes(5)));
+        SeedLanePair(db, "m3", 100, "EMERALD", "MIDDLE", win: false, opponent: 200, timeline: null); // no timeline
+        SeedLanePair(db, "m4", 100, "DIAMOND", "MIDDLE", win: true, opponent: 200, (cg: 6000, cx: 7000, og: 5000, ox: 6200, at: T0.AddMinutes(10)));
+
+        // champ 100 MIDDLE vs 300 — favorable. 3 EMERALD games (3W), all with timelines (champ ahead).
+        SeedLanePair(db, "m5", 100, "EMERALD", "MIDDLE", win: true, opponent: 300, (cg: 7000, cx: 8000, og: 5500, ox: 6500, at: T0));
+        SeedLanePair(db, "m6", 100, "EMERALD", "MIDDLE", win: true, opponent: 300, (cg: 6800, cx: 7800, og: 5600, ox: 6400, at: T0.AddMinutes(2)));
+        SeedLanePair(db, "m7", 100, "EMERALD", "MIDDLE", win: true, opponent: 300, (cg: 6900, cx: 7900, og: 5400, ox: 6300, at: T0.AddMinutes(3)));
+
+        // champ 100 MIDDLE vs 400 — even. 2 DIAMOND games (1W). 1 with timeline.
+        SeedLanePair(db, "m8", 100, "DIAMOND", "MIDDLE", win: true, opponent: 400, (cg: 5500, cx: 6500, og: 5400, ox: 6400, at: T0.AddMinutes(7)));
+        SeedLanePair(db, "m9", 100, "DIAMOND", "MIDDLE", win: false, opponent: 400, timeline: null);
+
+        // unranked champ-side game (only visible under scope "all").
+        SeedLanePair(db, "m10", 100, null, "MIDDLE", win: true, opponent: 300, (cg: 6000, cx: 7000, og: 5800, ox: 6700, at: T0.AddMinutes(1)));
+
+        await db.SaveChangesAsync();
+        return new SeededContext(connection, db);
+    }
+
+    private static void SeedLanePair(
+        TranscendenceContext db, string matchId, int championId, string? championTier, string role, bool win,
+        int opponent, (int cg, int cx, int og, int ox, DateTime at)? timeline = null)
+    {
+        var champSummoner = NewSummoner();
+        var oppSummoner = NewSummoner();
+        if (championTier != null)
+            db.Ranks.Add(new Rank { Id = Guid.NewGuid(), SummonerId = champSummoner.Id, QueueType = "RANKED_SOLO_5x5", Tier = championTier });
+
+        var match = new Transcendence.Data.Models.LoL.Match.Match
+        {
+            Id = Guid.NewGuid(),
+            MatchId = matchId,
+            MatchDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Duration = 1800,
+            Patch = Patch,
+            QueueId = 420,
+            QueueFamily = "RANKED_SOLO_DUO",
+            QueueType = "420",
+            Status = FetchStatus.Success,
+            PlatformRegion = "NA1",
+            FetchedAt = DateTime.UtcNow
+        };
+
+        db.Summoners.Add(champSummoner);
+        db.Summoners.Add(oppSummoner);
+        db.Matches.Add(match);
+        db.MatchParticipants.Add(NewParticipant(match, champSummoner, participantId: 1, teamId: 100, championId, role, win));
+        db.MatchParticipants.Add(NewParticipant(match, oppSummoner, participantId: 2, teamId: 200, opponent, role, !win));
+
+        if (timeline is { } t)
+        {
+            db.MatchParticipantTimelineSnapshots.Add(NewSnapshot(match, participantId: 1, t.cg, t.cx, t.at));
+            db.MatchParticipantTimelineSnapshots.Add(NewSnapshot(match, participantId: 2, t.og, t.ox, t.at));
+        }
+    }
+
+    private static Summoner NewSummoner() => new()
+    {
+        Id = Guid.NewGuid(),
+        PlatformRegion = "NA1",
+        Region = "americas",
+        GameName = Guid.NewGuid().ToString("N")[..8],
+        TagLine = "NA1",
+        Puuid = Guid.NewGuid().ToString("N"),
+        SummonerName = "s",
+        RiotSummonerId = Guid.NewGuid().ToString("N")
+    };
+
+    private static MatchParticipant NewParticipant(
+        Transcendence.Data.Models.LoL.Match.Match match, Summoner summoner, int participantId, int teamId,
+        int championId, string role, bool win) => new()
+    {
+        Id = Guid.NewGuid(),
+        MatchId = match.Id,
+        Match = match,
+        SummonerId = summoner.Id,
+        Summoner = summoner,
+        Puuid = summoner.Puuid,
+        ParticipantId = participantId,
+        TeamId = teamId,
+        ChampionId = championId,
+        TeamPosition = role,
+        Win = win
+    };
+
+    private static MatchParticipantTimelineSnapshot NewSnapshot(
+        Transcendence.Data.Models.LoL.Match.Match match, int participantId, int gold, int xp, DateTime at) => new()
+    {
+        MatchId = match.Id,
+        Match = match,
+        ParticipantId = participantId,
+        MinuteMark = 15,
+        Gold = gold,
+        Xp = xp,
+        Cs = 0,
+        Level = 0,
+        FrameTimestampMs = 900000,
+        DerivedAtUtc = at
+    };
+
+    private sealed class SeededContext(SqliteConnection connection, TranscendenceContext db) : IAsyncDisposable
+    {
+        public TranscendenceContext Db { get; } = db;
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
**Step 2** of the precomputed-analytics layer (#90 tabular, #91 reader, #92 job). Serves champion **matchups** (counters / favorable / all-matchups + minute-15 gold/xp diffs) from a precomputed aggregate instead of the live **lane-pair self-join** over `MatchParticipants` + the **22.5M-row** timeline table — the exact query that drove the 2026-06-21 warm-storm incident.

### Design
- **`ChampionMatchupStat`** `(Patch, RankTier, ChampionId, Role, OpponentChampionId) → Games, Wins, TimelineGames, SumGoldDiffAt15, SumXpDiffAt15, LatestTimelineAtUtc`. `RankTier` is the **champion side's** tier (the read only scopes the champion side). All measures are additive — Games is a lane-**pair** count, not a distinct-match count, so there's no ban-rate-style non-additivity — so the read rolls a rank scope up with `SUM` (+ `MAX` for freshness). Avg diffs derive from `SumDiff / TimelineGames`, exactly matching the live `Average`.
- **All-region scope only.** The full region×tier grain would be ~1–2M rows/patch — too heavy to rebuild hourly on the HDD DB with EF inserts (no bulk-copy in the codebase). A **specific-region** matchup read **falls back to the raw compute** (rare, small-sample). Documented on the entity.
- **`RefreshMatchupsAsync`**: one self-join + double timeline `LEFT JOIN` aggregated over every champion at once, run through the `DbContext` so the **EF global query filters apply** (the equivalence verdict's required fix). Transactional patch replacement. The job runs it after the tabular refresh on the isolated `analytics-warm` lane.
- **Shared `BuildMatchupsResponse`** (threshold/degradation/counters/favorable/ordering) used by **both** the raw and stats paths → identical DTOs. Counters/favorable gained the **`ThenBy(OpponentChampionId)`** tie-break (verdict fix) on both paths for a deterministic `Take(5)` under win-rate ties.

### Correctness
**Gold equivalence tests**: the stats path equals the raw self-join compute **exactly** across rank scopes — counters/favorable/all-matchups (set + order), win rates, avg gold/xp diffs, timeline coverage/sample/freshness — plus the region fallback. 178 Service.Core + 40 WebAPI green; no model drift. New empty table → plain migration.

### After merge
Apply the migration to prod and **watch the first matchup refresh** (the heavy self-join) for DB saturation before relying on it — same monitoring as the tabular refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)