### PR TITLE
feat(analytics): precompute champion builds as a durable response cache

### DIFF
--- a/Transcendence.Data/Models/LoL/Analytics/ChampionBuildSnapshot.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/ChampionBuildSnapshot.cs
@@ -1,0 +1,30 @@
+namespace Transcendence.Data.Models.LoL.Analytics;
+
+/// <summary>
+/// A durable, precomputed champion-builds response for one <c>(Patch, ChampionId, Role, RankScope)</c> at
+/// the all-region scope. Builds are document-shaped (a nested, timing-ordered build path), so unlike the
+/// tabular win-rate/matchup aggregates they are <b>not</b> decomposed into structured columns — instead the
+/// refresh job runs the exact live <c>ComputeBuildsAsync</c> and persists its serialized response here, so a
+/// cold read becomes a point lookup + deserialize instead of a heavy raw scan. Because the stored value is
+/// the live compute's own output, equivalence is trivial (no behavior change).
+/// <para>
+/// Only the common rank scopes (<c>EMERALD_PLUS</c> — the page default — and <c>ALL</c>) are precomputed,
+/// at the all-region scope; a specific tier or region read falls back to the live compute.
+/// </para>
+/// </summary>
+public class ChampionBuildSnapshot
+{
+    public Guid Id { get; set; }
+
+    public string Patch { get; set; } = "";
+    public int ChampionId { get; set; }
+    public string Role { get; set; } = "";
+
+    /// <summary>Rank-scope token: "EMERALD_PLUS" or "ALL".</summary>
+    public string RankScope { get; set; } = "";
+
+    /// <summary>The serialized <c>ChampionBuildsResponse</c> (JSON), returned to callers verbatim.</summary>
+    public string Payload { get; set; } = "";
+
+    public DateTime ComputedAtUtc { get; set; }
+}

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -36,6 +36,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<ScopeMatchCountStat> ScopeMatchCountStats { get; set; }
     public DbSet<ChampionBanScopeStat> ChampionBanScopeStats { get; set; }
     public DbSet<ChampionMatchupStat> ChampionMatchupStats { get; set; }
+    public DbSet<ChampionBuildSnapshot> ChampionBuildSnapshots { get; set; }
 
     // Versioned static data
     public DbSet<Patch> Patches { get; set; }
@@ -656,6 +657,13 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
                 .IsUnique();
             // Matchup read: one champion+role, rolled up over the tiers in scope.
             entity.HasIndex(x => new { x.Patch, x.ChampionId, x.Role });
+        });
+
+        modelBuilder.Entity<ChampionBuildSnapshot>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            // Doubles as the UPSERT target and the read point-lookup.
+            entity.HasIndex(x => new { x.Patch, x.ChampionId, x.Role, x.RankScope }).IsUnique();
         });
     }
 }

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/BuildSnapshotSerialization.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/BuildSnapshotSerialization.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using Transcendence.Service.Core.Services.Analytics.Models;
+
+namespace Transcendence.Service.Core.Services.Analytics.Implementations;
+
+/// <summary>
+/// Single source of truth for serializing/deserializing a <see cref="ChampionBuildsResponse"/> to/from a
+/// <c>ChampionBuildSnapshot.Payload</c>. The refresh (serialize) and the read (deserialize) MUST use the
+/// same options so the round-trip is exact.
+/// </summary>
+internal static class BuildSnapshotSerialization
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    public static string Serialize(ChampionBuildsResponse response) =>
+        JsonSerializer.Serialize(response, Options);
+
+    public static ChampionBuildsResponse? Deserialize(string payload) =>
+        JsonSerializer.Deserialize<ChampionBuildsResponse>(payload, Options);
+}

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
@@ -295,6 +295,38 @@ public partial class ChampionAnalyticsComputeService
         return BuildMatchupsResponse(championId, role, rankTierScope, normalizedRegion, patch, aggregates);
     }
 
