### PR TITLE
refactor(analytics): rename matchups-only service to ChampionMatchupComputeService (P10.1)

### DIFF
--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -167,7 +167,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             // Common filter/index fields
             entity.HasIndex(p => p.SummonerId);
             // Covering index for the dominant champion-analytics query
-            // (ChampionAnalyticsComputeService.ComputeWinRatesAsync): seek by ChampionId and read
+            // (ChampionWinRateComputeService.ComputeWinRatesAsync): seek by ChampionId and read
             // the join + aggregate payload (MatchId for the Match join, SummonerId for the Ranks
             // join, TeamPosition + Win for the grouping) straight from the index leaf — turning the
             // ~48k-block heap fetch into an index-only scan (prod EXPLAIN: the MatchParticipants
@@ -178,7 +178,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             // to hot tables". This also covers a plain (ChampionId) seek, so no separate index is kept.
             entity.HasIndex(p => p.ChampionId, "IX_MatchParticipants_ChampionId_Covering");
             // Covering index for the champion-side scan of the matchup query
-            // (ChampionAnalyticsComputeService.ComputeMatchupsAsync): seek by (ChampionId, TeamPosition)
+            // (ChampionMatchupComputeService.ComputeMatchupsAsync): seek by (ChampionId, TeamPosition)
             // and read MatchId/ParticipantId/Win/TeamId from the leaf so the scan is index-only (prod
             // EXPLAIN: it was a ~50k-cost bitmap heap scan). Bare shape in the model; INCLUDE in the
             // raw-SQL migration. Replaces the plain non-covering (ChampionId, TeamPosition) index.
@@ -529,7 +529,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
                 .OnDelete(DeleteBehavior.Cascade);
             entity.HasIndex(x => new { x.MinuteMark, x.MatchId });
             // Covering index for the matchup gold/xp-diff-at-15 join
-            // (ChampionAnalyticsComputeService.ComputeMatchupsAsync). That query LEFT-joins this
+            // (ChampionMatchupComputeService.ComputeMatchupsAsync). That query LEFT-joins this
             // 22.5M-row table twice — championTimeline and opponentTimeline — on
             // (MatchId, ParticipantId) with MinuteMark == 15. The key columns mirror the PK, so the
             // join key was already seekable; the win is the INCLUDE payload, which lets both scans run

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/AnalyticsSampleThreshold.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/AnalyticsSampleThreshold.cs
@@ -7,7 +7,7 @@ namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 /// <summary>
 /// Shared adaptive sample-size threshold for champion analytics: the minimum games a (role, tier)
 /// must have before its win rate is trusted, scaled down during the new-patch ramp so early-patch
-/// pages still render. Extracted from <see cref="ChampionAnalyticsComputeService"/> so the win-rate /
+/// pages still render. Extracted from the original analytics compute service (P10.1) so the win-rate /
 /// tier-list path (<see cref="ChampionWinRateComputeService"/>) and the builds path share one rule
 /// instead of duplicating it (a divergence would silently make the two surfaces disagree on what
 /// counts as enough data). Static + all inputs passed in, so it adds no new injected dependency.

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/AnalyticsScopeMath.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/AnalyticsScopeMath.cs
@@ -4,8 +4,10 @@ namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 
 /// <summary>
 /// Shared, stateless rank-tier-scope parsing/application + sample-size math for champion analytics.
