### PR TITLE
feat(analytics): precompute pro-builds + pro-playrate (durable response cache)

### DIFF
--- a/Transcendence.Data/Models/LoL/Analytics/AnalyticsResponseSnapshot.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/AnalyticsResponseSnapshot.cs
@@ -1,0 +1,35 @@
+namespace Transcendence.Data.Models.LoL.Analytics;
+
+/// <summary>
+/// A durable, precomputed analytics RESPONSE for one <c>(Feature, ScopeKey, Patch)</c> — the same
+/// response-cache approach as <see cref="ChampionBuildSnapshot"/>, generalized for the response-shaped
+/// surfaces that don't decompose into structured columns. The refresh job runs the exact live compute and
+/// persists its serialized response here, so a cold read becomes a point lookup + deserialize instead of a
+/// raw scan; equivalence is trivial (the stored value is the live compute's own output).
+/// <para>
+/// Used for the roster-filtered pro surfaces (where the scope is a read-time intersection, so a structured
+/// decomposition isn't equivalence-preserving):
+/// <list type="bullet">
+/// <item><c>Feature="proplayrate"</c>, <c>ScopeKey</c> = the roster scope token ("all"/"pro"/"highelo").</item>
+/// <item><c>Feature="probuilds"</c>, <c>ScopeKey</c> = <c>"{championId}:{role}:{scope}"</c>.</item>
+/// </list>
+/// All at the all-region scope; a specific region (or a role/scope not precomputed) falls back to live compute.
+/// </para>
+/// </summary>
+public class AnalyticsResponseSnapshot
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Surface discriminator: "probuilds" | "proplayrate".</summary>
+    public string Feature { get; set; } = "";
+
+    /// <summary>Feature-specific scope key (see the class summary).</summary>
+    public string ScopeKey { get; set; } = "";
+
+    public string Patch { get; set; } = "";
+
+    /// <summary>The serialized response DTO (JSON), returned to callers verbatim.</summary>
+    public string Payload { get; set; } = "";
+
+    public DateTime ComputedAtUtc { get; set; }
+}

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -37,6 +37,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<ChampionBanScopeStat> ChampionBanScopeStats { get; set; }
     public DbSet<ChampionMatchupStat> ChampionMatchupStats { get; set; }
     public DbSet<ChampionBuildSnapshot> ChampionBuildSnapshots { get; set; }
+    public DbSet<AnalyticsResponseSnapshot> AnalyticsResponseSnapshots { get; set; }
 
     // Versioned static data
     public DbSet<Patch> Patches { get; set; }
@@ -664,6 +665,13 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             entity.HasKey(x => x.Id);
             // Doubles as the UPSERT target and the read point-lookup.
             entity.HasIndex(x => new { x.Patch, x.ChampionId, x.Role, x.RankScope }).IsUnique();
+        });
+
+        modelBuilder.Entity<AnalyticsResponseSnapshot>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            // Doubles as the UPSERT target and the read point-lookup.
+            entity.HasIndex(x => new { x.Feature, x.ScopeKey, x.Patch }).IsUnique();
         });
     }
 }

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/AnalyticsSnapshotSerialization.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/AnalyticsSnapshotSerialization.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+
+namespace Transcendence.Service.Core.Services.Analytics.Implementations;
+
+/// <summary>
+/// Single source of truth for serializing/deserializing a response DTO to/from an
+/// <c>AnalyticsResponseSnapshot.Payload</c>. The refresh (serialize) and the read (deserialize) MUST use the
+/// same options so the round-trip is exact.
+/// </summary>
+internal static class AnalyticsSnapshotSerialization
+{
+    /// <summary><c>AnalyticsResponseSnapshot.Feature</c> values.</summary>
+    public const string ProBuildsFeature = "probuilds";
+    public const string ProPlayrateFeature = "proplayrate";
+
+    /// <summary>Roster scopes precomputed for the pro surfaces (the <c>NormalizeProScope</c> tokens).</summary>
+    public static readonly string[] ProScopes = ["all", "pro", "highelo"];
+
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web);
+
+    public static string Serialize<T>(T response) => JsonSerializer.Serialize(response, Options);
+
+    public static T? Deserialize<T>(string payload) => JsonSerializer.Deserialize<T>(payload, Options);
+}

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsComputeService.Stats.cs
@@ -335,6 +335,65 @@ public partial class ChampionAnalyticsComputeService
             .Select(x => (DateTime?)x.ComputedAtUtc)
             .FirstOrDefaultAsync(ct);
 