+    public async Task<ChampionBuildsResponse> ComputeBuildsFromStatsAsync(
+        int championId,
+        string role,
+        string? rankTier,
+        string? region,
+        string patch,
+        CancellationToken ct)
+    {
+        var regionFilter = AnalyticsRegionCatalog.NormalizeToFilter(region);
+        var scopeToken = ScopeTokenOf(ParseRankTierScope(rankTier));
+
+        // Only EMERALD_PLUS + ALL are precomputed, at the all-region scope; a specific tier/region (or a
+        // missing/un-refreshed snapshot) falls back to the live build compute.
+        if (regionFilter == null &&
+            (scopeToken == RankTierCatalog.EmeraldPlusScope || scopeToken == RankTierCatalog.AllScope))
+        {
+            var payload = await _context.ChampionBuildSnapshots.AsNoTracking()
+                .Where(x => x.Patch == patch && x.ChampionId == championId && x.Role == role && x.RankScope == scopeToken)
+                .Select(x => x.Payload)
+                .FirstOrDefaultAsync(ct);
+
+            if (payload != null)
+            {
+                var cached = BuildSnapshotSerialization.Deserialize(payload);
+                if (cached != null)
+                    return cached;
+            }
+        }
+
+        return await ComputeBuildsAsync(championId, role, rankTier, region, patch, ct);
+    }
+
     // ---- shared helpers for the stats path ----
 
     private Task<bool> HasStatsAsync(string patch, CancellationToken ct) =>

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -200,7 +200,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
         var response = await _cache.GetOrCreateAsync(
             cacheKey,
-            async cancel => await _computeService.ComputeBuildsAsync(
+            async cancel => await _computeService.ComputeBuildsFromStatsAsync(
                 championId,
                 normalizedRole,
                 normalizedTier == "all" ? null : normalizedTier,
@@ -434,7 +434,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         // ── Builds + matchups for the resolved lane (region=ALL, given tier) ──
         var buildsKey = $"{BuildsCacheKeyPrefix}{championId}:{effectiveRole}:{normalizedTier}:{normalizedRegion}:{currentPatch}";
         var buildsTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "builds" };
-        var builds = await _computeService.ComputeBuildsAsync(
+        var builds = await _computeService.ComputeBuildsFromStatsAsync(
             championId, effectiveRole, tierForCompute, normalizedRegion, currentPatch, ct);
         await _cache.SetAsync(buildsKey, builds, AnalyticsCacheOptions, buildsTags, ct);
 

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
@@ -33,14 +33,24 @@ public class PrecomputedAnalyticsRefresher : IPrecomputedAnalyticsRefresher
 
     private const string RankedSoloQueueType = "RANKED_SOLO_5x5";
 
+    /// <summary>Minimum (champion, role) games on a patch before a build snapshot is computed (mirrors the build sample floor).</summary>
+    private const int MinBuildGames = 30;
+
+    /// <summary>The rank scopes precomputed for builds: the page default + all-ranks. Specific tiers fall back to raw.</summary>
+    private static readonly (string Scope, string? RankTier)[] BuildScopes =
+        [(RankTierCatalog.EmeraldPlusScope, RankTierCatalog.EmeraldPlusScope), (RankTierCatalog.AllScope, null)];
+
     private readonly TranscendenceContext _context;
+    private readonly IChampionAnalyticsComputeService _computeService;
     private readonly ILogger<PrecomputedAnalyticsRefresher> _logger;
 
     public PrecomputedAnalyticsRefresher(
         TranscendenceContext context,
+        IChampionAnalyticsComputeService computeService,
         ILogger<PrecomputedAnalyticsRefresher> logger)
     {
         _context = context;
+        _computeService = computeService;
         _logger = logger;
     }
 
@@ -189,6 +199,53 @@ public class PrecomputedAnalyticsRefresher : IPrecomputedAnalyticsRefresher
         await tx.CommitAsync(ct);
 
         _logger.LogInformation("Precompute refresh (matchups) patch {Patch}: {Rows} rows", patch, rows.Count);
+        return rows.Count;
+    }
+
+    // ---- ChampionBuildSnapshot: durable per-(champion, role, scope) build response (all-region) ----
+
+    public async Task<int> RefreshBuildsAsync(string patch, CancellationToken ct)
+    {
+        var computedAt = DateTime.UtcNow;
+
+        // Played (champion, role) pairs with enough games to produce a build (mirrors the build sample floor).
+        var pairs = await _context.ChampionRoleTierStats
+            .AsNoTracking()
+            .Where(x => x.Patch == patch)
+            .GroupBy(x => new { x.ChampionId, x.Role })
+            .Select(g => new { g.Key.ChampionId, g.Key.Role, Games = g.Sum(x => x.Games) })
+            .Where(x => x.Games >= MinBuildGames)
+            .ToListAsync(ct);
+
+        // Compute every (pair, scope) response first (reads), then replace the patch's rows transactionally.
+        var rows = new List<ChampionBuildSnapshot>(pairs.Count * BuildScopes.Length);
+        foreach (var pair in pairs)
+        {
+            foreach (var (scope, rankTier) in BuildScopes)
+            {
+                var response = await _computeService.ComputeBuildsAsync(
+                    pair.ChampionId, pair.Role, rankTier, region: null, patch, ct);
+
+                rows.Add(new ChampionBuildSnapshot
+                {
+                    Patch = patch,
+                    ChampionId = pair.ChampionId,
+                    Role = pair.Role,
+                    RankScope = scope,
+                    Payload = BuildSnapshotSerialization.Serialize(response),
+                    ComputedAtUtc = computedAt
+                });
+            }
+        }
+
+        await using var tx = await _context.Database.BeginTransactionAsync(ct);
+        await _context.ChampionBuildSnapshots.Where(x => x.Patch == patch).ExecuteDeleteAsync(ct);
+        _context.ChampionBuildSnapshots.AddRange(rows);
+        await _context.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        _logger.LogInformation("Precompute refresh (builds) patch {Patch}: {Rows} snapshots ({Pairs} champion-roles)",
+            patch, rows.Count, pairs.Count);
         return rows.Count;
     }
 

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
@@ -66,6 +66,19 @@ public interface IChampionAnalyticsComputeService
         string patch,
         CancellationToken ct);
 
+    /// <summary>
+    /// Builds served from the durable <c>ChampionBuildSnapshot</c> (the persisted live response for the
+    /// common all-region scopes), falling back to <see cref="ComputeBuildsAsync"/> for a specific tier/region
+    /// or a patch without a snapshot yet. The stored value is the live compute's own output, so it's identical.
+    /// </summary>
+    Task<ChampionBuildsResponse> ComputeBuildsFromStatsAsync(
+        int championId,
+        string role,
+        string? rankTier,
+        string? region,
+        string patch,
+        CancellationToken ct);
+
     Task<ChampionProBuildsResponse> ComputeProBuildsAsync(
         int championId,
         string? region,

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
@@ -21,6 +21,14 @@ public interface IPrecomputedAnalyticsRefresher
     /// champion at once — replacing the patch's rows transactionally. Returns the row count written.
     /// </summary>
     Task<int> RefreshMatchupsAsync(string patch, CancellationToken ct);
+
+    /// <summary>
+    /// Recomputes + persists the durable build responses (<c>ChampionBuildSnapshot</c>) for
+    /// <paramref name="patch"/>: the live <c>ComputeBuildsAsync</c> for each played (champion, role) at the
+    /// common rank scopes (all-region), serialized so cold reads are a lookup instead of a raw scan.
+    /// Returns the snapshot count written.
+    /// </summary>
+    Task<int> RefreshBuildsAsync(string patch, CancellationToken ct);
 }
 
 /// <summary>Row counts written per table, for logging/observability.</summary>

--- a/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
@@ -40,9 +40,10 @@ public class RefreshPrecomputedAnalyticsJob(
 
         var result = await refresher.RefreshTabularCoreAsync(patch, ct);
         var matchupRows = await refresher.RefreshMatchupsAsync(patch, ct);
+        var buildRows = await refresher.RefreshBuildsAsync(patch, ct);
 
         logger.LogInformation(
-            "Precompute refresh patch {Patch} completed in {ElapsedMs}ms: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban, {Matchup} matchup rows.",
-            patch, stopwatch.ElapsedMilliseconds, result.RoleTierRows, result.ScopeMatchCountRows, result.BanScopeRows, matchupRows);
+            "Precompute refresh patch {Patch} completed in {ElapsedMs}ms: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban, {Matchup} matchup, {Build} build rows.",
+            patch, stopwatch.ElapsedMilliseconds, result.RoleTierRows, result.ScopeMatchCountRows, result.BanScopeRows, matchupRows, buildRows);
     }
 }