-/// Extracted from <see cref="ChampionAnalyticsComputeService"/> so the raw and stats-backed read paths
-/// share one focused, pure implementation. All members are pure functions of their parameters.
+/// Extracted from the original analytics compute service (P10.1) so the raw and stats-backed read paths
+/// across <see cref="ChampionWinRateComputeService"/>, <see cref="ChampionBuildComputeService"/>,
+/// <see cref="ChampionProComputeService"/>, and <see cref="ChampionMatchupComputeService"/> share one
+/// focused, pure implementation. All members are pure functions of their parameters.
 /// </summary>
 internal static class AnalyticsScopeMath
 {

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -46,7 +46,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
     private readonly TranscendenceContext _context;
     private readonly HybridCache _cache;
-    private readonly IChampionAnalyticsComputeService _computeService;
+    private readonly IChampionMatchupComputeService _matchupService;
     private readonly IChampionWinRateComputeService _winRateService;
     private readonly IChampionBuildComputeService _buildService;
     private readonly IChampionProComputeService _proService;
@@ -56,7 +56,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
     public ChampionAnalyticsService(
         TranscendenceContext context,
         HybridCache cache,
-        IChampionAnalyticsComputeService computeService,
+        IChampionMatchupComputeService matchupService,
         IChampionWinRateComputeService winRateService,
         IChampionBuildComputeService buildService,
         IChampionProComputeService proService,
@@ -65,7 +65,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
     {
         _context = context;
         _cache = cache;
-        _computeService = computeService;
+        _matchupService = matchupService;
         _winRateService = winRateService;
         _buildService = buildService;
         _proService = proService;
@@ -376,7 +376,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         // for a specific region or an un-refreshed patch). HybridCache stays the hot tier in front.
         var response = await _cache.GetOrCreateAsync(
             cacheKey,
-            async cancel => await _computeService.ComputeMatchupsFromStatsAsync(
+            async cancel => await _matchupService.ComputeMatchupsFromStatsAsync(
                 championId,
                 normalizedRole,
                 normalizedTier == "all" ? null : normalizedTier,
@@ -464,7 +464,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
         var matchupsKey = $"{MatchupsCacheKeyPrefix}{championId}:{effectiveRole}:{normalizedTier}:{normalizedRegion}:{currentPatch}";
         var matchupsTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "matchups" };
-        var matchups = await _computeService.ComputeMatchupsFromStatsAsync(
+        var matchups = await _matchupService.ComputeMatchupsFromStatsAsync(
             championId, effectiveRole, tierForCompute, normalizedRegion, currentPatch, ct);
         await _cache.SetAsync(matchupsKey, matchups, AnalyticsCacheOptions, matchupsTags, ct);
 

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildComputeService.cs
@@ -9,10 +9,10 @@ using Transcendence.Service.Core.Services.Analytics.Models;
 namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 
 /// <summary>
-/// Raw + stats-backed computation for champion builds. Extracted from
-/// <see cref="ChampionAnalyticsComputeService"/> (P10.1) so this domain is a focused unit; win rates /
-/// tier lists, pro builds/playrate, and matchups stay on that service. Behavior is identical to the
-/// pre-extraction code — the analytics test suite (raw + raw-vs-stats build equivalence) is the gate.
+/// Raw + stats-backed computation for champion builds. Extracted from the original analytics compute
+/// service (P10.1) so this domain is a focused unit; win rates / tier lists, pro builds/playrate, and
+/// matchups (<see cref="ChampionMatchupComputeService"/>) live in their own services. Behavior is identical
+/// to the pre-extraction code — the analytics test suite (raw + raw-vs-stats build equivalence) is the gate.
 /// </summary>
 public sealed class ChampionBuildComputeService : IChampionBuildComputeService
 {

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildPathBuilder.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildPathBuilder.cs
@@ -7,7 +7,7 @@ namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 
 /// <summary>
 /// Composes the sectioned, timing-aware build path (and the shared item/rune normalisation helpers)
-/// for champion builds. Extracted verbatim from <see cref="ChampionAnalyticsComputeService"/> so the
+/// for champion builds. Extracted verbatim from <see cref="ChampionBuildComputeService"/> so the
 /// build-path composition logic lives on its own; behaviour is unchanged.
 /// </summary>
 internal sealed class ChampionBuildPathBuilder

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionMatchupComputeService.Stats.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionMatchupComputeService.Stats.cs
@@ -10,7 +10,7 @@ namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 /// (Win-rate and tier-list stats live in <c>ChampionWinRateComputeService</c>; builds in
 /// <c>ChampionBuildComputeService</c>; the pro surfaces in <c>ChampionProComputeService</c>.)
 /// </summary>
-public partial class ChampionAnalyticsComputeService
+public partial class ChampionMatchupComputeService
 {
 
     public async Task<ChampionMatchupsResponse> ComputeMatchupsFromStatsAsync(

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionMatchupComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionMatchupComputeService.cs
@@ -7,16 +7,17 @@ using Transcendence.Service.Core.Services.Analytics.Models;
 namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 
 /// <summary>
-/// Raw computation service for champion matchups using EF Core aggregation. Win rates / tier lists, builds,
-/// and the pro surfaces have been extracted to their own services (P10.1); this service owns matchups only.
+/// Raw computation service for champion matchups using EF Core aggregation. This is the matchups-only
+/// service that remained after the analytics god-file was decomposed (P10.1) — win rates / tier lists,
+/// builds, and the pro surfaces each live in their own <c>Champion{WinRate,Build,Pro}ComputeService</c>.
 /// </summary>
-public partial class ChampionAnalyticsComputeService : IChampionAnalyticsComputeService
+public partial class ChampionMatchupComputeService : IChampionMatchupComputeService
 {
     private const int MinMatchupSampleSize = 30;
     private const int MatchupsToShow = 5;
     private readonly TranscendenceContext _context;
 
-    public ChampionAnalyticsComputeService(TranscendenceContext context)
+    public ChampionMatchupComputeService(TranscendenceContext context)
     {
         _context = context;
     }

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionProComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionProComputeService.cs
@@ -10,10 +10,10 @@ namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 
 /// <summary>
 /// Raw + stats-backed computation for the pro / high-elo surfaces (pro builds, pro champion playrate, and
-/// the public pro roster). Extracted from <see cref="ChampionAnalyticsComputeService"/> (P10.1) so this
-/// domain is a focused unit; win rates / tier lists and builds have their own services, and matchups stay
-/// on that service. Behavior is identical to the pre-extraction code — the analytics test suite (raw +
-/// raw-vs-stats pro-surface equivalence) is the gate.
+/// the public pro roster). Extracted from the original analytics compute service (P10.1) so this domain is
+/// a focused unit; win rates / tier lists, builds, and matchups (<see cref="ChampionMatchupComputeService"/>)
+/// each have their own service. Behavior is identical to the pre-extraction code — the analytics test suite
+/// (raw + raw-vs-stats pro-surface equivalence) is the gate.
 /// </summary>
 public sealed class ChampionProComputeService : IChampionProComputeService
 {

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionWinRateComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionWinRateComputeService.cs
@@ -9,10 +9,10 @@ using Transcendence.Service.Core.Services.Analytics.Models;
 namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 
 /// <summary>
-/// Raw + stats-backed computation for champion win rates and the tier list. Extracted from
-/// <see cref="ChampionAnalyticsComputeService"/> (P10.1) so this domain is a focused unit; builds,
-/// pro builds/playrate, and matchups stay on that service. Behavior is identical to the pre-extraction
-/// code — the analytics test suite (raw + raw-vs-stats equivalence) is the gate.
+/// Raw + stats-backed computation for champion win rates and the tier list. Extracted from the original
+/// analytics compute service (P10.1) so this domain is a focused unit; builds, pro builds/playrate, and
+/// matchups (<see cref="ChampionMatchupComputeService"/>) live in their own services. Behavior is identical
+/// to the pre-extraction code — the analytics test suite (raw + raw-vs-stats equivalence) is the gate.
 /// </summary>
 public sealed class ChampionWinRateComputeService : IChampionWinRateComputeService
 {

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/PrecomputedAnalyticsRefresher.cs
@@ -12,7 +12,7 @@ namespace Transcendence.Service.Core.Services.Analytics.Implementations;
 /// <summary>
 /// Rebuilds the tabular-core precomputed analytics aggregates from raw match data. See
 /// <see cref="IPrecomputedAnalyticsRefresher"/>. Every aggregation mirrors the filters of the live
-/// compute (<c>ChampionAnalyticsComputeService</c>) so the read path can roll these atoms up to the exact
+/// compute (the <c>Champion{WinRate,Build,Pro,Matchup}ComputeService</c> services) so the read path can roll these atoms up to the exact
 /// same numbers:
 /// <list type="bullet">
 /// <item><c>ChampionRoleTierStat</c>: a LEFT JOIN to the current solo rank gives each participant a tier

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionBuildComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionBuildComputeService.cs
@@ -4,9 +4,9 @@ namespace Transcendence.Service.Core.Services.Analytics.Interfaces;
 
 /// <summary>
 /// Raw computation service for champion builds (and their durable-snapshot fast path). Extracted from
-/// <see cref="IChampionAnalyticsComputeService"/> so the builds domain is a focused unit; win rates /
-/// tier lists, pro builds/playrate, and matchups remain elsewhere. Performs EF Core aggregation without
-/// caching.
+/// the original analytics compute contract (P10.1) so the builds domain is a focused unit; win rates /
+/// tier lists, pro builds/playrate, and matchups (<see cref="IChampionMatchupComputeService"/>) live in
+/// their own services. Performs EF Core aggregation without caching.
 /// </summary>
 public interface IChampionBuildComputeService
 {

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionMatchupComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionMatchupComputeService.cs
@@ -4,9 +4,10 @@ namespace Transcendence.Service.Core.Services.Analytics.Interfaces;
 
 /// <summary>
 /// Raw computation service for champion matchups. Performs EF Core aggregation queries without caching.
-/// Win rates / tier lists, builds, and the pro surfaces have their own compute services (P10.1).
+/// The matchups-only contract left after the analytics god-file was decomposed (P10.1); win rates /
+/// tier lists, builds, and the pro surfaces each have their own compute-service interface.
 /// </summary>
-public interface IChampionAnalyticsComputeService
+public interface IChampionMatchupComputeService
 {
     /// <summary>
     /// Computes matchup data (counters and favorable matchups) for a champion.

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionProComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionProComputeService.cs
@@ -4,9 +4,10 @@ namespace Transcendence.Service.Core.Services.Analytics.Interfaces;
 
 /// <summary>
 /// Raw + stats-backed computation for the pro / high-elo surfaces (pro builds, pro champion playrate, and
-/// the public pro roster). Extracted from <see cref="IChampionAnalyticsComputeService"/> (P10.1) so this
-/// domain is a focused unit; win rates / tier lists and builds live in their own services, and matchups
-/// remain on the original. Performs EF Core aggregation without caching.
+/// the public pro roster). Extracted from the original analytics compute contract (P10.1) so this domain
+/// is a focused unit; win rates / tier lists, builds, and matchups
+/// (<see cref="IChampionMatchupComputeService"/>) each live in their own service. Performs EF Core
+/// aggregation without caching.
 /// </summary>
 public interface IChampionProComputeService
 {

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionWinRateComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionWinRateComputeService.cs
@@ -4,9 +4,10 @@ namespace Transcendence.Service.Core.Services.Analytics.Interfaces;
 
 /// <summary>
 /// Raw computation service for champion win-rate and tier-list analytics (and their stats-backed
-/// fast paths). Extracted from <see cref="IChampionAnalyticsComputeService"/> so the win-rate / tier-list
-/// domain is a focused unit; builds, pro builds/playrate, and matchups remain on that service.
-/// Performs EF Core aggregation without caching.
+/// fast paths). Extracted from the original analytics compute contract (P10.1) so the win-rate / tier-list
+/// domain is a focused unit; builds, pro builds/playrate, and matchups
+/// (<see cref="IChampionMatchupComputeService"/>) live in their own services. Performs EF Core aggregation
+/// without caching.
 /// </summary>
 public interface IChampionWinRateComputeService
 {

--- a/Transcendence.Service.Core/Services/Analytics/RankTierCatalog.cs
+++ b/Transcendence.Service.Core/Services/Analytics/RankTierCatalog.cs
@@ -3,7 +3,7 @@ namespace Transcendence.Service.Core.Services.Analytics;
 /// <summary>
 /// Canonical rank-tier groupings shared across LoL + TFT analytics. The Emerald+ set is the default
 /// "high-elo" analytics scope; it was previously copy-pasted as an inline <c>|| </c>-chain in several
-/// places (ChampionAnalyticsComputeService, TftAnalyticsComputeService). Exposed as a list so EF Core
+/// places (the LoL analytics compute services, TftAnalyticsComputeService). Exposed as a list so EF Core
 /// translates <c>EmeraldPlusTiers.Contains(tier)</c> to a SQL <c>IN (...)</c> — equivalent to the chain.
 /// </summary>
 public static class RankTierCatalog
@@ -29,7 +29,7 @@ public static class RankTierCatalog
     /// Rank-scope tokens the analytics surface can request — and that the refresh job precomputes the
     /// distinct-match (ban-rate) denominators for: the unfiltered <see cref="AllScope"/>, the high-elo
     /// <see cref="EmeraldPlusScope"/> composite, and every exact tier. Mirrors <c>ParseRankTierScope</c>
-    /// in ChampionAnalyticsComputeService (which normalizes "EMERALD+" → "EMERALD_PLUS").
+    /// in <c>AnalyticsScopeMath</c> (which normalizes "EMERALD+" → "EMERALD_PLUS").
     /// </summary>
     public static readonly IReadOnlyList<string> RankScopeTokens =
         [AllScope, EmeraldPlusScope, .. AllTiers];

--- a/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IChampionWinRateComputeService, ChampionWinRateComputeService>();
         services.AddScoped<IChampionBuildComputeService, ChampionBuildComputeService>();
         services.AddScoped<IChampionProComputeService, ChampionProComputeService>();
-        services.AddScoped<IChampionAnalyticsComputeService, ChampionAnalyticsComputeService>();
+        services.AddScoped<IChampionMatchupComputeService, ChampionMatchupComputeService>();
         services.AddScoped<IChampionAnalyticsService, ChampionAnalyticsService>();
         services.AddScoped<IPrecomputedAnalyticsRefresher, PrecomputedAnalyticsRefresher>();
         services.AddScoped<ITftSummonerReadService, TftSummonerReadService>();

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
@@ -254,7 +254,7 @@ public class ChampionAnalyticsServiceTests
         harness.BuildService
             .Setup(x => x.ComputeBuildsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChampionBuildsResponse(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", [], []));
-        harness.ComputeService
+        harness.MatchupService
             .Setup(x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ChampionMatchupsResponse
             {
@@ -286,7 +286,7 @@ public class ChampionAnalyticsServiceTests
         harness.BuildService.Verify(
             x => x.ComputeBuildsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
-        harness.ComputeService.Verify(
+        harness.MatchupService.Verify(
             x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ProService.Verify(
@@ -303,7 +303,7 @@ public class ChampionAnalyticsServiceTests
             SqliteConnection connection,
             SqliteCompatibleTranscendenceContext db,
             ServiceProvider services,
-            Mock<IChampionAnalyticsComputeService> computeService,
+            Mock<IChampionMatchupComputeService> matchupService,
             Mock<IChampionWinRateComputeService> winRateService,
             Mock<IChampionBuildComputeService> buildService,
             Mock<IChampionProComputeService> proService,
@@ -312,7 +312,7 @@ public class ChampionAnalyticsServiceTests
             _connection = connection;
             Db = db;
             _services = services;
-            ComputeService = computeService;
+            MatchupService = matchupService;
             WinRateService = winRateService;
             BuildService = buildService;
             ProService = proService;
@@ -320,7 +320,7 @@ public class ChampionAnalyticsServiceTests
         }
 
         public SqliteCompatibleTranscendenceContext Db { get; }
-        public Mock<IChampionAnalyticsComputeService> ComputeService { get; }
+        public Mock<IChampionMatchupComputeService> MatchupService { get; }
         public Mock<IChampionWinRateComputeService> WinRateService { get; }
         public Mock<IChampionBuildComputeService> BuildService { get; }
         public Mock<IChampionProComputeService> ProService { get; }
@@ -343,7 +343,7 @@ public class ChampionAnalyticsServiceTests
             serviceCollection.AddHybridCache();
             var services = serviceCollection.BuildServiceProvider();
 
-            var compute = new Mock<IChampionAnalyticsComputeService>();
+            var matchup = new Mock<IChampionMatchupComputeService>();
             var winRate = new Mock<IChampionWinRateComputeService>();
             var build = new Mock<IChampionBuildComputeService>();
             var pro = new Mock<IChampionProComputeService>();
@@ -359,7 +359,7 @@ public class ChampionAnalyticsServiceTests
             var service = new ChampionAnalyticsService(
                 db,
                 services.GetRequiredService<HybridCache>(),
-                compute.Object,
+                matchup.Object,
                 winRate.Object,
                 build.Object,
                 pro.Object,
@@ -383,7 +383,7 @@ public class ChampionAnalyticsServiceTests
                     ]
                 }));
 
-            return new Harness(connection, db, services, compute, winRate, build, pro, service);
+            return new Harness(connection, db, services, matchup, winRate, build, pro, service);
         }
 
         public void SetActivePatch(string version, DateTime releaseUtc)

--- a/tests/Transcendence.Service.Core.Tests/ChampionMatchupStatsEquivalenceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionMatchupStatsEquivalenceTests.cs
@@ -56,7 +56,7 @@ public class ChampionMatchupStatsEquivalenceTests
         stats.Should().BeEquivalentTo(raw, o => o.WithStrictOrdering());
     }
 
-    private static ChampionAnalyticsComputeService Service(TranscendenceContext db) =>
+    private static ChampionMatchupComputeService Service(TranscendenceContext db) =>
         new(db);
 
     private static ChampionProComputeService ProService(TranscendenceContext db) =>


### PR DESCRIPTION
## What

Pure rename completing the `ChampionAnalyticsComputeService` god-file decomposition. After win-rate (#100), builds (#102), and pro (#103) were extracted into their own `Champion{WinRate,Build,Pro}ComputeService` classes, the only domain left on the 1217-line original was **matchups**. This renames the misnamed shell to reflect its single responsibility.

- `ChampionAnalyticsComputeService` / `.Stats` → `ChampionMatchupComputeService` (file renames via `git mv`, history preserved)
- `IChampionAnalyticsComputeService` → `IChampionMatchupComputeService`
- Class/interface XML-doc summaries rewritten as matchups-only (dropped stale "champion analytics" framing)

## References updated

- `ServiceCollectionExtensions`: DI registration repointed
- `ChampionAnalyticsService` (orchestrator): injected field/param/usages → `IChampionMatchupComputeService` (renamed field `_computeService` → `_matchupService`)
- All `<see cref>` doc references in the extracted services/interfaces, `AnalyticsScopeMath`, `ChampionBuildPathBuilder`, `AnalyticsSampleThreshold` repointed (no CS1574 unresolved crefs)
- Plain-text comment mentions in `RankTierCatalog`, `PrecomputedAnalyticsRefresher`, `TranscendenceContext` corrected to the current owning types
- Tests: `ChampionAnalyticsServiceTests` Harness mock → `MatchupService`; `ChampionMatchupStatsEquivalenceTests` helper → `ChampionMatchupComputeService`
- EF migration files left untouched (immutable; stale historical comments are fine)

## Validation

- `dotnet build Transcendence.sln`: 0 errors, only baseline warnings (no new CS1574)
- Service.Core tests: **183 passed**, 0 failed (matchups raw-vs-stats equivalence is the behavior gate)
- WebAPI tests: **40 passed**, 0 failed

No behavior change, no asserted test values changed, no OpenAPI change. The analytics god-file is now four focused services: win-rate / build / pro / matchup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)