### PR TITLE
feat(analytics): "Updated N min ago" freshness signal (Step 4)

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
@@ -327,6 +327,14 @@ public partial class ChampionAnalyticsComputeService
         return await ComputeBuildsAsync(championId, role, rankTier, region, patch, ct);
     }
 
+    public Task<DateTime?> GetAnalyticsComputedAtAsync(string patch, CancellationToken ct) =>
+        _context.ChampionRoleTierStats
+            .AsNoTracking()
+            .Where(x => x.Patch == patch)
+            .OrderByDescending(x => x.ComputedAtUtc)
+            .Select(x => (DateTime?)x.ComputedAtUtc)
+            .FirstOrDefaultAsync(ct);
+
     // ---- shared helpers for the stats path ----
 
     private Task<bool> HasStatsAsync(string patch, CancellationToken ct) =>

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -64,6 +64,19 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         _multiRegionOptions = multiRegionOptions.Value;
     }
 
+    /// <summary>
+    /// When the precomputed analytics for <paramref name="patch"/> were last refreshed (the "updated N ago"
+    /// signal), cached briefly per patch since it only advances on the hourly refresh. Null while a patch is
+    /// still served by live compute (no aggregates yet).
+    /// </summary>
+    private async Task<DateTime?> ResolveAnalyticsFreshnessAsync(string patch, CancellationToken ct) =>
+        await _cache.GetOrCreateAsync(
+            $"analytics:freshness:v1:{patch}",
+            async cancel => await _computeService.GetAnalyticsComputedAtAsync(patch, cancel),
+            ActivePatchCacheOptions,
+            tags: new[] { AnalyticsCacheTag, CacheTags.ForPatch(patch) },
+            cancellationToken: ct);
+
     public async Task<ChampionWinRateSummary> GetWinRatesAsync(
         int championId,
         ChampionAnalyticsFilter filter,
@@ -108,7 +121,8 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             ChampionId: championId,
             Patch: currentPatch,
             ByRoleTier: winRates,
-            Sample: BuildSampleMetadata(sampleSize, patchContext)
+            Sample: BuildSampleMetadata(sampleSize, patchContext),
+            ComputedAtUtc: await ResolveAnalyticsFreshnessAsync(currentPatch, ct)
         );
     }
 
@@ -165,7 +179,8 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             RankTier: normalizedTier,
             Region: normalizedRegion,
             Entries: entries,
-            Sample: BuildSampleMetadata(sampleSize, patchContext)
+            Sample: BuildSampleMetadata(sampleSize, patchContext),
+            ComputedAtUtc: await ResolveAnalyticsFreshnessAsync(currentPatch, ct)
         );
     }
 

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
@@ -30,6 +30,13 @@ public interface IChampionAnalyticsComputeService
         CancellationToken ct);
 
     /// <summary>
+    /// When the precomputed analytics aggregates for <paramref name="patch"/> were last rebuilt (all rows of
+    /// a refresh share one timestamp), or null if the patch has no aggregates yet. Surfaced as the
+    /// "updated N ago" freshness signal.
+    /// </summary>
+    Task<DateTime?> GetAnalyticsComputedAtAsync(string patch, CancellationToken ct);
+
+    /// <summary>
     /// Win rates served from the precomputed <c>ChampionRoleTierStat</c>/ban aggregate tables (a fast
     /// indexed scope roll-up instead of a raw-match scan), falling back to <see cref="ComputeWinRatesAsync"/>
     /// when no aggregates exist for the patch yet. Produces DTOs identical to the raw path.

--- a/Transcendence.Service.Core/Services/Analytics/Models/ChampionWinRateDto.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/ChampionWinRateDto.cs
@@ -24,5 +24,7 @@ public record ChampionWinRateSummary(
     int ChampionId,
     string Patch,
     List<ChampionWinRateDto> ByRoleTier,
-    AnalyticsSampleMetadata? Sample = null
+    AnalyticsSampleMetadata? Sample = null,
+    // When the precomputed analytics for this patch were last refreshed (null while serving live compute).
+    DateTime? ComputedAtUtc = null
 );

--- a/Transcendence.Service.Core/Services/Analytics/Models/TierListDto.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/TierListDto.cs
@@ -53,5 +53,7 @@ public record TierListResponse(
     string? RankTier,         // "all" for all ranks, or scope token (e.g., "EMERALD_PLUS")
     string Region,
     List<TierListEntry> Entries,
-    AnalyticsSampleMetadata? Sample = null
+    AnalyticsSampleMetadata? Sample = null,
+    // When the precomputed analytics for this patch were last refreshed (null while serving live compute).
+    DateTime? ComputedAtUtc = null
 );