--- a/Transcendence.Service/Migrations/20260625042547_AddChampionBuildSnapshot.Designer.cs
+++ b/Transcendence.Service/Migrations/20260625042547_AddChampionBuildSnapshot.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260625042547_AddChampionBuildSnapshot")]
+    partial class AddChampionBuildSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260625042547_AddChampionBuildSnapshot.cs
+++ b/Transcendence.Service/Migrations/20260625042547_AddChampionBuildSnapshot.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChampionBuildSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChampionBuildSnapshots",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Patch = table.Column<string>(type: "text", nullable: false),
+                    ChampionId = table.Column<int>(type: "integer", nullable: false),
+                    Role = table.Column<string>(type: "text", nullable: false),
+                    RankScope = table.Column<string>(type: "text", nullable: false),
+                    Payload = table.Column<string>(type: "text", nullable: false),
+                    ComputedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChampionBuildSnapshots", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionBuildSnapshots_Patch_ChampionId_Role_RankScope",
+                table: "ChampionBuildSnapshots",
+                columns: new[] { "Patch", "ChampionId", "Role", "RankScope" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChampionBuildSnapshots");
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
@@ -252,7 +252,7 @@ public class ChampionAnalyticsServiceTests
                 new ChampionWinRateDto(103, "TOP", "EMERALD_PLUS", 40, 18, 0.45, 0.05, 0.02, 12, 50, "15.1")
             ]);
         harness.ComputeService
