### PR TITLE
feat(api): partition public read limits per client IP, exempt internal/SSR (P8.2)

### DIFF
--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -14,6 +14,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading.RateLimiting;
 using System.Text;
 using Transcendence.Data;
@@ -55,27 +57,13 @@ builder.Services.AddExceptionHandler<ApiExceptionHandler>();
 builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-    options.AddFixedWindowLimiter("expensive-read", limiter =>
-    {
-        limiter.PermitLimit = 120;
-        limiter.Window = TimeSpan.FromMinutes(1);
-        limiter.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-        limiter.QueueLimit = 0;
-    });
-    options.AddFixedWindowLimiter("search-read", limiter =>
-    {
-        limiter.PermitLimit = 600;
-        limiter.Window = TimeSpan.FromMinutes(1);
-        limiter.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-        limiter.QueueLimit = 0;
-    });
-    options.AddFixedWindowLimiter("multisearch-read", limiter =>
-    {
-        limiter.PermitLimit = 60;
-        limiter.Window = TimeSpan.FromMinutes(1);
-        limiter.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-        limiter.QueueLimit = 0;
-    });
+    // Public read limiters are partitioned PER CLIENT IP (not one global window), so a single client
+    // cannot exhaust everyone's budget. Internal/SSR traffic is exempt — the web frontend's server-side
+    // fetches reach the API directly (no X-Forwarded-For → a private/loopback address), and would
+    // otherwise all collapse into one shared partition. See BuildIpReadPartition.
+    options.AddPolicy("expensive-read", httpContext => BuildIpReadPartition(httpContext, permitLimit: 120));
+    options.AddPolicy("search-read", httpContext => BuildIpReadPartition(httpContext, permitLimit: 600));
+    options.AddPolicy("multisearch-read", httpContext => BuildIpReadPartition(httpContext, permitLimit: 60));
     options.AddFixedWindowLimiter("admin-write", limiter =>
     {
         limiter.PermitLimit = 30;
@@ -397,4 +385,51 @@ static string BuildAuthRateLimitPartitionKey(HttpContext context)
 {
     var clientIp = context.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip";
     return $"ip:{clientIp}";
+}
+
+// Per-IP fixed-window partition for the public read limiters. Internal/SSR traffic (the web container's
+// server-side fetches, health probes, other backend services) reaches the API directly with a
+// private/loopback source address — it is our own trusted traffic and is NOT throttled (otherwise every
+// SSR request would share one partition and starve under a single cap). Only public, forwarded client IPs
+// (restored by UseForwardedHeaders, the same mechanism the auth limiters rely on) get a per-IP budget.
+static RateLimitPartition<string> BuildIpReadPartition(HttpContext context, int permitLimit)
+{
+    var ip = context.Connection.RemoteIpAddress;
+    if (ip is not null && ip.IsIPv4MappedToIPv6)
+        ip = ip.MapToIPv4();
+
+    if (ip is null || IsInternalAddress(ip))
+        return RateLimitPartition.GetNoLimiter("internal");
+
+    return RateLimitPartition.GetFixedWindowLimiter(
+        $"ip:{ip}",
+        _ => new FixedWindowRateLimiterOptions
+        {
+            PermitLimit = permitLimit,
+            Window = TimeSpan.FromMinutes(1),
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+            QueueLimit = 0
+        });
+}
+
+static bool IsInternalAddress(IPAddress ip)
+{
+    if (IPAddress.IsLoopback(ip))
+        return true;
+
+    var bytes = ip.GetAddressBytes();
+    if (ip.AddressFamily == AddressFamily.InterNetwork && bytes.Length == 4)
+    {
+        return bytes[0] == 10                                        // 10.0.0.0/8
+            || (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) // 172.16.0.0/12
+            || (bytes[0] == 192 && bytes[1] == 168)                  // 192.168.0.0/16
+            || (bytes[0] == 169 && bytes[1] == 254);                 // 169.254.0.0/16 link-local
+    }
+    if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+    {
+        return ip.IsIPv6LinkLocal
+            || ip.IsIPv6SiteLocal
+            || (bytes.Length == 16 && (bytes[0] & 0xFE) == 0xFC);    // fc00::/7 unique-local
+    }
+    return false;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,6 +384,7 @@ The web app never exposes backend tokens to browser JS:
 - Admin bootstrap can grant initial admin role from configured email allowlist (`Auth:AdminBootstrap:Emails`).
 - Admin mutating operations are rate-limited (`admin-write`) and audited (`AdminAuditEvents`).
 - Auth endpoints have dedicated rate limits for login/register/refresh/logout protection.
+- Public read endpoints (`expensive-read`/`search-read`/`multisearch-read`) are rate-limited **per client IP** (not one shared global window), so a single client cannot exhaust everyone's budget. Internal/SSR traffic — the web frontend's server-side fetches, health probes, other backend services — reaches the API directly with a private/loopback source address and is **exempt** (`BuildIpReadPartition`/`IsInternalAddress` in `Program.cs`); it would otherwise all collapse into one partition and starve under a single cap. Browser traffic carries its real public IP via `UseForwardedHeaders` (the same mechanism the auth limiters rely on).
 - Admin UX uses curated `/api/admin/*` endpoints and `/admin/*` pages, including:
   - pipeline overview with worker/server snapshots and effective concurrency
   - database + analysis metrics with per-region ingestion health


### PR DESCRIPTION
## What

Second slice of **P8.2** (the first, #99, added the public BFF proxy allowlist). The public read limiters — `expensive-read` / `search-read` / `multisearch-read` — were single **global** fixed windows shared by every caller, so one client could exhaust everyone's budget. They are now partitioned **per client IP** (same 120 / 600 / 60-per-minute limits, now per client).

## The SSR wrinkle (and the design call)

A naive per-IP key would make this *worse* for server-side rendering: the web frontend fetches analytics directly via `getTrnClient()` (server→server, no reverse proxy → no `X-Forwarded-For`), so **all SSR traffic shares the web container's single private IP** and would collapse into one partition, starving under a single cap.

So **internal/SSR traffic is exempt** (`GetNoLimiter`): private (RFC1918) / loopback / link-local / IPv6-ULA source addresses — the web container's SSR, health probes, other backend services — are our own trusted traffic and aren't throttled. Only **public, forwarded client IPs** (restored by `UseForwardedHeaders`, the same mechanism the auth limiters already rely on) get a per-IP budget. New helpers `BuildIpReadPartition` + `IsInternalAddress` in `Program.cs`.

Global overload protection stays the cache/precompute layer's job; this slice is about per-client fairness + anti-abuse on the public read surface.

## Notes

- Policy **names are unchanged**, so the `[EnableRateLimiting("...")]` controller attributes and the `auth-*` / `admin-write` limiters are untouched.
- No contract/OpenAPI change.

## Validation

- `dotnet build` clean (only the pre-existing `ForwardedHeaders.KnownNetworks` baseline warning).
- `Transcendence.WebAPI.Tests` **40/40** ✓ (the `WebApplicationFactory` suite boots the app, exercising the limiter registration).

## P8.2 status

With this, **P8.2 is complete**: public BFF proxy allowlist (#99) + partitioned per-IP read limits (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)