--- a/apps/web/app/lol/champions/[championId]/page.tsx
+++ b/apps/web/app/lol/champions/[championId]/page.tsx
@@ -12,6 +12,7 @@ import { ItemBuildDisplay } from "@/components/ItemBuildDisplay";
 import { RuneTreeDisplay } from "@/components/RuneTreeDisplay";
 import { StatsBar } from "@/components/StatsBar";
 import { TierBadge } from "@/components/TierBadge";
+import { UpdatedAgo } from "@/components/UpdatedAgo";
 import { WinRateText } from "@/components/WinRateText";
 import { Card } from "@/components/ui/Card";
 import { DataBar } from "@/components/ui/DataBar";
@@ -35,7 +36,11 @@ import {
 import { deriveTier } from "@/lib/tierlist";
 
 type ChampionWinRateDto = components["schemas"]["ChampionWinRateDto"];
-type ChampionWinRateSummary = components["schemas"]["ChampionWinRateSummary"];
+// `computedAtUtc` is the ISO-8601 UTC timestamp (or null) of when the precomputed
+// analytics for the patch were last refreshed; powers the "Updated N min ago" label.
+type ChampionWinRateSummary = components["schemas"]["ChampionWinRateSummary"] & {
+  computedAtUtc?: string | null;
+};
 type ChampionProfileAnalyticsResponse = components["schemas"]["ChampionProfileAnalyticsResponse"];
 type MatchupEntryDto = components["schemas"]["MatchupEntryDto"];
 
@@ -257,6 +262,12 @@ async function ChampionHeroMeta({
         <p className="text-sm text-muted">
           {roleDisplayLabel(effectiveRole)} &middot; {rankTierDisplayLabel(normalizedRankTier ?? "all")} &middot; {activeRegionLabel}
         </p>
+        {(winrates as ChampionWinRateSummary | null)?.computedAtUtc ? (
+          <UpdatedAgo
+            className="text-xs"
+            timestamp={(winrates as ChampionWinRateSummary | null)?.computedAtUtc}
+          />
+        ) : null}
       </div>
       <div className="-mt-2 flex flex-wrap items-center gap-2 text-xs">
         <Link

--- a/apps/web/app/lol/tierlist/page.tsx
+++ b/apps/web/app/lol/tierlist/page.tsx
@@ -1,5 +1,3 @@
-import type { components } from "@transcendence/api-client";
-
 import { BackendErrorCard } from "@/components/BackendErrorCard";
 import { AnalyticsSampleBanner } from "@/components/AnalyticsSampleBanner";
 import { TierListFilterBar } from "@/components/TierListFilterBar";
@@ -24,9 +22,10 @@ import {
 } from "@/lib/ranks";
 import { roleDisplayLabel } from "@/lib/roles";
 import { fetchChampionMap } from "@/lib/staticData";
-import { normalizeTierListEntries } from "@/lib/tierlist";
+import { normalizeTierListEntries, type TierListResponseLike } from "@/lib/tierlist";
+import { UpdatedAgo } from "@/components/UpdatedAgo";
 
-type TierListResponse = components["schemas"]["TierListResponse"];
+type TierListResponse = TierListResponseLike;
 
 export default async function TierListPage({
   searchParams
@@ -133,6 +132,12 @@ export default async function TierListPage({
             <span>{rankTierDisplayLabel(rankTierValue ?? "all")}</span>
             <span aria-hidden="true">·</span>
             <span className="type-tabular tabular-nums">{normalizedEntries.length} champions</span>
+            {tierlist.computedAtUtc ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <UpdatedAgo timestamp={tierlist.computedAtUtc} />
+              </>
+            ) : null}
           </>
         }
         filters={

--- a/apps/web/components/UpdatedAgo.tsx
+++ b/apps/web/components/UpdatedAgo.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/cn";
+
+// Subtle "Updated 23 min ago" freshness label for precomputed analytics.
+// Client component so it can compute relative time from the viewer's clock.
+// Renders nothing when the timestamp is missing — informational metadata only,
+// so it stays grayscale/muted (no gold, no badge, no border).
+
+function formatRelative(fromMs: number, nowMs: number): string {
+  const diffMs = Math.max(0, nowMs - fromMs);
+  const minutes = Math.floor(diffMs / 60_000);
+
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes} min ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days} ${days === 1 ? "day" : "days"} ago`;
+}
+
+export function UpdatedAgo({
+  timestamp,
+  className
+}: {
+  timestamp?: string | null;
+  className?: string;
+}) {
+  const fromMs = React.useMemo(() => {
+    if (!timestamp) return null;
+    const parsed = Date.parse(timestamp);
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [timestamp]);
+
+  // Recompute on mount (and tick once a minute) so the label stays fresh without
+  // a server round-trip. Starts null so SSR and first client paint agree.
+  const [nowMs, setNowMs] = React.useState<number | null>(null);
+  React.useEffect(() => {
+    if (fromMs == null) return;
+    setNowMs(Date.now());
+    const id = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, [fromMs]);
+
+  if (fromMs == null || nowMs == null) return null;
+
+  return (
+    <span className={cn("text-muted", className)}>Updated {formatRelative(fromMs, nowMs)}</span>
+  );
+}

--- a/apps/web/lib/tierlist.ts
+++ b/apps/web/lib/tierlist.ts
@@ -27,6 +27,13 @@ export type TierListSummary = {
 
 type ApiTierListEntry = components["schemas"]["TierListEntry"];
 
+// Mirrors the tier-list response with the fields we read off it. `computedAtUtc`
+// is the ISO-8601 UTC timestamp (or null) of when the precomputed analytics for
+// the patch were last refreshed; it powers the "Updated N min ago" indicator.
+export type TierListResponseLike = components["schemas"]["TierListResponse"] & {
+  computedAtUtc?: string | null;
+};
+
 export const TIER_ORDER: UITierGrade[] = ["S", "A", "B", "C", "D"];
 
 export function decodeTierGrade(

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -6918,6 +6918,11 @@
           },
           "sample": {
             "$ref": "#/components/schemas/AnalyticsSampleMetadata"
+          },
+          "computedAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -9076,6 +9081,11 @@
           },
           "sample": {
             "$ref": "#/components/schemas/AnalyticsSampleMetadata"
+          },
+          "computedAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         },
         "additionalProperties": false

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4952,6 +4952,8 @@ export interface components {
             patch?: string | null;
             byRoleTier?: components["schemas"]["ChampionWinRateDto"][] | null;
             sample?: components["schemas"]["AnalyticsSampleMetadata"];
+            /** Format: date-time */
+            computedAtUtc?: string | null;
         };
         CommonProBuildDto: {
             items?: number[] | null;
@@ -5708,6 +5710,8 @@ export interface components {
             region?: string | null;
             entries?: components["schemas"]["TierListEntry"][] | null;
             sample?: components["schemas"]["AnalyticsSampleMetadata"];
+            /** Format: date-time */
+            computedAtUtc?: string | null;
         };
         /**
          * Format: int32

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsStatsEquivalenceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsStatsEquivalenceTests.cs
@@ -103,6 +103,21 @@ public class ChampionAnalyticsStatsEquivalenceTests
         statsTl.Should().BeEquivalentTo(rawTl, o => o.WithStrictOrdering());
     }
 
+    [Fact]
+    public async Task GetAnalyticsComputedAt_ReturnsRefreshTimestamp_OrNullWhenNoAggregates()
+    {
+        await using var ctx = await SeededAsync();
+        var before = DateTime.UtcNow;
+        await Refresh(ctx.Db);
+        var svc = Service(ctx.Db);
+
+        var computedAt = await svc.GetAnalyticsComputedAtAsync(Patch, CancellationToken.None);
+        computedAt.Should().NotBeNull();
+        computedAt!.Value.Should().BeOnOrAfter(before.AddSeconds(-5));
+
+        (await svc.GetAnalyticsComputedAtAsync("99.9", CancellationToken.None)).Should().BeNull();
+    }
+
     // ---- harness ----
 
     private static ChampionAnalyticsComputeService Service(TranscendenceContext db) =>


### PR DESCRIPTION
**Step 4 (final)** of the precomputed-analytics layer — surfaces *when* the precomputed data was last refreshed, completing the UX (u.gg/op.gg-style "updated N ago").

### Backend
- `ComputedAtUtc` on `ChampionWinRateSummary` + `TierListResponse`, resolved by a cached per-patch `GetAnalyticsComputedAtAsync` (= max `ComputedAtUtc` over the patch's `ChampionRoleTierStat` rows — all rows of a refresh share one timestamp). **Null** while a patch is still served by live compute (no aggregates yet).
- Regenerated `openapi/transcendence.v1.json` + the `@transcendence/api-client` schema, so `api:check` passes.

### Frontend (`apps/web`)
- New **`UpdatedAgo`** client component: a subtle "Updated 23 min ago" relative-time label — dependency-free (plain `Date` math), SSR-safe (renders nothing until mount), ticks once a minute, renders nothing when the timestamp is absent. **Muted/grayscale** per the Ladder design (gold is reserved for actions; this is informational metadata).
- Rendered in the **tier-list** Toolbar meta slot + the **champion page header**.

### Correctness
`GetAnalyticsComputedAtAsync` returns the refresh timestamp (and null for an un-refreshed patch) — tested. Service.Core + WebAPI suites green; web `tsc --noEmit` + lint clean. **No schema change** — pure read/UX, safe to deploy.

Completes the layer: win-rates + tier list + matchups + builds all serve from precompute, refreshed hourly on the isolated lane, with a freshness indicator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)