-            .Setup(x => x.ComputeBuildsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
+            .Setup(x => x.ComputeBuildsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChampionBuildsResponse(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", [], []));
         harness.ComputeService
             .Setup(x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
@@ -284,7 +284,7 @@ public class ChampionAnalyticsServiceTests
             x => x.ComputeWinRatesFromStatsAsync(103, It.IsAny<ChampionAnalyticsFilter>(), "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ComputeService.Verify(
-            x => x.ComputeBuildsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
+            x => x.ComputeBuildsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ComputeService.Verify(
             x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsStatsEquivalenceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsStatsEquivalenceTests.cs
@@ -119,7 +119,7 @@ public class ChampionAnalyticsStatsEquivalenceTests
             NullLogger<ChampionAnalyticsComputeService>.Instance);
 
     private static async Task Refresh(TranscendenceContext db) =>
-        await new PrecomputedAnalyticsRefresher(db, NullLogger<PrecomputedAnalyticsRefresher>.Instance)
+        await new PrecomputedAnalyticsRefresher(db, Service(db), NullLogger<PrecomputedAnalyticsRefresher>.Instance)
             .RefreshTabularCoreAsync(Patch, CancellationToken.None);
 
     private static async Task<SeededContext> SeededAsync()

--- a/tests/Transcendence.Service.Core.Tests/ChampionBuildSnapshotTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionBuildSnapshotTests.cs
@@ -1,0 +1,186 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Data.Models.LoL.Static;
+using Transcendence.Service.Core.Services.Analytics.Implementations;
+using Transcendence.Service.Core.Services.Analytics.Models;
+using Transcendence.Service.Core.Tests.Support;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// Builds are precomputed as a durable response cache (the refresh persists the exact live
+/// <c>ComputeBuildsAsync</c> output), so the gate is: a read served from the snapshot equals the live
+/// compute (the serialize → store → deserialize round-trip is exact), and a specific tier/region falls back
+/// to raw. Identical builds are seeded so the (otherwise non-deterministic) representative pick is unambiguous.
+/// </summary>
+public class ChampionBuildSnapshotTests
+{
+    private const string Patch = "15.2";
+    private const int ChampionId = 100;
+    private const string Role = "MIDDLE";
+
+    [Fact]
+    public async Task BuildsFromStats_EqualLiveCompute_ForPrecomputedScopes_AndFallBackOtherwise()
+    {
+        await using var ctx = await SeededAsync();
+        var svc = Service(ctx.Db);
+        var refresher = new PrecomputedAnalyticsRefresher(ctx.Db, svc, NullLogger<PrecomputedAnalyticsRefresher>.Instance);
+
+        await refresher.RefreshTabularCoreAsync(Patch, CancellationToken.None);
+        var snapshots = await refresher.RefreshBuildsAsync(Patch, CancellationToken.None);
+
+        // One played (champion, role) x 2 precomputed scopes.
+        snapshots.Should().Be(2);
+
+        // ALL scope: participants are UNRANKED so this carries the real build — the rich round-trip case.
+        var rawAll = await svc.ComputeBuildsAsync(ChampionId, Role, null, null, Patch, CancellationToken.None);
+        var statsAll = await svc.ComputeBuildsFromStatsAsync(ChampionId, Role, null, null, Patch, CancellationToken.None);
+        statsAll.Should().BeEquivalentTo(rawAll, "the snapshot is the live compute's own serialized output");
+        statsAll.Builds.Should().NotBeEmpty("the ALL scope includes the unranked participants");
+
+        // EMERALD_PLUS scope: no emerald+ participants → empty, and still equal to the live compute.
+        var rawEm = await svc.ComputeBuildsAsync(ChampionId, Role, "EMERALD_PLUS", null, Patch, CancellationToken.None);
+        var statsEm = await svc.ComputeBuildsFromStatsAsync(ChampionId, Role, "EMERALD_PLUS", null, Patch, CancellationToken.None);
+        statsEm.Should().BeEquivalentTo(rawEm);
+
+        // A specific tier is not precomputed → falls back to the live compute.
+        var rawDia = await svc.ComputeBuildsAsync(ChampionId, Role, "DIAMOND", null, Patch, CancellationToken.None);
+        var statsDia = await svc.ComputeBuildsFromStatsAsync(ChampionId, Role, "DIAMOND", null, Patch, CancellationToken.None);
+        statsDia.Should().BeEquivalentTo(rawDia);
+
+        // A specific region is not precomputed → falls back to the live compute.
+        var rawNa = await svc.ComputeBuildsAsync(ChampionId, Role, null, "NA1", Patch, CancellationToken.None);
+        var statsNa = await svc.ComputeBuildsFromStatsAsync(ChampionId, Role, null, "NA1", Patch, CancellationToken.None);
+        statsNa.Should().BeEquivalentTo(rawNa);
+    }
+
+    [Fact]
+    public async Task BuildsFromStats_FallsBackToLiveCompute_WhenNoSnapshot()
+    {
+        await using var ctx = await SeededAsync();
+        var svc = Service(ctx.Db);
+        // No refresh run → no snapshots.
+        var raw = await svc.ComputeBuildsAsync(ChampionId, Role, null, null, Patch, CancellationToken.None);
+        var stats = await svc.ComputeBuildsFromStatsAsync(ChampionId, Role, null, null, Patch, CancellationToken.None);
+        stats.Should().BeEquivalentTo(raw);
+    }
+
+    private static ChampionAnalyticsComputeService Service(TranscendenceContext db) =>
+        new(db,
+            Options.Create(new ChampionAnalyticsComputeOptions
+            {
+                MinimumGamesRequired = 1,
+                EarlyPatchMinimumGamesRequired = 1,
+                BootstrapPatchMinimumGamesRequired = 1,
+                BootstrapWindowHours = 24,
+                ProvisionalWindowHours = 96,
+                MaturingWindowHours = 240
+            }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+
+    private static async Task<SeededContext> SeededAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<TranscendenceContext>().UseSqlite(connection).Options;
+        var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Patches.Add(new Patch { Version = Patch, ReleaseDate = DateTime.UtcNow.AddDays(-20), DetectedAt = DateTime.UtcNow.AddDays(-20), IsActive = true });
+        foreach (var itemId in new[] { 6672, 3031, 3072, 6694 })
+            db.ItemVersions.Add(new ItemVersion { ItemId = itemId, PatchVersion = Patch, Name = $"Item {itemId}", Tags = ["Damage"], BuildsFrom = [1038], BuildsInto = [], InStore = true, PriceTotal = 3000 });
+
+        var purchases = new (int ItemId, int TimestampMs, BuildItemCategory Category)[]
+        {
+            (1055, 5_000, BuildItemCategory.Starter),
+            (6672, 600_000, BuildItemCategory.Legendary),
+            (3006, 700_000, BuildItemCategory.Boots),
+            (3031, 900_000, BuildItemCategory.Legendary),
+            (3072, 1_200_000, BuildItemCategory.Legendary),
+            (6694, 1_500_000, BuildItemCategory.Legendary)
+        };
+
+        // 30 identical builds (= MinBuildGames), so the (champion, role) pair is precomputed and the
+        // dominant build is unambiguous (no ties → deterministic representative).
+        for (var i = 0; i < 30; i++)
+            SeedBuild(db, $"NA1_B{i}", win: i < 18, finalItems: [6672, 3031, 3072, 6694], purchases: purchases);
+
+        await db.SaveChangesAsync();
+        return new SeededContext(connection, db);
+    }
+
+    private static void SeedBuild(
+        TranscendenceContext db, string matchId, bool win, int[] finalItems,
+        (int ItemId, int TimestampMs, BuildItemCategory Category)[] purchases)
+    {
+        var summoner = new Summoner
+        {
+            Id = Guid.NewGuid(),
+            PlatformRegion = "NA1",
+            Region = "americas",
+            GameName = matchId,
+            TagLine = "NA1",
+            Puuid = Guid.NewGuid().ToString("N"),
+            SummonerName = matchId,
+            RiotSummonerId = Guid.NewGuid().ToString("N")
+        };
+        var match = new Transcendence.Data.Models.LoL.Match.Match
+        {
+            Id = Guid.NewGuid(),
+            MatchId = matchId,
+            MatchDate = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            Duration = 1800,
+            Patch = Patch,
+            QueueId = 420,
+            QueueFamily = "RANKED_SOLO_DUO",
+            QueueType = "420",
+            Status = FetchStatus.Success,
+            PlatformRegion = "NA1",
+            FetchedAt = DateTime.UtcNow
+        };
+        var participant = new MatchParticipant
+        {
+            Id = Guid.NewGuid(),
+            MatchId = match.Id,
+            Match = match,
+            SummonerId = summoner.Id,
+            Summoner = summoner,
+            Puuid = summoner.Puuid,
+            ParticipantId = 1,
+            TeamId = 100,
+            ChampionId = ChampionId,
+            TeamPosition = Role,
+            Win = win,
+            SummonerSpell1Id = 4,
+            SummonerSpell2Id = 12
+        };
+
+        db.Summoners.Add(summoner);
+        db.Matches.Add(match);
+        db.MatchParticipants.Add(participant);
+
+        for (var slot = 0; slot < finalItems.Length; slot++)
+            db.MatchParticipantItems.Add(new MatchParticipantItem { MatchParticipantId = participant.Id, SlotIndex = slot, ItemId = finalItems[slot], PatchVersion = Patch });
+
+        for (var index = 0; index < purchases.Length; index++)
+            db.MatchParticipantItemPurchases.Add(new MatchParticipantItemPurchase { MatchId = match.Id, Match = match, ParticipantId = 1, PurchaseIndex = index, ItemId = purchases[index].ItemId, TimestampMs = purchases[index].TimestampMs, Category = purchases[index].Category });
+
+        db.MatchParticipantSkillOrders.Add(new MatchParticipantSkillOrder { MatchId = match.Id, Match = match, ParticipantId = 1, Sequence = "QWE", FirstThree = "QWE", MaxOrder = "Q>E>W" });
+    }
+
+    private sealed class SeededContext(SqliteConnection connection, TranscendenceContext db) : IAsyncDisposable
+    {
+        public TranscendenceContext Db { get; } = db;
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/ChampionMatchupStatsEquivalenceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionMatchupStatsEquivalenceTests.cs
@@ -27,7 +27,7 @@ public class ChampionMatchupStatsEquivalenceTests
     public async Task Matchups_StatsPath_EqualsRawCompute_AcrossRankScopes()
     {
         await using var ctx = await SeededAsync();
-        await new PrecomputedAnalyticsRefresher(ctx.Db, NullLogger<PrecomputedAnalyticsRefresher>.Instance)
+        await new PrecomputedAnalyticsRefresher(ctx.Db, Service(ctx.Db), NullLogger<PrecomputedAnalyticsRefresher>.Instance)
             .RefreshMatchupsAsync(Patch, CancellationToken.None);
         var svc = Service(ctx.Db);
 
@@ -46,7 +46,7 @@ public class ChampionMatchupStatsEquivalenceTests
     public async Task Matchups_SpecificRegion_FallsBackToRawCompute()
     {
         await using var ctx = await SeededAsync();
-        await new PrecomputedAnalyticsRefresher(ctx.Db, NullLogger<PrecomputedAnalyticsRefresher>.Instance)
+        await new PrecomputedAnalyticsRefresher(ctx.Db, Service(ctx.Db), NullLogger<PrecomputedAnalyticsRefresher>.Instance)
             .RefreshMatchupsAsync(Patch, CancellationToken.None);
         var svc = Service(ctx.Db);
 

--- a/tests/Transcendence.Service.Core.Tests/PrecomputedAnalyticsRefresherTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/PrecomputedAnalyticsRefresherTests.cs
@@ -2,10 +2,12 @@ using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Transcendence.Data;
 using Transcendence.Data.Models.LoL.Account;
 using Transcendence.Data.Models.LoL.Match;
 using Transcendence.Service.Core.Services.Analytics.Implementations;
+using Transcendence.Service.Core.Services.Analytics.Models;
 using Transcendence.Service.Core.Tests.Support;
 
 namespace Transcendence.Service.Core.Tests;
@@ -137,7 +139,11 @@ public class PrecomputedAnalyticsRefresherTests
 
     private static async Task Refresh(TranscendenceContext db)
     {
-        var refresher = new PrecomputedAnalyticsRefresher(db, NullLogger<PrecomputedAnalyticsRefresher>.Instance);
+        var compute = new ChampionAnalyticsComputeService(
+            db,
+            Options.Create(new ChampionAnalyticsComputeOptions { MinimumGamesRequired = 1 }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+        var refresher = new PrecomputedAnalyticsRefresher(db, compute, NullLogger<PrecomputedAnalyticsRefresher>.Instance);
         await refresher.RefreshTabularCoreAsync(Patch, CancellationToken.None);
     }
 


### PR DESCRIPTION
**Step 3** of the precomputed-analytics layer. Builds are **document-shaped** (a nested, timing-ordered build path), so unlike the tabular win-rate/matchup data they are **not** decomposed into structured columns — the structured 6-table reconstruction is `eq=conditional` and would require several *documented non-determinism behavior changes* (you signed off on the durable-response approach instead). The refresh runs the **exact** live `ComputeBuildsAsync` and persists its serialized response, so a cold read is a point lookup + deserialize instead of a heavy raw scan, and **equivalence is trivial** (the stored value *is* the live compute's output — no behavior change).

### Design
- **`ChampionBuildSnapshot`** `(Patch, ChampionId, Role, RankScope) → Payload, ComputedAtUtc)`, all-region, for the common scopes **`EMERALD_PLUS`** (page default) + **`ALL`**. `BuildSnapshotSerialization` is the single round-trip source of truth.
- **`RefreshBuildsAsync`**: for each played `(champion, role)` with ≥30 games (from `ChampionRoleTierStat`), compute both scopes and replace the patch's rows transactionally. Wired into the refresh job after tabular + matchups, on the isolated `analytics-warm` lane.
- **`ComputeBuildsFromStatsAsync`**: point-lookup the snapshot for the common all-region scopes; a specific tier/region or a missing snapshot **falls back to the live compute**. The read endpoint + the default-profile warm path both serve from it.

### Correctness
A read served from the snapshot equals the live compute (the serialize → store → deserialize round-trip is exact) — tested for the rich `ALL` scope and the empty `EMERALD_PLUS` scope, plus the specific-tier/region + no-snapshot fallbacks. **180 Service.Core + 40 WebAPI green; no drift.** New empty table → plain migration.

### After merge
Apply the migration to prod and **watch the first build refresh** — it runs ~500-700 serial `ComputeBuildsAsync` (one per played champion-role × 2 scopes), the heaviest part of the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)