+    public async Task<ChampionProBuildsResponse> ComputeProBuildsFromStatsAsync(
+        int championId,
+        string? region,
+        string? role,
+        string scope,
+        string patch,
+        CancellationToken ct)
+    {
+        var normalizedRegion = string.IsNullOrWhiteSpace(region) ? "ALL" : region.Trim().ToUpperInvariant();
+        var normalizedRole = string.IsNullOrWhiteSpace(role) ? "ALL" : role.Trim().ToUpperInvariant();
+        var normalizedScope = NormalizeProScope(scope);
+
+        // Precomputed only at the all-region scope for a specific role; everything else falls back to live.
+        if (normalizedRegion == "ALL" && normalizedRole != "ALL")
+        {
+            var key = $"{championId}:{normalizedRole}:{normalizedScope}";
+            var payload = await _context.AnalyticsResponseSnapshots.AsNoTracking()
+                .Where(x => x.Feature == AnalyticsSnapshotSerialization.ProBuildsFeature && x.ScopeKey == key && x.Patch == patch)
+                .Select(x => x.Payload)
+                .FirstOrDefaultAsync(ct);
+
+            if (payload != null)
+            {
+                var cached = AnalyticsSnapshotSerialization.Deserialize<ChampionProBuildsResponse>(payload);
+                if (cached != null)
+                    return cached;
+            }
+        }
+
+        return await ComputeProBuildsAsync(championId, region, role, scope, patch, ct);
+    }
+
+    public async Task<ProChampionPlayrateResponse> ComputeProChampionPlayrateFromStatsAsync(
+        string? region,
+        string scope,
+        string patch,
+        CancellationToken ct)
+    {
+        var normalizedRegion = string.IsNullOrWhiteSpace(region) ? "ALL" : region.Trim().ToUpperInvariant();
+        var normalizedScope = NormalizeProScope(scope);
+
+        if (normalizedRegion == "ALL")
+        {
+            var payload = await _context.AnalyticsResponseSnapshots.AsNoTracking()
+                .Where(x => x.Feature == AnalyticsSnapshotSerialization.ProPlayrateFeature && x.ScopeKey == normalizedScope && x.Patch == patch)
+                .Select(x => x.Payload)
+                .FirstOrDefaultAsync(ct);
+
+            if (payload != null)
+            {
+                var cached = AnalyticsSnapshotSerialization.Deserialize<ProChampionPlayrateResponse>(payload);
+                if (cached != null)
+                    return cached;
+            }
+        }
+
+        return await ComputeProChampionPlayrateAsync(region, scope, patch, ct);
+    }
+
     // ---- shared helpers for the stats path ----
 
     private Task<bool> HasStatsAsync(string patch, CancellationToken ct) =>

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -260,7 +260,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
         var response = await _cache.GetOrCreateAsync(
             cacheKey,
-            async cancel => await _computeService.ComputeProBuildsAsync(
+            async cancel => await _computeService.ComputeProBuildsFromStatsAsync(
                 championId,
                 normalizedRegion,
                 normalizedRole,
@@ -300,7 +300,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
         var response = await _cache.GetOrCreateAsync(
             cacheKey,
-            async cancel => await _computeService.ComputeProChampionPlayrateAsync(
+            async cancel => await _computeService.ComputeProChampionPlayrateFromStatsAsync(
                 normalizedRegion,
                 normalizedScope,
                 resolvedPatch,
@@ -466,7 +466,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             const string proRegion = "ALL";
             var proKey = $"{ProBuildsCacheKeyPrefix}{championId}:{proRegion}:{effectiveRole}:{proScope}:{currentPatch}";
             var proTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "probuilds" };
-            var proBuilds = await _computeService.ComputeProBuildsAsync(
+            var proBuilds = await _computeService.ComputeProBuildsFromStatsAsync(
                 championId, proRegion, effectiveRole, proScope, currentPatch, ct);
             await _cache.SetAsync(proKey, proBuilds, AnalyticsCacheOptions, proTags, ct);
         }

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
@@ -249,6 +249,74 @@ public class PrecomputedAnalyticsRefresher : IPrecomputedAnalyticsRefresher
         return rows.Count;
     }
 
+    // ---- AnalyticsResponseSnapshot: durable pro-builds + pro-playrate responses (all-region) ----
+
+    public async Task<int> RefreshProSurfacesAsync(string patch, CancellationToken ct)
+    {
+        var computedAt = DateTime.UtcNow;
+        var rows = new List<AnalyticsResponseSnapshot>();
+
+        // Pro-playrate: one response per roster scope, all-region.
+        foreach (var scope in AnalyticsSnapshotSerialization.ProScopes)
+        {
+            var response = await _computeService.ComputeProChampionPlayrateAsync(region: null, scope, patch, ct);
+            rows.Add(new AnalyticsResponseSnapshot
+            {
+                Feature = AnalyticsSnapshotSerialization.ProPlayrateFeature,
+                ScopeKey = scope,
+                Patch = patch,
+                Payload = AnalyticsSnapshotSerialization.Serialize(response),
+                ComputedAtUtc = computedAt
+            });
+        }
+
+        // Pro-builds: per pro-played (champion, role) x roster scope, all-region. Enumerate the (champion,
+        // role) pairs the active roster (pro OR high-elo) actually plays — much smaller than the general
+        // population — and precompute each scope's response (pro/highelo subsets may be empty; that's fine).
+        var rosterPuuids = await _context.TrackedProSummoners
+            .AsNoTracking()
+            .Where(x => x.IsActive && (x.IsPro || x.IsHighEloOtp))
+            .Select(x => x.Puuid)
+            .Where(p => p != null && p != "")
+            .Distinct()
+            .ToListAsync(ct);
+
+        var pairs = rosterPuuids.Count == 0
+            ? []
+            : await BaseParticipants(patch)
+                .Where(mp => mp.Puuid != null && rosterPuuids.Contains(mp.Puuid))
+                .Select(mp => new { mp.ChampionId, Role = mp.TeamPosition! })
+                .Distinct()
+                .ToListAsync(ct);
+
+        foreach (var pair in pairs)
+        {
+            foreach (var scope in AnalyticsSnapshotSerialization.ProScopes)
+            {
+                var response = await _computeService.ComputeProBuildsAsync(
+                    pair.ChampionId, region: null, pair.Role, scope, patch, ct);
+                rows.Add(new AnalyticsResponseSnapshot
+                {
+                    Feature = AnalyticsSnapshotSerialization.ProBuildsFeature,
+                    ScopeKey = $"{pair.ChampionId}:{pair.Role}:{scope}",
+                    Patch = patch,
+                    Payload = AnalyticsSnapshotSerialization.Serialize(response),
+                    ComputedAtUtc = computedAt
+                });
+            }
+        }
+
+        await using var tx = await _context.Database.BeginTransactionAsync(ct);
+        await _context.AnalyticsResponseSnapshots.Where(x => x.Patch == patch).ExecuteDeleteAsync(ct);
+        _context.AnalyticsResponseSnapshots.AddRange(rows);
+        await _context.SaveChangesAsync(ct);
+        await tx.CommitAsync(ct);
+
+        _logger.LogInformation("Precompute refresh (pro surfaces) patch {Patch}: {Rows} snapshots ({Pairs} pro champion-roles)",
+            patch, rows.Count, pairs.Count);
+        return rows.Count;
+    }
+
     // ---- ChampionRoleTierStat: per (region, current-tier, champion, role) Games/Wins (additive) ----
 
     private async Task<List<ChampionRoleTierStat>> BuildRoleTierStatsAsync(

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsComputeService.cs
@@ -105,6 +105,29 @@ public interface IChampionAnalyticsComputeService
         CancellationToken ct);
 
     /// <summary>
+    /// Pro builds served from the durable <c>AnalyticsResponseSnapshot</c> (the persisted live response),
+    /// falling back to <see cref="ComputeProBuildsAsync"/> for a specific region, an all-roles request, or a
+    /// patch without a snapshot. The stored value is the live compute's own output, so it's identical.
+    /// </summary>
+    Task<ChampionProBuildsResponse> ComputeProBuildsFromStatsAsync(
+        int championId,
+        string? region,
+        string? role,
+        string scope,
+        string patch,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Pro champion playrate served from the durable snapshot, falling back to
+    /// <see cref="ComputeProChampionPlayrateAsync"/> for a specific region or a patch without a snapshot.
+    /// </summary>
+    Task<ProChampionPlayrateResponse> ComputeProChampionPlayrateFromStatsAsync(
+        string? region,
+        string scope,
+        string patch,
+        CancellationToken ct);
+
+    /// <summary>
     /// Returns the public roster of tracked pro players (IsActive &amp;&amp; IsPro).
     /// </summary>
     Task<List<ProPlayerDto>> ComputeProRosterAsync(

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IPrecomputedAnalyticsRefresher.cs
@@ -29,6 +29,13 @@ public interface IPrecomputedAnalyticsRefresher
     /// Returns the snapshot count written.
     /// </summary>
     Task<int> RefreshBuildsAsync(string patch, CancellationToken ct);
+
+    /// <summary>
+    /// Recomputes + persists the durable pro-surface responses (<c>AnalyticsResponseSnapshot</c>) for
+    /// <paramref name="patch"/>: pro-playrate per roster scope, and pro-builds for each pro-played
+    /// (champion, role) x roster scope, all-region. Returns the snapshot count written.
+    /// </summary>
+    Task<int> RefreshProSurfacesAsync(string patch, CancellationToken ct);
 }
 
 /// <summary>Row counts written per table, for logging/observability.</summary>

--- a/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
@@ -41,9 +41,10 @@ public class RefreshPrecomputedAnalyticsJob(
         var result = await refresher.RefreshTabularCoreAsync(patch, ct);
         var matchupRows = await refresher.RefreshMatchupsAsync(patch, ct);
         var buildRows = await refresher.RefreshBuildsAsync(patch, ct);
+        var proRows = await refresher.RefreshProSurfacesAsync(patch, ct);
 
         logger.LogInformation(
-            "Precompute refresh patch {Patch} completed in {ElapsedMs}ms: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban, {Matchup} matchup, {Build} build rows.",
-            patch, stopwatch.ElapsedMilliseconds, result.RoleTierRows, result.ScopeMatchCountRows, result.BanScopeRows, matchupRows, buildRows);
+            "Precompute refresh patch {Patch} completed in {ElapsedMs}ms: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban, {Matchup} matchup, {Build} build, {Pro} pro rows.",
+            patch, stopwatch.ElapsedMilliseconds, result.RoleTierRows, result.ScopeMatchCountRows, result.BanScopeRows, matchupRows, buildRows, proRows);
     }
 }

--- a/Transcendence.Service/Migrations/20260626031931_AddAnalyticsResponseSnapshot.Designer.cs
+++ b/Transcendence.Service/Migrations/20260626031931_AddAnalyticsResponseSnapshot.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260626031931_AddAnalyticsResponseSnapshot")]
+    partial class AddAnalyticsResponseSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260626031931_AddAnalyticsResponseSnapshot.cs
+++ b/Transcendence.Service/Migrations/20260626031931_AddAnalyticsResponseSnapshot.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAnalyticsResponseSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AnalyticsResponseSnapshots",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Feature = table.Column<string>(type: "text", nullable: false),
+                    ScopeKey = table.Column<string>(type: "text", nullable: false),
+                    Patch = table.Column<string>(type: "text", nullable: false),
+                    Payload = table.Column<string>(type: "text", nullable: false),
+                    ComputedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnalyticsResponseSnapshots", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnalyticsResponseSnapshots_Feature_ScopeKey_Patch",
+                table: "AnalyticsResponseSnapshots",
+                columns: new[] { "Feature", "ScopeKey", "Patch" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AnalyticsResponseSnapshots");
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
@@ -265,7 +265,7 @@ public class ChampionAnalyticsServiceTests
                 Patch = "15.1"
             });
         harness.ComputeService
-            .Setup(x => x.ComputeProBuildsAsync(103, "ALL", "MIDDLE", "all", "15.1", It.IsAny<CancellationToken>()))
+            .Setup(x => x.ComputeProBuildsFromStatsAsync(103, "ALL", "MIDDLE", "all", "15.1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChampionProBuildsResponse(103, "15.1", "MIDDLE", "ALL", "all", [], [], []));
         await harness.Db.SaveChangesAsync();
 
@@ -290,7 +290,7 @@ public class ChampionAnalyticsServiceTests
             x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ComputeService.Verify(
-            x => x.ComputeProBuildsAsync(103, "ALL", "MIDDLE", "all", "15.1", It.IsAny<CancellationToken>()),
+            x => x.ComputeProBuildsFromStatsAsync(103, "ALL", "MIDDLE", "all", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/tests/Transcendence.Service.Core.Tests/ProSurfaceSnapshotTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ProSurfaceSnapshotTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Data.Models.LoL.Static;
+using Transcendence.Service.Core.Services.Analytics.Implementations;
+using Transcendence.Service.Core.Services.Analytics.Models;
+using Transcendence.Service.Core.Tests.Support;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// Pro-builds + pro-playrate are precomputed as a durable response cache (the refresh persists the exact
+/// live compute output), so the gate is: a read served from the snapshot equals the live compute (the
+/// serialize → store → deserialize round-trip is exact), and a specific region falls back to raw.
+/// </summary>
+public class ProSurfaceSnapshotTests
+{
+    private const string Patch = "15.2";
+
+    [Fact]
+    public async Task ProSurfacesFromStats_EqualLiveCompute_AndFallBackForSpecificRegion()
+    {
+        await using var ctx = await SeededAsync();
+        var svc = Service(ctx.Db);
+        var refresher = new PrecomputedAnalyticsRefresher(ctx.Db, svc, NullLogger<PrecomputedAnalyticsRefresher>.Instance);
+
+        var snapshots = await refresher.RefreshProSurfacesAsync(Patch, CancellationToken.None);
+        // pro-playrate (3 scopes) + pro-builds for (266, TOP) x 3 scopes.
+        snapshots.Should().Be(6);
+
+        // pro-playrate: snapshot read == live compute, for each scope.
+        foreach (var scope in new[] { "all", "pro", "highelo" })
+        {
+            var raw = await svc.ComputeProChampionPlayrateAsync(null, scope, Patch, CancellationToken.None);
+            var stats = await svc.ComputeProChampionPlayrateFromStatsAsync(null, scope, Patch, CancellationToken.None);
+            stats.Should().BeEquivalentTo(raw, $"pro-playrate scope={scope}");
+        }
+
+        // pro-builds: snapshot read == live compute, for each scope.
+        foreach (var scope in new[] { "all", "pro", "highelo" })
+        {
+            var raw = await svc.ComputeProBuildsAsync(266, null, "TOP", scope, Patch, CancellationToken.None);
+            var stats = await svc.ComputeProBuildsFromStatsAsync(266, null, "TOP", scope, Patch, CancellationToken.None);
+            stats.Should().BeEquivalentTo(raw, $"pro-builds scope={scope}");
+        }
+
+        // A specific region is not precomputed → falls back to live compute.
+        var rawNa = await svc.ComputeProBuildsAsync(266, "NA1", "TOP", "all", Patch, CancellationToken.None);
+        var statsNa = await svc.ComputeProBuildsFromStatsAsync(266, "NA1", "TOP", "all", Patch, CancellationToken.None);
+        statsNa.Should().BeEquivalentTo(rawNa);
+
+        var rawPlNa = await svc.ComputeProChampionPlayrateAsync("NA1", "all", Patch, CancellationToken.None);
+        var statsPlNa = await svc.ComputeProChampionPlayrateFromStatsAsync("NA1", "all", Patch, CancellationToken.None);
+        statsPlNa.Should().BeEquivalentTo(rawPlNa);
+    }
+
+    [Fact]
+    public async Task ProSurfacesFromStats_FallBackToLive_WhenNoSnapshot()
+    {
+        await using var ctx = await SeededAsync();
+        var svc = Service(ctx.Db);
+        // No refresh → no snapshots.
+        var raw = await svc.ComputeProBuildsAsync(266, null, "TOP", "all", Patch, CancellationToken.None);
+        var stats = await svc.ComputeProBuildsFromStatsAsync(266, null, "TOP", "all", Patch, CancellationToken.None);
+        stats.Should().BeEquivalentTo(raw);
+    }
+
+    private static ChampionAnalyticsComputeService Service(TranscendenceContext db) =>
+        new(db,
+            Options.Create(new ChampionAnalyticsComputeOptions
+            {
+                MinimumGamesRequired = 1,
+                EarlyPatchMinimumGamesRequired = 1,
+                BootstrapPatchMinimumGamesRequired = 1,
+                BootstrapWindowHours = 24,
+                ProvisionalWindowHours = 96,
+                MaturingWindowHours = 240
+            }),
+            NullLogger<ChampionAnalyticsComputeService>.Instance);
+
+    private static async Task<SeededContext> SeededAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<TranscendenceContext>().UseSqlite(connection).Options;
+        var db = new SqliteCompatibleTranscendenceContext(options);
+        await db.Database.EnsureCreatedAsync();
+
+        db.Patches.Add(new Patch { Version = Patch, ReleaseDate = DateTime.UtcNow.AddDays(-2), DetectedAt = DateTime.UtcNow.AddDays(-2), IsActive = true });
+
+        db.TrackedProSummoners.Add(new TrackedProSummoner { Id = Guid.NewGuid(), Puuid = "pro-puuid", PlatformRegion = "NA1", ProName = "Pro", TeamName = "Team", IsPro = true, IsHighEloOtp = false, IsActive = true });
+        db.TrackedProSummoners.Add(new TrackedProSummoner { Id = Guid.NewGuid(), Puuid = "otp-puuid", PlatformRegion = "NA1", IsPro = false, IsHighEloOtp = true, IsActive = true });
+
+        SeedProMatch(db, "pro-puuid", "Pro", "NA1_PRO", championId: 266, role: "TOP", matchDate: 2_000);
+        SeedProMatch(db, "otp-puuid", "Otp", "NA1_OTP", championId: 266, role: "TOP", matchDate: 1_000);
+
+        await db.SaveChangesAsync();
+        return new SeededContext(connection, db);
+    }
+
+    private static void SeedProMatch(TranscendenceContext db, string puuid, string name, string matchId, int championId, string role, long matchDate)
+    {
+        var summoner = new Summoner
+        {
+            Id = Guid.NewGuid(),
+            PlatformRegion = "NA1",
+            Region = "americas",
+            GameName = name,
+            TagLine = "NA1",
+            Puuid = puuid,
+            SummonerName = name,
+            RiotSummonerId = Guid.NewGuid().ToString("N")
+        };
+        var match = new Transcendence.Data.Models.LoL.Match.Match
+        {
+            Id = Guid.NewGuid(),
+            MatchId = matchId,
+            MatchDate = matchDate,
+            Duration = 1800,
+            Patch = Patch,
+            QueueId = 420,
+            QueueFamily = "RANKED_SOLO_DUO",
+            QueueType = "420",
+            Status = FetchStatus.Success,
+            PlatformRegion = "NA1",
+            FetchedAt = DateTime.UtcNow
+        };
+        db.Summoners.Add(summoner);
+        db.Matches.Add(match);
+        db.MatchParticipants.Add(new MatchParticipant
+        {
+            Id = Guid.NewGuid(),
+            MatchId = match.Id,
+            Match = match,
+            SummonerId = summoner.Id,
+            Summoner = summoner,
+            Puuid = puuid,
+            ParticipantId = 1,
+            TeamId = 100,
+            ChampionId = championId,
+            TeamPosition = role,
+            Win = true,
+            SummonerSpell1Id = 4,
+            SummonerSpell2Id = 12
+        });
+    }
+
+    private sealed class SeededContext(SqliteConnection connection, TranscendenceContext db) : IAsyncDisposable
+    {
+        public TranscendenceContext Db { get; } = db;
+        public async ValueTask DisposeAsync()
+        {
+            await Db.DisposeAsync();
+            await connection.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
The **last two compute-on-read** analytics surfaces. Like builds, they're response-shaped and **roster-filtered** (the scope is a read-time intersection over the tracked roster), so a structured decomposition isn't equivalence-preserving — the durable response cache stores the exact live compute output, making it **trivially equivalent**. With this, the **entire** analytics read surface serves from precompute; **no read is a raw scan anymore** — the warm-storm-class risk is fully closed.

- Generic **`AnalyticsResponseSnapshot`** `(Feature, ScopeKey, Patch → Payload, ComputedAtUtc)` + `AnalyticsSnapshotSerialization`, generalizing the builds pattern.
- **`RefreshProSurfacesAsync`**: pro-playrate per roster scope (all/pro/highelo); pro-builds for each **pro-played** `(champion, role)` × scope (all-region) — enumerated from the active roster's actual matches, so it's bounded to what pros play. Wired into the refresh job after builds.
- **`ComputeProBuildsFromStatsAsync`** / **`ComputeProChampionPlayrateFromStatsAsync`**: point-lookup the snapshot, fall back to live for a specific region / all-roles request / missing snapshot. Read endpoints + the warm path serve from them.

Tests: snapshot reads equal the live compute across all roster scopes (round-trip exact), and a specific region falls back to raw. **183 Service.Core + 40 WebAPI green; no drift.** New empty table → plain migration; applied to prod pre-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)