### PR TITLE
refactor(admin): decompose AdminOperationsController behind jobs/overview/logs facades (P10.1)

### DIFF
--- a/Transcendence.Service.Core/Services/Admin/Implementations/AdminJobsFacade.cs
+++ b/Transcendence.Service.Core/Services/Admin/Implementations/AdminJobsFacade.cs
@@ -1,0 +1,765 @@
+using System.Text.Json;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Microsoft.Extensions.Options;
+using Transcendence.Service.Core.Services.Admin.Interfaces;
+using Transcendence.Service.Core.Services.Jobs.Configuration;
+using Transcendence.WebAPI.Controllers;
+
+namespace Transcendence.Service.Core.Services.Admin.Implementations;
+
+/// <summary>
+/// Hosts the verbatim job-storage/Hangfire logic extracted from AdminOperationsController's
+/// <c>jobs/*</c> actions (P10.1). Behavior-preserving: the controller still maps results to
+/// IActionResult and records audit events.
+/// </summary>
+public sealed class AdminJobsFacade(
+    JobStorage jobStorage,
+    IOptions<WorkerJobScheduleOptions> workerScheduleOptions,
+    IOptions<MultiRegionIngestionOptions> multiRegionOptions,
+    IRecurringJobManager recurringJobManager,
+    IWorkerRecurringJobPolicy recurringJobPolicy) : IAdminJobsFacade
+{
+    private const int DefaultJobScanLimit = 5000;
+    private const int DefaultJobScanPageSize = 250;
+    private static readonly HashSet<string> BulkDeletableStates = ["enqueued", "scheduled", "failed"];
+    private static readonly HashSet<string> SupportedListStates = ["enqueued", "processing", "scheduled", "failed"];
+    private static readonly HashSet<string> PausableRecurringJobIds =
+    [
+        WorkerRecurringJobPolicy.ChampionAnalyticsIngestionJobId,
+        WorkerRecurringJobPolicy.SummonerMaintenanceJobId,
+        WorkerRecurringJobPolicy.MatchTimelineBackfillJobId,
+        WorkerRecurringJobPolicy.RetryFailedMatchesJobId
+    ];
+
+    private static readonly string[] KnownPlatformRegions =
+    [
+        "NA1", "EUW1", "EUN1", "KR", "BR1", "JP1", "LA1", "LA2", "OC1", "TR1", "RU", "PH2", "SG2", "TH2", "TW2",
+        "VN2"
+    ];
+
+    public IReadOnlyList<AdminRecurringJobDto> GetRecurringJobs()
+    {
+        using var connection = jobStorage.GetConnection();
+        var storedJobs = connection.GetRecurringJobs()
+            .ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
+        var descriptors = recurringJobPolicy.BuildDescriptors(workerScheduleOptions.Value);
+        var jobs = new List<AdminRecurringJobDto>();
+
+        foreach (var descriptor in descriptors.OrderBy(x => x.JobId, StringComparer.Ordinal))
+        {
+            storedJobs.TryGetValue(descriptor.JobId, out var stored);
+            jobs.Add(new AdminRecurringJobDto(
+                Id: descriptor.JobId,
+                Queue: stored?.Queue ?? "default",
+                Cron: stored?.Cron ?? descriptor.CronExpression,
+                NextExecution: stored?.NextExecution,
+                LastExecution: stored?.LastExecution,
+                LastJobId: stored?.LastJobId,
+                LastJobState: stored?.LastJobState,
+                Error: stored?.Error,
+                IsPresentInStorage: stored is not null,
+                IsEnabledByConfiguration: descriptor.IsEnabled,
+                IsPaused: descriptor.IsEnabled && stored is null,
+                IsPausable: PausableRecurringJobIds.Contains(descriptor.JobId)));
+        }
+
+        foreach (var extra in storedJobs.Values
+                     .Where(x => descriptors.All(d => !string.Equals(d.JobId, x.Id, StringComparison.OrdinalIgnoreCase)))
+                     .OrderBy(x => x.Id, StringComparer.Ordinal))
+        {
+            jobs.Add(new AdminRecurringJobDto(
+                Id: extra.Id,
+                Queue: extra.Queue ?? "default",
+                Cron: extra.Cron,
+                NextExecution: extra.NextExecution,
+                LastExecution: extra.LastExecution,
+                LastJobId: extra.LastJobId,
+                LastJobState: extra.LastJobState,
+                Error: extra.Error,
+                IsPresentInStorage: true,
+                IsEnabledByConfiguration: false,
+                IsPaused: false,
+                IsPausable: false));
+        }
+
+        return jobs;
+    }
+
+    public AdminMutationResult TriggerRecurring(string id)
+    {
+        try
+        {
+            RecurringJob.TriggerJob(id.Trim());
+            return new AdminMutationResult(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new AdminMutationResult(false, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the recurring job id is one that admin is allowed to pause/resume.
+    /// </summary>
+    public static bool IsPausableRecurringJob(string normalizedId) =>
+        PausableRecurringJobIds.Contains(normalizedId);
+
+    public AdminMutationResult PauseRecurring(string id)
+    {
+        var normalizedId = id.Trim();
+        try
+        {
+            RecurringJob.RemoveIfExists(normalizedId);
+            return new AdminMutationResult(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new AdminMutationResult(false, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the recurring-job descriptor for an admin resume request, returning a discriminated
+    /// validation outcome that the controller maps to the original BadRequest responses.
+    /// </summary>
+    public AdminResumeValidation ValidateResume(string normalizedId)
+    {
+        var descriptor = recurringJobPolicy
+            .BuildDescriptors(workerScheduleOptions.Value)
+            .FirstOrDefault(x => string.Equals(x.JobId, normalizedId, StringComparison.OrdinalIgnoreCase));
+        if (descriptor is null || !PausableRecurringJobIds.Contains(normalizedId))
+            return new AdminResumeValidation(AdminResumeValidationKind.NotPausable, null);
+        if (!descriptor.IsEnabled)
+            return new AdminResumeValidation(AdminResumeValidationKind.DisabledByConfiguration, null);
+
+        return new AdminResumeValidation(AdminResumeValidationKind.Ok, descriptor);
+    }
+
+    public AdminMutationResult ResumeRecurring(string id)
+    {
+        var normalizedId = id.Trim();
+        var validation = ValidateResume(normalizedId);
+        if (validation.Kind != AdminResumeValidationKind.Ok || validation.Descriptor is null)
+        {
+            // The controller is expected to short-circuit on validation; defensively mirror failure.
+            return new AdminMutationResult(false, null);
+        }
+
+        try
+        {
+            validation.Descriptor.Apply(recurringJobManager);
+            return new AdminMutationResult(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new AdminMutationResult(false, ex.Message);
+        }
+    }
+
+    public AdminQueueSummaryResponse GetQueueSummary(int scanLimit)
+    {
+        var monitoring = jobStorage.GetMonitoringApi();
+        var safeScanLimit = Math.Clamp(scanLimit, 100, 50000);
+        var jobs = ScanJobs(monitoring, ["enqueued", "processing", "scheduled", "failed"], safeScanLimit, out var truncated);
+        var groups = jobs
+            .GroupBy(x => new { x.State, x.Queue, x.JobType, x.JobMethod, x.Region })
+            .Select(g => new AdminJobGroupDto(
+                State: g.Key.State,
+                Queue: g.Key.Queue,
+                JobType: g.Key.JobType,
+                JobMethod: g.Key.JobMethod,
+                Region: g.Key.Region,
+                Count: g.LongCount(),
+                OldestSeenAtUtc: g.Min(x => x.StateChangedAtUtc),
+                NewestSeenAtUtc: g.Max(x => x.StateChangedAtUtc)))
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.State, StringComparer.Ordinal)
+            .Take(25)
+            .ToList();
+
+        return new AdminQueueSummaryResponse(
+            GeneratedAtUtc: DateTime.UtcNow,
+            Truncated: truncated,
+            ScanLimit: safeScanLimit,
+            Queues: monitoring.Queues()
+                .Select(q => new AdminQueueSnapshot(q.Name, q.Length, q.Fetched))
+                .OrderByDescending(x => x.Length)
+                .ToList(),
+            TopGroups: groups);
+    }
+
+    public AdminJobListLookup GetJobs(
+        string state,
+        string? queue,
+        string? type,
+        string? region,
+        string? q,
+        int? olderThanMinutes,
+        int from,
+        int count,
+        int scanLimit)
+    {
+        var normalizedStates = NormalizeRequestedStates([state]);
+        if (normalizedStates.Count == 0)
+            return new AdminJobListLookup(false, null);
+
+        var safeFrom = Math.Max(0, from);
+        var safeCount = Math.Clamp(count, 1, 200);
+        var safeScanLimit = Math.Clamp(scanLimit, 100, 50000);
+        var monitoring = jobStorage.GetMonitoringApi();
+        var jobs = ScanJobs(monitoring, normalizedStates, safeScanLimit, out var truncated);
+        var filtered = ApplyJobFilters(jobs, queue, type, region, q, olderThanMinutes).ToList();
+        var page = filtered.Skip(safeFrom).Take(safeCount).ToList();
+
+        return new AdminJobListLookup(true, new AdminJobListResponse(
+            GeneratedAtUtc: DateTime.UtcNow,
+            From: safeFrom,
+            Count: safeCount,
+            TotalMatched: filtered.Count,
+            Truncated: truncated,
+            ScanLimit: safeScanLimit,
+            Items: page));
+    }
+
+    public IReadOnlyList<AdminFailedJobDto> GetFailedJobs(int from, int count)
+    {
+        var monitoring = jobStorage.GetMonitoringApi();
+        var safeFrom = Math.Max(0, from);
+        var safeCount = Math.Clamp(count, 1, 100);
+        var failed = monitoring.FailedJobs(safeFrom, safeCount)
+            .Select(x => new AdminFailedJobDto(
+                x.Key,
+                x.Value.Reason,
+                x.Value.ExceptionType,
+                x.Value.ExceptionMessage,
+                x.Value.FailedAt))
+            .ToList();
+
+        return failed;
+    }
+
+    public AdminJobDetailDto? GetJobDetail(string safeJobId) => BuildJobDetail(safeJobId);
+
+    public AdminMutationResult RetryFailedJob(string jobId)
+    {
+        try
+        {
+            BackgroundJob.Requeue(jobId.Trim());
+            return new AdminMutationResult(true, null);
+        }
+        catch (Exception ex)
+        {
+            return new AdminMutationResult(false, ex.Message);
+        }
+    }
+
+    public AdminDeleteJobOutcome DeleteJob(string normalizedId, string? expectedState)
+    {
+        try
+        {
+            var detailBeforeDelete = BuildJobDetail(normalizedId);
+            var deleted = string.IsNullOrWhiteSpace(expectedState)
+                ? BackgroundJob.Delete(normalizedId)
+                : BackgroundJob.Delete(normalizedId, expectedState);
+            var currentState = deleted
+                ? "Deleted"
+                : BuildJobDetail(normalizedId)?.CurrentState ?? detailBeforeDelete?.CurrentState;
+            var message = BuildDeleteMessage(normalizedId, deleted, expectedState, currentState);
+            return new AdminDeleteJobOutcome(
+                Result: new AdminDeleteJobResultDto
+                {
+                    JobId = normalizedId,
+                    Deleted = deleted,
+                    ExpectedState = expectedState,
+                    CurrentState = currentState,
+                    Message = message
+                },
+                Deleted: deleted,
+                ExpectedState: expectedState,
+                CurrentState: currentState,
+                Message: message,
+                ThrewError: null);
+        }
+        catch (Exception ex)
+        {
+            return new AdminDeleteJobOutcome(
+                Result: null,
+                Deleted: false,
+                ExpectedState: expectedState,
+                CurrentState: null,
+                Message: null,
+                ThrewError: ex.Message);
+        }
+    }
+
+    public AdminBulkDeleteJobsOutcome BulkDeleteJobs(AdminBulkDeleteJobsRequest request)
+    {
+        var states = NormalizeRequestedStates(request.States?.Count > 0 ? request.States : ["enqueued", "scheduled", "failed"]);
+        // The controller validates state-allowance before calling; defensively keep the same normalization.
+
+        var safeLimit = Math.Clamp(request.Limit ?? 500, 1, 5000);
+        var safeScanLimit = Math.Clamp(request.ScanLimit ?? DefaultJobScanLimit, 100, 50000);
+        var monitoring = jobStorage.GetMonitoringApi();
+        var candidates = ApplyJobFilters(
+                ScanJobs(monitoring, states, safeScanLimit, out var truncated),
+                queue: null,
+                request.JobType,
+                request.Region,
+                request.Query,
+                request.OlderThanMinutes,
+                request.Queues)
+            .Take(safeLimit)
+            .ToList();
+
+        var deleted = 0;
+        var failed = 0;
+        if (!request.DryRun)
+        {
+            foreach (var candidate in candidates)
+            {
+                if (BackgroundJob.Delete(candidate.JobId, candidate.State))
+                    deleted++;
+                else
+                    failed++;
+            }
+        }
+
+        return new AdminBulkDeleteJobsOutcome(
+            Result: new AdminBulkDeleteJobsResultDto(
+                DryRun: request.DryRun,
+                Truncated: truncated,
+                Matched: candidates.Count,
+                Deleted: deleted,
+                Failed: failed,
+                SampleJobIds: candidates.Take(20).Select(x => x.JobId).ToList()),
+            States: states,
+            SafeLimit: safeLimit,
+            SafeScanLimit: safeScanLimit,
+            Matched: candidates.Count,
+            Deleted: deleted,
+            Failed: failed,
+            Truncated: truncated);
+    }
+
+    /// <summary>
+    /// Validates the requested bulk-delete states against the allowed set, returning the normalized
+    /// states (so the controller can reject before mutating, exactly like the original action).
+    /// </summary>
+    public static AdminBulkDeleteValidation ValidateBulkDeleteStates(IReadOnlyList<string>? requestStates)
+    {
+        var states = NormalizeRequestedStates(requestStates?.Count > 0 ? requestStates : ["enqueued", "scheduled", "failed"]);
+        var isValid = states.Count != 0 && states.All(x => BulkDeletableStates.Contains(x));
+        return new AdminBulkDeleteValidation(isValid, states);
+    }
+
+    private AdminJobDetailDto? BuildJobDetail(string safeJobId)
+    {
+        var monitoring = jobStorage.GetMonitoringApi();
+        var details = monitoring.JobDetails(safeJobId);
+        if (details is null)
+            return null;
+
+        var history = details.History ?? [];
+        var states = history
+            .Select(MapStateTransition)
+            .OrderByDescending(x => x.CreatedAtUtc)
+            .ToList();
+        var currentState = states.FirstOrDefault();
+        var failedState = states.FirstOrDefault(x => string.Equals(x.StateName, "Failed", StringComparison.OrdinalIgnoreCase));
+        var processingState = states.FirstOrDefault(x => string.Equals(x.StateName, "Processing", StringComparison.OrdinalIgnoreCase));
+        var enqueuedState = states.FirstOrDefault(x => string.Equals(x.StateName, "Enqueued", StringComparison.OrdinalIgnoreCase));
+        var scheduledState = states.FirstOrDefault(x => string.Equals(x.StateName, "Scheduled", StringComparison.OrdinalIgnoreCase));
+        var deletedState = states.FirstOrDefault(x => string.Equals(x.StateName, "Deleted", StringComparison.OrdinalIgnoreCase));
+
+        var queue = GetDictionaryValue(currentState?.Data, "Queue") ??
+            GetDictionaryValue(enqueuedState?.Data, "Queue") ??
+            GetDictionaryValue(scheduledState?.Data, "Queue") ??
+            "default";
+
+        return new AdminJobDetailDto(
+            JobId: safeJobId,
+            CurrentState: currentState?.StateName,
+            Queue: queue,
+            JobType: details.Job?.Type?.FullName,
+            JobMethod: details.Job?.Method?.Name,
+            Arguments: details.Job?.Args?.Select(SafeSerialize).ToList() ?? [],
+            Region: InferRegion(details.Job),
+            CreatedAtUtc: details.CreatedAt,
+            EnqueuedAtUtc: enqueuedState?.CreatedAtUtc,
+            ScheduledAtUtc: scheduledState?.CreatedAtUtc,
+            StartedAtUtc: processingState?.CreatedAtUtc,
+            StateChangedAtUtc: currentState?.CreatedAtUtc,
+            FailedAtUtc: failedState?.CreatedAtUtc,
+            DeletedAtUtc: deletedState?.CreatedAtUtc,
+            ServerId: GetDictionaryValue(processingState?.Data, "ServerId") ??
+                GetDictionaryValue(currentState?.Data, "ServerId"),
+            Reason: failedState?.Reason ?? currentState?.Reason,
+            ExceptionType: GetDictionaryValue(failedState?.Data, "ExceptionType"),
+            ExceptionMessage: GetDictionaryValue(failedState?.Data, "ExceptionMessage"),
+            ExceptionDetails: GetDictionaryValue(failedState?.Data, "ExceptionDetails"),
+            FailedCount: states.Count(x => string.Equals(x.StateName, "Failed", StringComparison.OrdinalIgnoreCase)),
+            States: states,
+            Properties: details.Properties is null
+                ? new Dictionary<string, string>(StringComparer.Ordinal)
+                : new Dictionary<string, string>(details.Properties, StringComparer.Ordinal));
+    }
+
+    private static string BuildDeleteMessage(
+        string jobId,
+        bool deleted,
+        string? expectedState,
+        string? currentState)
+    {
+        if (deleted)
+            return $"Job {jobId} deleted.";
+
+        if (!string.IsNullOrWhiteSpace(expectedState) && !string.IsNullOrWhiteSpace(currentState))
+        {
+            return
+                $"Job {jobId} was not deleted because it is now in state {currentState} instead of {expectedState}.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(currentState))
+            return $"Job {jobId} was not deleted. Current state: {currentState}.";
+
+        return $"Job {jobId} was not deleted because it no longer exists or its state could not be resolved.";
+    }
+
+    private IReadOnlyList<string> GetEnabledRegions()
+    {
+        var multiRegion = multiRegionOptions.Value;
+        if (multiRegion.Enabled && multiRegion.Regions.Count > 0)
+        {
+            return multiRegion.Regions
+                .Where(x => x.Enabled && !string.IsNullOrWhiteSpace(x.Region))
+                .Select(x => NormalizeRegionKey(x.Region))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        return KnownPlatformRegions.ToList();
+    }
+
+    private IReadOnlyList<AdminJobListItemDto> ScanJobs(
+        IMonitoringApi monitoring,
+        IReadOnlyCollection<string> requestedStates,
+        int scanLimit,
+        out bool truncated)
+    {
+        var items = new List<AdminJobListItemDto>(Math.Min(scanLimit, 2000));
+        var truncatedLocal = false;
+
+        bool Add(AdminJobListItemDto item)
+        {
+            items.Add(item);
+            if (items.Count < scanLimit)
+                return true;
+
+            truncatedLocal = true;
+            return false;
+        }
+
+        if (requestedStates.Contains("enqueued"))
+        {
+            foreach (var queue in monitoring.Queues())
+            {
+                for (var offset = 0; offset < queue.Length; offset += DefaultJobScanPageSize)
+                {
+                    foreach (var row in monitoring.EnqueuedJobs(queue.Name, offset, DefaultJobScanPageSize))
+                    {
+                        if (!Add(MapEnqueuedJob(queue.Name, row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (requestedStates.Contains("processing"))
+        {
+            var total = monitoring.ProcessingCount();
+            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
+            {
+                foreach (var row in monitoring.ProcessingJobs(offset, DefaultJobScanPageSize))
+                {
+                        if (!Add(MapProcessingJob(row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                }
+            }
+        }
+
+        if (requestedStates.Contains("scheduled"))
+        {
+            var total = monitoring.ScheduledCount();
+            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
+            {
+                foreach (var row in monitoring.ScheduledJobs(offset, DefaultJobScanPageSize))
+                {
+                        if (!Add(MapScheduledJob(row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                }
+            }
+        }
+
+        if (requestedStates.Contains("failed"))
+        {
+            var total = monitoring.FailedCount();
+            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
+            {
+                foreach (var row in monitoring.FailedJobs(offset, DefaultJobScanPageSize))
+                {
+                        if (!Add(MapFailedJob(row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                }
+            }
+        }
+
+        truncated = truncatedLocal;
+        return items;
+    }
+
+    private IEnumerable<AdminJobListItemDto> ApplyJobFilters(
+        IReadOnlyList<AdminJobListItemDto> jobs,
+        string? queue,
+        string? jobType,
+        string? region,
+        string? query,
+        int? olderThanMinutes,
+        IReadOnlyCollection<string>? queues = null)
+    {
+        var normalizedQueue = string.IsNullOrWhiteSpace(queue) ? null : queue.Trim();
+        var normalizedType = string.IsNullOrWhiteSpace(jobType) ? null : jobType.Trim();
+        var normalizedRegion = string.IsNullOrWhiteSpace(region) ? null : NormalizeRegionKey(region);
+        var normalizedQuery = string.IsNullOrWhiteSpace(query) ? null : query.Trim();
+        var queueSet = queues?
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var olderThanCutoffUtc = olderThanMinutes.HasValue && olderThanMinutes.Value > 0
+            ? DateTime.UtcNow.AddMinutes(-olderThanMinutes.Value)
+            : (DateTime?)null;
+
+        return jobs.Where(job =>
+        {
+            if (normalizedQueue is not null && !string.Equals(job.Queue, normalizedQueue, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (queueSet is not null && queueSet.Count > 0 && !queueSet.Contains(job.Queue))
+                return false;
+            if (normalizedType is not null &&
+                !(job.JobType?.Contains(normalizedType, StringComparison.OrdinalIgnoreCase) ?? false))
+                return false;
+            if (normalizedRegion is not null &&
+                !string.Equals(job.Region, normalizedRegion, StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (olderThanCutoffUtc.HasValue &&
+                job.StateChangedAtUtc.HasValue &&
+                job.StateChangedAtUtc.Value > olderThanCutoffUtc.Value)
+                return false;
+            if (normalizedQuery is null)
+                return true;
+
+            var haystack = string.Join(
+                " ",
+                [
+                    job.JobId,
+                    job.State,
+                    job.Queue,
+                    job.JobType ?? string.Empty,
+                    job.JobMethod ?? string.Empty,
+                    job.Region ?? string.Empty,
+                    job.Reason ?? string.Empty,
+                    job.ExceptionType ?? string.Empty,
+                    job.ExceptionMessage ?? string.Empty,
+                    string.Join(" ", job.Arguments)
+                ]);
+            return haystack.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase);
+        });
+    }
+
+    private AdminJobListItemDto MapEnqueuedJob(string queueName, KeyValuePair<string, EnqueuedJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Enqueued",
+            Queue: queueName,
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.EnqueuedAt,
+            StartedAtUtc: null,
+            ServerId: null,
+            Reason: dto.State,
+            ExceptionType: null,
+            ExceptionMessage: null,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private AdminJobListItemDto MapProcessingJob(KeyValuePair<string, ProcessingJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Processing",
+            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.StartedAt,
+            StartedAtUtc: dto.StartedAt,
+            ServerId: dto.ServerId,
+            Reason: null,
+            ExceptionType: null,
+            ExceptionMessage: null,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private AdminJobListItemDto MapScheduledJob(KeyValuePair<string, ScheduledJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Scheduled",
+            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.ScheduledAt ?? dto.EnqueueAt,
+            StartedAtUtc: null,
+            ServerId: null,
+            Reason: $"Enqueue at {dto.EnqueueAt:u}",
+            ExceptionType: null,
+            ExceptionMessage: null,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private AdminJobListItemDto MapFailedJob(KeyValuePair<string, FailedJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Failed",
+            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.FailedAt,
+            StartedAtUtc: null,
+            ServerId: GetDictionaryValue(dto.StateData, "ServerId"),
+            Reason: dto.Reason,
+            ExceptionType: dto.ExceptionType,
+            ExceptionMessage: dto.ExceptionMessage,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private string? InferRegion(Job? job)
+    {
+        if (job?.Args is null || job.Args.Count == 0)
+            return null;
+
+        var enabledRegions = GetEnabledRegions()
+            .Concat(KnownPlatformRegions)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var arg in job.Args)
+        {
+            if (arg is null)
+                continue;
+
+            if (arg is string raw)
+            {
+                var normalized = NormalizeRegionKey(raw);
+                if (enabledRegions.Contains(normalized))
+                    return normalized;
+
+                foreach (var token in raw.Split([':', '/', '|', ',', ' '], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    normalized = NormalizeRegionKey(token);
+                    if (enabledRegions.Contains(normalized))
+                        return normalized;
+                }
+
+                continue;
+            }
+
+            var asString = arg.ToString();
+            if (string.IsNullOrWhiteSpace(asString))
+                continue;
+
+            var parsed = NormalizeRegionKey(asString);
+            if (enabledRegions.Contains(parsed))
+                return parsed;
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyCollection<string> NormalizeRequestedStates(IReadOnlyCollection<string> states)
+    {
+        return states
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(SupportedListStates.Contains)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string NormalizeRegionKey(string? region)
+    {
+        return string.IsNullOrWhiteSpace(region) ? "UNKNOWN" : region.Trim().ToUpperInvariant();
+    }
+
+    private static string? GetDictionaryValue(IDictionary<string, string>? data, string key)
+    {
+        return data is not null && data.TryGetValue(key, out var value) ? value : null;
+    }
+
+    private static string? GetDictionaryValue(IReadOnlyDictionary<string, string>? data, string key)
+    {
+        return data is not null && data.TryGetValue(key, out var value) ? value : null;
+    }
+
+    private static string SafeSerialize(object? arg)
+    {
+        if (arg is null)
+            return "null";
+
+        try
+        {
+            return JsonSerializer.Serialize(arg);
+        }
+        catch
+        {
+            return arg.ToString() ?? "<unserializable>";
+        }
+    }
+
+    private static AdminJobStateTransitionDto MapStateTransition(StateHistoryDto state)
+    {
+        var data = state.Data ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        return new AdminJobStateTransitionDto(
+            state.StateName,
+            state.CreatedAt,
+            state.Reason,
+            new Dictionary<string, string>(data, StringComparer.Ordinal));
+    }
+}

--- a/Transcendence.Service.Core/Services/Admin/Implementations/AdminLogsFacade.cs
+++ b/Transcendence.Service.Core/Services/Admin/Implementations/AdminLogsFacade.cs
@@ -1,0 +1,240 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Transcendence.Service.Core.Services.Admin.Interfaces;
+using Transcendence.Service.Core.Services.Diagnostics;
+using Transcendence.WebAPI.Controllers;
+
+namespace Transcendence.Service.Core.Services.Admin.Implementations;
+
+/// <summary>
+/// Hosts the verbatim service-log tailing logic extracted from AdminOperationsController's
+/// <c>logs/services</c> action (P10.1). Behavior-preserving: response shapes and parsing are
+/// identical to the original.
+/// </summary>
+public sealed class AdminLogsFacade(IConfiguration configuration) : IAdminLogsFacade
+{
+    private static readonly HashSet<string> AllowedServiceLogKeys = ["webapi", "service"];
+
+    public AdminServiceLogsLookup GetServiceLogs(
+        string service,
+        string? level,
+        string? q,
+        DateTime? sinceUtc,
+        DateTime? untilUtc,
+        int limit)
+    {
+        var serviceKey = service.Trim().ToLowerInvariant();
+        if (!AllowedServiceLogKeys.Contains(serviceKey))
+        {
+            return new AdminServiceLogsLookup(false, null);
+        }
+
+        var safeLimit = Math.Clamp(limit, 1, 500);
+        var directory = ResolveOperationalLogDirectory(serviceKey);
+        var logFiles = directory is null
+            ? []
+            : GetOperationalLogFiles(directory, serviceKey).ToList();
+        if (logFiles.Count == 0)
+        {
+            return new AdminServiceLogsLookup(true, new AdminServiceLogsResponse(
+                new AdminLogSourceDto(
+                    Service: serviceKey,
+                    Available: false,
+                    FilesScanned: 0,
+                    LatestTimestampUtc: null,
+                    Truncated: false),
+                Array.Empty<AdminServiceLogDto>()));
+        }
+
+        var normalizedLevel = string.IsNullOrWhiteSpace(level)
+            ? null
+            : level.Trim().ToUpperInvariant();
+        var search = string.IsNullOrWhiteSpace(q) ? null : q.Trim();
+
+        var entries = new List<AdminServiceLogDto>(safeLimit);
+        DateTime? latestTimestampUtc = null;
+        var truncated = false;
+
+        foreach (var path in logFiles)
+        {
+            foreach (var line in ReadMostRecentLines(path, maxLines: 4000))
+            {
+                if (!TryParseOperationalLogLine(line, out var parsed))
+                    continue;
+
+                latestTimestampUtc ??= parsed.TimestampUtc;
+
+                if (normalizedLevel is not null && !string.Equals(parsed.Level, normalizedLevel, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (sinceUtc.HasValue && parsed.TimestampUtc < sinceUtc.Value)
+                    continue;
+
+                if (untilUtc.HasValue && parsed.TimestampUtc > untilUtc.Value)
+                    continue;
+
+                if (search is not null &&
+                    !ContainsSearch(parsed.Message, search) &&
+                    !ContainsSearch(parsed.Category, search) &&
+                    !ContainsSearch(parsed.Exception, search))
+                    continue;
+
+                entries.Add(parsed);
+                if (entries.Count >= safeLimit)
+                {
+                    truncated = true;
+                    break;
+                }
+            }
+
+            if (entries.Count >= safeLimit)
+                break;
+        }
+
+        return new AdminServiceLogsLookup(true, new AdminServiceLogsResponse(
+            new AdminLogSourceDto(
+                Service: serviceKey,
+                Available: true,
+                FilesScanned: logFiles.Count,
+                LatestTimestampUtc: latestTimestampUtc,
+                Truncated: truncated),
+            entries));
+    }
+
+    private static IEnumerable<string> ReadMostRecentLines(string path, int maxLines)
+    {
+        if (maxLines <= 0)
+            return [];
+
+        var lines = new List<string>(maxLines);
+        var reversedLineBuffer = new List<byte>(1024);
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        if (stream.Length == 0)
+            return lines;
+
+        const int readBufferSize = 4096;
+        var readBuffer = new byte[readBufferSize];
+        var position = stream.Length;
+
+        while (position > 0 && lines.Count < maxLines)
+        {
+            var bytesToRead = (int)Math.Min(readBufferSize, position);
+            position -= bytesToRead;
+            stream.Seek(position, SeekOrigin.Begin);
+            var bytesRead = stream.Read(readBuffer, 0, bytesToRead);
+
+            for (var i = bytesRead - 1; i >= 0 && lines.Count < maxLines; i--)
+            {
+                var current = readBuffer[i];
+                if (current == (byte)'\n')
+                {
+                    AddLineFromReversedBytes(reversedLineBuffer, lines);
+                    continue;
+                }
+
+                reversedLineBuffer.Add(current);
+            }
+        }
+
+        if (lines.Count < maxLines)
+            AddLineFromReversedBytes(reversedLineBuffer, lines);
+
+        return lines;
+    }
+
+    private static void AddLineFromReversedBytes(List<byte> reversedBytes, List<string> lines)
+    {
+        if (reversedBytes.Count == 0)
+            return;
+
+        var lineBytes = reversedBytes.ToArray();
+        Array.Reverse(lineBytes);
+        reversedBytes.Clear();
+
+        var line = Encoding.UTF8.GetString(lineBytes).TrimEnd('\r');
+        if (line.Length > 0)
+            lines.Add(line);
+    }
+
+    private static bool TryParseOperationalLogLine(string line, out AdminServiceLogDto dto)
+    {
+        dto = default!;
+        try
+        {
+            var entry = JsonSerializer.Deserialize<OperationalLogEntry>(line);
+            if (entry is null)
+                return false;
+
+            dto = new AdminServiceLogDto(
+                entry.TimestampUtc,
+                entry.Service,
+                entry.Level,
+                entry.Category,
+                entry.EventId,
+                entry.Message,
+                entry.Exception);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool ContainsSearch(string? value, string search)
+    {
+        return !string.IsNullOrWhiteSpace(value) &&
+               value.Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string? ResolveOperationalLogDirectory(string serviceKey)
+    {
+        var sourceSpecificDirectory = configuration[$"AdminLogs:Sources:{serviceKey}:DirectoryPath"];
+        if (!string.IsNullOrWhiteSpace(sourceSpecificDirectory))
+            return sourceSpecificDirectory.Trim();
+
+        var sharedDirectory = configuration["OperationalLogs:DirectoryPath"];
+        if (!string.IsNullOrWhiteSpace(sharedDirectory))
+            return sharedDirectory.Trim();
+
+        return string.Equals(serviceKey, "webapi", StringComparison.OrdinalIgnoreCase)
+            ? Path.Combine(AppContext.BaseDirectory, "logs")
+            : null;
+    }
+
+    private static IEnumerable<string> GetOperationalLogFiles(string directory, string serviceKey)
+    {
+        if (!Directory.Exists(directory))
+            yield break;
+
+        var candidates = Directory.EnumerateFiles(directory, $"{serviceKey}.log*")
+            .Select(path => new
+            {
+                Path = path,
+                SortOrder = GetLogFileSortOrder(path, serviceKey)
+            })
+            .Where(x => x.SortOrder.HasValue)
+            .OrderBy(x => x.SortOrder!.Value)
+            .Select(x => x.Path);
+
+        foreach (var candidate in candidates)
+            yield return candidate;
+    }
+
+    private static int? GetLogFileSortOrder(string path, string serviceKey)
+    {
+        var fileName = Path.GetFileName(path);
+        var liveName = $"{serviceKey}.log";
+        if (string.Equals(fileName, liveName, StringComparison.OrdinalIgnoreCase))
+            return 0;
+
+        var prefix = $"{liveName}.";
+        if (!fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return int.TryParse(fileName[prefix.Length..], out var parsedSuffix)
+            ? parsedSuffix
+            : null;
+    }
+}

--- a/Transcendence.Service.Core/Services/Admin/Implementations/AdminOverviewFacade.cs
+++ b/Transcendence.Service.Core/Services/Admin/Implementations/AdminOverviewFacade.cs
@@ -1,0 +1,565 @@
+using System.Text.Json;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Services.Admin.Interfaces;
+using Transcendence.Service.Core.Services.Jobs.Configuration;
+using Transcendence.Service.Core.Services.RiotApi;
+using Transcendence.WebAPI.Controllers;
+
+namespace Transcendence.Service.Core.Services.Admin.Implementations;
+
+/// <summary>
+/// Hosts the verbatim overview/metrics snapshot logic extracted from AdminOperationsController
+/// (P10.1). Behavior-preserving: shapes/values are identical to the original actions.
+/// </summary>
+public sealed class AdminOverviewFacade(
+    JobStorage jobStorage,
+    IOptions<ChampionAnalyticsIngestionJobOptions> ingestionOptions,
+    IOptions<MultiRegionIngestionOptions> multiRegionOptions,
+    TranscendenceContext db) : IAdminOverviewFacade
+{
+    private const int DefaultJobScanPageSize = 250;
+
+    private static readonly string[] KnownPlatformRegions =
+    [
+        "NA1", "EUW1", "EUN1", "KR", "BR1", "JP1", "LA1", "LA2", "OC1", "TR1", "RU", "PH2", "SG2", "TH2", "TW2",
+        "VN2"
+    ];
+
+    public async Task<AdminOverviewResponse> GetOverviewAsync(CancellationToken ct)
+    {
+        var monitoring = jobStorage.GetMonitoringApi();
+        var stats = monitoring.GetStatistics();
+        var queues = monitoring.Queues()
+            .Select(q => new AdminQueueSnapshot(
+                q.Name,
+                q.Length,
+                q.Fetched))
+            .OrderByDescending(x => x.Length)
+            .ToList();
+        var servers = monitoring.Servers()
+            .Select(s => new AdminServerSnapshot(
+                s.Name,
+                s.WorkersCount,
+                s.StartedAt,
+                s.Heartbeat,
+                s.Queues.ToList()))
+            .OrderBy(x => x.Name, StringComparer.Ordinal)
+            .ToList();
+
+        var dbConnected = await db.Database.CanConnectAsync(ct);
+        return new AdminOverviewResponse(
+            DateTime.UtcNow,
+            dbConnected,
+            stats.Enqueued,
+            stats.Processing,
+            stats.Scheduled,
+            stats.Failed,
+            stats.Succeeded,
+            stats.Recurring,
+            stats.Deleted,
+            servers.Sum(x => x.WorkersCount),
+            servers,
+            queues);
+    }
+
+    public async Task<AdminAnalysisMetricsResponse> GetAnalysisMetricsAsync(CancellationToken ct)
+    {
+        var generatedAtUtc = DateTime.UtcNow;
+        var monitoring = jobStorage.GetMonitoringApi();
+        var backlogByRegion = BuildBacklogByRegion(
+            ScanJobs(monitoring, ["enqueued", "processing", "scheduled"], scanLimit: 2500, out _));
+
+        var enabledRegions = GetEnabledRegions();
+        var activePatch = await db.Patches
+            .AsNoTracking()
+            .Where(p => p.IsActive)
+            .Select(p => new { p.Version, p.ReleaseDate })
+            .FirstOrDefaultAsync(ct);
+
+        var activePatchVersion = activePatch?.Version;
+        var staleAfterMinutes = Math.Max(15, ingestionOptions.Value.DataStaleAfterMinutes);
+        var staleCutoffUtc = generatedAtUtc.AddMinutes(-staleAfterMinutes);
+
+        var summonerCounts = (await db.Summoners
+                .AsNoTracking()
+                .GroupBy(x => x.PlatformRegion)
+                .Select(g => new { Region = g.Key, Count = g.LongCount() })
+                .ToListAsync(ct))
+            .ToDictionary(x => NormalizeRegionKey(x.Region), x => x.Count, StringComparer.OrdinalIgnoreCase);
+
+        var proCounts = (await db.TrackedProSummoners
+                .AsNoTracking()
+                .Where(x => x.IsActive)
+                .GroupBy(x => x.PlatformRegion)
+                .Select(g => new { Region = g.Key, Count = g.LongCount() })
+                .ToListAsync(ct))
+            .ToDictionary(x => NormalizeRegionKey(x.Region), x => x.Count, StringComparer.OrdinalIgnoreCase);
+
+        Dictionary<string, RegionMatchAggregate> matchAggregates;
+        Dictionary<string, RegionTimelineAggregate> timelineAggregates;
+        long totalMatches;
+        long currentPatchSuccessfulMatches;
+        long currentPatchRankedMatches;
+        long currentPatchTimelineSuccess;
+        long currentPatchTimelineEligible;
+
+        if (string.IsNullOrWhiteSpace(activePatchVersion))
+        {
+            matchAggregates = new Dictionary<string, RegionMatchAggregate>(StringComparer.OrdinalIgnoreCase);
+            timelineAggregates = new Dictionary<string, RegionTimelineAggregate>(StringComparer.OrdinalIgnoreCase);
+            totalMatches = await db.Matches.IgnoreQueryFilters().AsNoTracking().LongCountAsync(ct);
+            currentPatchSuccessfulMatches = 0;
+            currentPatchRankedMatches = 0;
+            currentPatchTimelineSuccess = 0;
+            currentPatchTimelineEligible = 0;
+        }
+        else
+        {
+            totalMatches = await db.Matches.IgnoreQueryFilters().AsNoTracking().LongCountAsync(ct);
+
+            matchAggregates = (await db.Matches
+                    .IgnoreQueryFilters()
+                    .AsNoTracking()
+                    .Where(x => x.Patch == activePatchVersion)
+                    .GroupBy(x => x.PlatformRegion)
+                    .Select(g => new
+                    {
+                        Region = g.Key,
+                        Total = g.LongCount(),
+                        Successful = g.LongCount(x => x.Status == FetchStatus.Success),
+                        TemporaryFailure = g.LongCount(x => x.Status == FetchStatus.TemporaryFailure),
+                        Unfetched = g.LongCount(x => x.Status == FetchStatus.Unfetched),
+                        PermanentlyUnfetchable = g.LongCount(x => x.Status == FetchStatus.PermanentlyUnfetchable),
+                        OutsideRetention = g.LongCount(x => x.Status == FetchStatus.OutsideRetentionWindow),
+                        RankedSuccessful =
+                            g.LongCount(x => x.Status == FetchStatus.Success &&
+                                             x.QueueId == QueueCatalog.RankedSoloDuoQueueId),
+                        LatestSuccessfulFetchUtc =
+                            g.Where(x => x.Status == FetchStatus.Success && x.FetchedAt != null).Max(x => x.FetchedAt)
+                    })
+                    .ToListAsync(ct))
+                .ToDictionary(
+                    x => NormalizeRegionKey(x.Region),
+                    x => new RegionMatchAggregate(
+                        NormalizeRegionKey(x.Region),
+                        x.Total,
+                        x.Successful,
+                        x.TemporaryFailure,
+                        x.Unfetched,
+                        x.PermanentlyUnfetchable,
+                        x.OutsideRetention,
+                        x.RankedSuccessful,
+                        x.LatestSuccessfulFetchUtc),
+                    StringComparer.OrdinalIgnoreCase);
+
+            timelineAggregates = (await db.MatchTimelineFetchStates
+                    .AsNoTracking()
+                    .Where(x => x.Match.Patch == activePatchVersion && x.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId)
+                    .GroupBy(x => x.Match.PlatformRegion)
+                    .Select(g => new
+                    {
+                        Region = g.Key,
+                        Successful = g.LongCount(x => x.Status == MatchTimelineFetchStatus.Success),
+                        Pending = g.LongCount(x => x.Status == MatchTimelineFetchStatus.Unfetched),
+                        TemporaryFailure = g.LongCount(x => x.Status == MatchTimelineFetchStatus.TemporaryFailure),
+                        PermanentFailure = g.LongCount(x => x.Status == MatchTimelineFetchStatus.PermanentlyFailed),
+                        NotApplicable = g.LongCount(x => x.Status == MatchTimelineFetchStatus.NotApplicable)
+                    })
+                    .ToListAsync(ct))
+                .ToDictionary(
+                    x => NormalizeRegionKey(x.Region),
+                    x => new RegionTimelineAggregate(
+                        NormalizeRegionKey(x.Region),
+                        x.Successful,
+                        x.Pending,
+                        x.TemporaryFailure,
+                        x.PermanentFailure,
+                        x.NotApplicable),
+                    StringComparer.OrdinalIgnoreCase);
+
+            currentPatchSuccessfulMatches = matchAggregates.Values.Sum(x => x.Successful);
+            currentPatchRankedMatches = matchAggregates.Values.Sum(x => x.RankedSuccessful);
+            currentPatchTimelineSuccess = timelineAggregates.Values.Sum(x => x.Successful);
+            currentPatchTimelineEligible = timelineAggregates.Values.Sum(x =>
+                x.Successful + x.Pending + x.TemporaryFailure + x.PermanentFailure);
+        }
+
+        var refreshLockSnapshot = await db.RefreshLocks
+            .AsNoTracking()
+            .GroupBy(_ => 1)
+            .Select(g => new
+            {
+                Active = g.Count(x => x.LockedUntilUtc >= generatedAtUtc),
+                Expired = g.Count(x => x.LockedUntilUtc < generatedAtUtc)
+            })
+            .FirstOrDefaultAsync(ct);
+
+        var allRegions = enabledRegions
+            .Concat(summonerCounts.Keys)
+            .Concat(matchAggregates.Keys)
+            .Concat(timelineAggregates.Keys)
+            .Concat(proCounts.Keys)
+            .Concat(backlogByRegion.Keys)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var regions = allRegions
+            .Select(region =>
+            {
+                matchAggregates.TryGetValue(region, out var matchAggregate);
+                timelineAggregates.TryGetValue(region, out var timelineAggregate);
+                backlogByRegion.TryGetValue(region, out var backlogAggregate);
+                summonerCounts.TryGetValue(region, out var regionSummoners);
+                proCounts.TryGetValue(region, out var regionPros);
+
+                var successful = matchAggregate?.Successful ?? 0;
+                var latestSuccessfulFetchUtc = matchAggregate?.LatestSuccessfulFetchUtc;
+                var hasBacklog = (backlogAggregate?.Enqueued ?? 0) + (backlogAggregate?.Processing ?? 0) +
+                    (backlogAggregate?.Scheduled ?? 0) > 0;
+                var isStale = !latestSuccessfulFetchUtc.HasValue || latestSuccessfulFetchUtc.Value < staleCutoffUtc;
+                var health = successful >= Math.Max(1, ingestionOptions.Value.MinimumSuccessfulMatchesForCurrentPatch) &&
+                    !isStale
+                    ? "healthy"
+                    : hasBacklog && (backlogAggregate?.Processing ?? 0) > 0
+                        ? "catching_up"
+                        : hasBacklog
+                            ? "blocked"
+                            : "stale";
+
+                return new AdminAnalysisRegionMetricsDto(
+                    Region: region,
+                    Enabled: enabledRegions.Contains(region),
+                    Summoners: regionSummoners,
+                    CurrentPatchTotalMatches: matchAggregate?.Total ?? 0,
+                    CurrentPatchSuccessfulMatches: successful,
+                    CurrentPatchTemporaryFailures: matchAggregate?.TemporaryFailure ?? 0,
+                    CurrentPatchUnfetchedMatches: matchAggregate?.Unfetched ?? 0,
+                    CurrentPatchPermanentlyUnfetchableMatches: matchAggregate?.PermanentlyUnfetchable ?? 0,
+                    CurrentPatchOutsideRetentionMatches: matchAggregate?.OutsideRetention ?? 0,
+                    RankedCurrentPatchMatches: matchAggregate?.RankedSuccessful ?? 0,
+                    LatestSuccessfulFetchUtc: latestSuccessfulFetchUtc,
+                    TimelineSuccessfulMatches: timelineAggregate?.Successful ?? 0,
+                    TimelinePendingMatches: timelineAggregate?.Pending ?? 0,
+                    TimelineTemporaryFailures: timelineAggregate?.TemporaryFailure ?? 0,
+                    TimelinePermanentFailures: timelineAggregate?.PermanentFailure ?? 0,
+                    TrackedProSummoners: regionPros,
+                    EnqueuedJobs: backlogAggregate?.Enqueued ?? 0,
+                    ProcessingJobs: backlogAggregate?.Processing ?? 0,
+                    ScheduledJobs: backlogAggregate?.Scheduled ?? 0,
+                    Health: health);
+            })
+            .ToList();
+
+        return new AdminAnalysisMetricsResponse(
+            GeneratedAtUtc: generatedAtUtc,
+            ActivePatchVersion: activePatchVersion,
+            ActivePatchReleasedAtUtc: activePatch?.ReleaseDate,
+            Summary: new AdminAnalysisSummaryDto(
+                Summoners: summonerCounts.Values.Sum(),
+                Matches: totalMatches,
+                CurrentPatchSuccessfulMatches: currentPatchSuccessfulMatches,
+                CurrentPatchRankedMatches: currentPatchRankedMatches,
+                TimelineCoverageRatio: currentPatchTimelineEligible <= 0
+                    ? 0
+                    : Math.Round((double)currentPatchTimelineSuccess / currentPatchTimelineEligible, 4),
+                ActiveRefreshLocks: refreshLockSnapshot?.Active ?? 0,
+                ExpiredRefreshLocks: refreshLockSnapshot?.Expired ?? 0,
+                TrackedProSummoners: proCounts.Values.Sum()),
+            Regions: regions);
+    }
+
+    private IReadOnlyList<string> GetEnabledRegions()
+    {
+        var multiRegion = multiRegionOptions.Value;
+        if (multiRegion.Enabled && multiRegion.Regions.Count > 0)
+        {
+            return multiRegion.Regions
+                .Where(x => x.Enabled && !string.IsNullOrWhiteSpace(x.Region))
+                .Select(x => NormalizeRegionKey(x.Region))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        return KnownPlatformRegions.ToList();
+    }
+
+    private IReadOnlyDictionary<string, AdminBacklogRegionAggregate> BuildBacklogByRegion(
+        IReadOnlyList<AdminJobListItemDto> jobs)
+    {
+        return jobs
+            .Where(x => !string.IsNullOrWhiteSpace(x.Region))
+            .GroupBy(x => NormalizeRegionKey(x.Region))
+            .ToDictionary(
+                g => g.Key,
+                g => new AdminBacklogRegionAggregate(
+                    Enqueued: g.LongCount(x => string.Equals(x.State, "Enqueued", StringComparison.OrdinalIgnoreCase)),
+                    Processing: g.LongCount(x => string.Equals(x.State, "Processing", StringComparison.OrdinalIgnoreCase)),
+                    Scheduled: g.LongCount(x => string.Equals(x.State, "Scheduled", StringComparison.OrdinalIgnoreCase))),
+                StringComparer.OrdinalIgnoreCase);
+    }
+
+    private IReadOnlyList<AdminJobListItemDto> ScanJobs(
+        IMonitoringApi monitoring,
+        IReadOnlyCollection<string> requestedStates,
+        int scanLimit,
+        out bool truncated)
+    {
+        var items = new List<AdminJobListItemDto>(Math.Min(scanLimit, 2000));
+        var truncatedLocal = false;
+
+        bool Add(AdminJobListItemDto item)
+        {
+            items.Add(item);
+            if (items.Count < scanLimit)
+                return true;
+
+            truncatedLocal = true;
+            return false;
+        }
+
+        if (requestedStates.Contains("enqueued"))
+        {
+            foreach (var queue in monitoring.Queues())
+            {
+                for (var offset = 0; offset < queue.Length; offset += DefaultJobScanPageSize)
+                {
+                    foreach (var row in monitoring.EnqueuedJobs(queue.Name, offset, DefaultJobScanPageSize))
+                    {
+                        if (!Add(MapEnqueuedJob(queue.Name, row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (requestedStates.Contains("processing"))
+        {
+            var total = monitoring.ProcessingCount();
+            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
+            {
+                foreach (var row in monitoring.ProcessingJobs(offset, DefaultJobScanPageSize))
+                {
+                        if (!Add(MapProcessingJob(row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                }
+            }
+        }
+
+        if (requestedStates.Contains("scheduled"))
+        {
+            var total = monitoring.ScheduledCount();
+            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
+            {
+                foreach (var row in monitoring.ScheduledJobs(offset, DefaultJobScanPageSize))
+                {
+                        if (!Add(MapScheduledJob(row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                }
+            }
+        }
+
+        if (requestedStates.Contains("failed"))
+        {
+            var total = monitoring.FailedCount();
+            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
+            {
+                foreach (var row in monitoring.FailedJobs(offset, DefaultJobScanPageSize))
+                {
+                        if (!Add(MapFailedJob(row)))
+                        {
+                            truncated = truncatedLocal;
+                            return items;
+                        }
+                }
+            }
+        }
+
+        truncated = truncatedLocal;
+        return items;
+    }
+
+    private AdminJobListItemDto MapEnqueuedJob(string queueName, KeyValuePair<string, EnqueuedJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Enqueued",
+            Queue: queueName,
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.EnqueuedAt,
+            StartedAtUtc: null,
+            ServerId: null,
+            Reason: dto.State,
+            ExceptionType: null,
+            ExceptionMessage: null,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private AdminJobListItemDto MapProcessingJob(KeyValuePair<string, ProcessingJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Processing",
+            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.StartedAt,
+            StartedAtUtc: dto.StartedAt,
+            ServerId: dto.ServerId,
+            Reason: null,
+            ExceptionType: null,
+            ExceptionMessage: null,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private AdminJobListItemDto MapScheduledJob(KeyValuePair<string, ScheduledJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Scheduled",
+            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.ScheduledAt ?? dto.EnqueueAt,
+            StartedAtUtc: null,
+            ServerId: null,
+            Reason: $"Enqueue at {dto.EnqueueAt:u}",
+            ExceptionType: null,
+            ExceptionMessage: null,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private AdminJobListItemDto MapFailedJob(KeyValuePair<string, FailedJobDto> row)
+    {
+        var dto = row.Value;
+        return new AdminJobListItemDto(
+            JobId: row.Key,
+            State: "Failed",
+            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
+            JobType: dto.Job?.Type?.FullName,
+            JobMethod: dto.Job?.Method?.Name,
+            Region: InferRegion(dto.Job),
+            CreatedAtUtc: null,
+            StateChangedAtUtc: dto.FailedAt,
+            StartedAtUtc: null,
+            ServerId: GetDictionaryValue(dto.StateData, "ServerId"),
+            Reason: dto.Reason,
+            ExceptionType: dto.ExceptionType,
+            ExceptionMessage: dto.ExceptionMessage,
+            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
+    }
+
+    private string? InferRegion(Job? job)
+    {
+        if (job?.Args is null || job.Args.Count == 0)
+            return null;
+
+        var enabledRegions = GetEnabledRegions()
+            .Concat(KnownPlatformRegions)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var arg in job.Args)
+        {
+            if (arg is null)
+                continue;
+
+            if (arg is string raw)
+            {
+                var normalized = NormalizeRegionKey(raw);
+                if (enabledRegions.Contains(normalized))
+                    return normalized;
+
+                foreach (var token in raw.Split([':', '/', '|', ',', ' '], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    normalized = NormalizeRegionKey(token);
+                    if (enabledRegions.Contains(normalized))
+                        return normalized;
+                }
+
+                continue;
+            }
+
+            var asString = arg.ToString();
+            if (string.IsNullOrWhiteSpace(asString))
+                continue;
+
+            var parsed = NormalizeRegionKey(asString);
+            if (enabledRegions.Contains(parsed))
+                return parsed;
+        }
+
+        return null;
+    }
+
+    private static string NormalizeRegionKey(string? region)
+    {
+        return string.IsNullOrWhiteSpace(region) ? "UNKNOWN" : region.Trim().ToUpperInvariant();
+    }
+
+    private static string? GetDictionaryValue(IDictionary<string, string>? data, string key)
+    {
+        return data is not null && data.TryGetValue(key, out var value) ? value : null;
+    }
+
+    private static string SafeSerialize(object? arg)
+    {
+        if (arg is null)
+            return "null";
+
+        try
+        {
+            return JsonSerializer.Serialize(arg);
+        }
+        catch
+        {
+            return arg.ToString() ?? "<unserializable>";
+        }
+    }
+
+    private sealed record RegionMatchAggregate(
+        string Region,
+        long Total,
+        long Successful,
+        long TemporaryFailure,
+        long Unfetched,
+        long PermanentlyUnfetchable,
+        long OutsideRetention,
+        long RankedSuccessful,
+        DateTime? LatestSuccessfulFetchUtc);
+
+    private sealed record RegionTimelineAggregate(
+        string Region,
+        long Successful,
+        long Pending,
+        long TemporaryFailure,
+        long PermanentFailure,
+        long NotApplicable);
+}

--- a/Transcendence.Service.Core/Services/Admin/Interfaces/IAdminJobsFacade.cs
+++ b/Transcendence.Service.Core/Services/Admin/Interfaces/IAdminJobsFacade.cs
@@ -1,0 +1,108 @@
+using Transcendence.Service.Core.Services.Jobs.Configuration;
+using Transcendence.WebAPI.Controllers;
+
+namespace Transcendence.Service.Core.Services.Admin.Interfaces;
+
+/// <summary>
+/// Encapsulates all Hangfire/job-storage logic that previously lived directly in
+/// AdminOperationsController's <c>jobs/*</c> actions. The facade owns JobStorage, the recurring
+/// job manager/policy and the worker schedule options, and returns plain result/DTO types so the
+/// thin controller keeps ownership of HTTP status-code mapping and audit-event recording.
+/// Behavior is preserved verbatim from the original controller.
+/// </summary>
+public interface IAdminJobsFacade
+{
+    IReadOnlyList<AdminRecurringJobDto> GetRecurringJobs();
+
+    AdminMutationResult TriggerRecurring(string id);
+
+    AdminMutationResult PauseRecurring(string id);
+
+    AdminResumeValidation ValidateResume(string normalizedId);
+
+    AdminMutationResult ResumeRecurring(string id);
+
+    AdminQueueSummaryResponse GetQueueSummary(int scanLimit);
+
+    AdminJobListLookup GetJobs(
+        string state,
+        string? queue,
+        string? type,
+        string? region,
+        string? q,
+        int? olderThanMinutes,
+        int from,
+        int count,
+        int scanLimit);
+
+    IReadOnlyList<AdminFailedJobDto> GetFailedJobs(int from, int count);
+
+    AdminJobDetailDto? GetJobDetail(string safeJobId);
+
+    AdminMutationResult RetryFailedJob(string jobId);
+
+    AdminDeleteJobOutcome DeleteJob(string normalizedId, string? expectedState);
+
+    AdminBulkDeleteJobsOutcome BulkDeleteJobs(AdminBulkDeleteJobsRequest request);
+}
+
+/// <summary>
+/// Result of a guarded mutating recurring/background job operation. Mirrors the original
+/// controller's try/catch: on success <see cref="IsSuccess"/> is true and <see cref="Error"/> is
+/// null; on failure it carries the exception message so the controller can build the identical
+/// BadRequest payload and failure audit metadata.
+/// </summary>
+public sealed record AdminMutationResult(bool IsSuccess, string? Error);
+
+/// <summary>
+/// The normalized state-list outcome for <c>jobs/list</c>. When <see cref="StatesValid"/> is false
+/// the requested state could not be normalized and the controller must return the original
+/// 400 response. Otherwise <see cref="Response"/> holds the populated list payload.
+/// </summary>
+public sealed record AdminJobListLookup(bool StatesValid, AdminJobListResponse? Response);
+
+/// <summary>
+/// Outcome of a single-job delete. Carries the result DTO and the audit metadata pieces the
+/// controller needs to reproduce the original audit write (deleted flag, expected/current state,
+/// message). On exception <see cref="ThrewError"/> holds the message for the failure path.
+/// </summary>
+public sealed record AdminDeleteJobOutcome(
+    AdminDeleteJobResultDto? Result,
+    bool Deleted,
+    string? ExpectedState,
+    string? CurrentState,
+    string? Message,
+    string? ThrewError);
+
+/// <summary>
+/// Outcome of a bulk delete. Carries the result DTO plus the normalized states and counters that
+/// the controller writes into the audit metadata, preserving the original shape exactly.
+/// </summary>
+public sealed record AdminBulkDeleteJobsOutcome(
+    AdminBulkDeleteJobsResultDto Result,
+    IReadOnlyCollection<string> States,
+    int SafeLimit,
+    int SafeScanLimit,
+    int Matched,
+    int Deleted,
+    int Failed,
+    bool Truncated);
+
+public enum AdminResumeValidationKind
+{
+    Ok,
+    NotPausable,
+    DisabledByConfiguration
+}
+
+/// <summary>
+/// Discriminated outcome of resume-request validation, mapped by the controller to the original
+/// BadRequest responses (or to the success path that applies the descriptor).
+/// </summary>
+public sealed record AdminResumeValidation(AdminResumeValidationKind Kind, WorkerRecurringJobDescriptor? Descriptor);
+
+/// <summary>
+/// Outcome of bulk-delete state validation: whether the requested states are allowed and the
+/// normalized state set (so the controller can reproduce the original BadRequest exactly).
+/// </summary>
+public sealed record AdminBulkDeleteValidation(bool IsValid, IReadOnlyCollection<string> States);

--- a/Transcendence.Service.Core/Services/Admin/Interfaces/IAdminLogsFacade.cs
+++ b/Transcendence.Service.Core/Services/Admin/Interfaces/IAdminLogsFacade.cs
@@ -1,0 +1,29 @@
+using Transcendence.WebAPI.Controllers;
+
+namespace Transcendence.Service.Core.Services.Admin.Interfaces;
+
+/// <summary>
+/// Encapsulates the operational-log tailing logic extracted verbatim from
+/// AdminOperationsController's <c>logs/services</c> action (P10.1). Owns IConfiguration and the
+/// allowed service-log keys.
+/// </summary>
+public interface IAdminLogsFacade
+{
+    /// <summary>
+    /// Tails service log files. Returns a result whose <see cref="AdminServiceLogsLookup.ServiceAllowed"/>
+    /// is false when the requested service key is unsupported (the controller maps that to the
+    /// original 400 response); otherwise <see cref="AdminServiceLogsLookup.Response"/> holds the payload.
+    /// </summary>
+    AdminServiceLogsLookup GetServiceLogs(
+        string service,
+        string? level,
+        string? q,
+        DateTime? sinceUtc,
+        DateTime? untilUtc,
+        int limit);
+}
+
+/// <summary>
+/// Outcome of a service-log lookup. Mirrors the original action's validate-then-respond shape.
+/// </summary>
+public sealed record AdminServiceLogsLookup(bool ServiceAllowed, AdminServiceLogsResponse? Response);

--- a/Transcendence.Service.Core/Services/Admin/Interfaces/IAdminOverviewFacade.cs
+++ b/Transcendence.Service.Core/Services/Admin/Interfaces/IAdminOverviewFacade.cs
@@ -1,0 +1,15 @@
+using Transcendence.WebAPI.Controllers;
+
+namespace Transcendence.Service.Core.Services.Admin.Interfaces;
+
+/// <summary>
+/// Encapsulates the read-only system snapshot logic extracted verbatim from
+/// AdminOperationsController's <c>overview</c> and <c>metrics/analysis</c> actions (P10.1). Owns the
+/// EF context, ingestion/multi-region options and JobStorage that those snapshots read.
+/// </summary>
+public interface IAdminOverviewFacade
+{
+    Task<AdminOverviewResponse> GetOverviewAsync(CancellationToken ct);
+
+    Task<AdminAnalysisMetricsResponse> GetAnalysisMetricsAsync(CancellationToken ct);
+}

--- a/Transcendence.Service.Core/Services/Admin/Models/AdminOperationsContracts.cs
+++ b/Transcendence.Service.Core/Services/Admin/Models/AdminOperationsContracts.cs
@@ -1,0 +1,243 @@
+using System.ComponentModel.DataAnnotations;
+
+// NOTE: These admin DTO contracts intentionally live in the Transcendence.WebAPI.Controllers
+// namespace so that the public OpenAPI schema names and the controller's call sites remain
+// byte-for-byte unchanged after the controller was decomposed behind facades (P10.1).
+// They are physically hosted in Transcendence.Service.Core so the admin facades (which live in
+// Service.Core) can return them while the WebAPI controller still maps them to IActionResult.
+namespace Transcendence.WebAPI.Controllers;
+
+public record AdminOverviewResponse(
+    DateTime GeneratedAtUtc,
+    bool DatabaseConnected,
+    long Enqueued,
+    long Processing,
+    long Scheduled,
+    long Failed,
+    long Succeeded,
+    long Recurring,
+    long Deleted,
+    int EffectiveConcurrency,
+    IReadOnlyList<AdminServerSnapshot> Servers,
+    IReadOnlyList<AdminQueueSnapshot> Queues
+);
+
+public record AdminServerSnapshot(
+    string Name,
+    int WorkersCount,
+    DateTime StartedAtUtc,
+    DateTime? HeartbeatUtc,
+    IReadOnlyList<string> Queues
+);
+
+public record AdminQueueSnapshot(string Name, long Length, long? Fetched);
+
+public record AdminAnalysisMetricsResponse(
+    DateTime GeneratedAtUtc,
+    string? ActivePatchVersion,
+    DateTime? ActivePatchReleasedAtUtc,
+    AdminAnalysisSummaryDto Summary,
+    IReadOnlyList<AdminAnalysisRegionMetricsDto> Regions
+);
+
+public record AdminAnalysisSummaryDto(
+    long Summoners,
+    long Matches,
+    long CurrentPatchSuccessfulMatches,
+    long CurrentPatchRankedMatches,
+    double TimelineCoverageRatio,
+    int ActiveRefreshLocks,
+    int ExpiredRefreshLocks,
+    long TrackedProSummoners
+);
+
+public record AdminAnalysisRegionMetricsDto(
+    string Region,
+    bool Enabled,
+    long Summoners,
+    long CurrentPatchTotalMatches,
+    long CurrentPatchSuccessfulMatches,
+    long CurrentPatchTemporaryFailures,
+    long CurrentPatchUnfetchedMatches,
+    long CurrentPatchPermanentlyUnfetchableMatches,
+    long CurrentPatchOutsideRetentionMatches,
+    long RankedCurrentPatchMatches,
+    DateTime? LatestSuccessfulFetchUtc,
+    long TimelineSuccessfulMatches,
+    long TimelinePendingMatches,
+    long TimelineTemporaryFailures,
+    long TimelinePermanentFailures,
+    long TrackedProSummoners,
+    long EnqueuedJobs,
+    long ProcessingJobs,
+    long ScheduledJobs,
+    string Health
+);
+
+public record AdminRecurringJobDto(
+    string Id,
+    string Queue,
+    string Cron,
+    DateTime? NextExecution,
+    DateTime? LastExecution,
+    string? LastJobId,
+    string? LastJobState,
+    string? Error,
+    bool IsPresentInStorage,
+    bool IsEnabledByConfiguration,
+    bool IsPaused,
+    bool IsPausable
+);
+
+public record AdminJobGroupDto(
+    string State,
+    string Queue,
+    string? JobType,
+    string? JobMethod,
+    string? Region,
+    long Count,
+    DateTime? OldestSeenAtUtc,
+    DateTime? NewestSeenAtUtc
+);
+
+public record AdminQueueSummaryResponse(
+    DateTime GeneratedAtUtc,
+    bool Truncated,
+    int ScanLimit,
+    IReadOnlyList<AdminQueueSnapshot> Queues,
+    IReadOnlyList<AdminJobGroupDto> TopGroups
+);
+
+public record AdminJobListItemDto(
+    string JobId,
+    string State,
+    string Queue,
+    string? JobType,
+    string? JobMethod,
+    string? Region,
+    DateTime? CreatedAtUtc,
+    DateTime? StateChangedAtUtc,
+    DateTime? StartedAtUtc,
+    string? ServerId,
+    string? Reason,
+    string? ExceptionType,
+    string? ExceptionMessage,
+    IReadOnlyList<string> Arguments
+);
+
+public record AdminJobListResponse(
+    DateTime GeneratedAtUtc,
+    int From,
+    int Count,
+    int TotalMatched,
+    bool Truncated,
+    int ScanLimit,
+    IReadOnlyList<AdminJobListItemDto> Items
+);
+
+public record AdminFailedJobDto(
+    string JobId,
+    string? Reason,
+    string? ExceptionType,
+    string? ExceptionMessage,
+    DateTime? FailedAt
+);
+
+public record AdminJobDetailDto(
+    string JobId,
+    string? CurrentState,
+    string Queue,
+    string? JobType,
+    string? JobMethod,
+    IReadOnlyList<string> Arguments,
+    string? Region,
+    DateTime? CreatedAtUtc,
+    DateTime? EnqueuedAtUtc,
+    DateTime? ScheduledAtUtc,
+    DateTime? StartedAtUtc,
+    DateTime? StateChangedAtUtc,
+    DateTime? FailedAtUtc,
+    DateTime? DeletedAtUtc,
+    string? ServerId,
+    string? Reason,
+    string? ExceptionType,
+    string? ExceptionMessage,
+    string? ExceptionDetails,
+    int FailedCount,
+    IReadOnlyList<AdminJobStateTransitionDto> States,
+    IReadOnlyDictionary<string, string> Properties
+);
+
+public record AdminJobStateTransitionDto(
+    string StateName,
+    DateTime CreatedAtUtc,
+    string? Reason,
+    IReadOnlyDictionary<string, string> Data
+);
+
+public record AdminDeleteJobRequest(string? ExpectedState, string? Reason);
+
+public sealed class AdminDeleteJobResultDto
+{
+    [Required]
+    public string JobId { get; init; } = string.Empty;
+
+    public bool Deleted { get; init; }
+
+    public string? ExpectedState { get; init; }
+
+    public string? CurrentState { get; init; }
+
+    [Required]
+    public string Message { get; init; } = string.Empty;
+}
+
+public record AdminBulkDeleteJobsRequest(
+    IReadOnlyList<string>? States,
+    IReadOnlyList<string>? Queues,
+    string? JobType,
+    string? Region,
+    string? Query,
+    int? OlderThanMinutes,
+    int? Limit,
+    int? ScanLimit,
+    bool DryRun
+);
+
+public record AdminBulkDeleteJobsResultDto(
+    bool DryRun,
+    bool Truncated,
+    int Matched,
+    int Deleted,
+    int Failed,
+    IReadOnlyList<string> SampleJobIds
+);
+
+public record AdminServiceLogDto(
+    DateTime TimestampUtc,
+    string Service,
+    string Level,
+    string Category,
+    int EventId,
+    string? Message,
+    string? Exception
+);
+
+public record AdminLogSourceDto(
+    string Service,
+    bool Available,
+    int FilesScanned,
+    DateTime? LatestTimestampUtc,
+    bool Truncated
+);
+
+public record AdminServiceLogsResponse(
+    AdminLogSourceDto Source,
+    IReadOnlyList<AdminServiceLogDto> Items
+);
+
+public record AdminBacklogRegionAggregate(
+    long Enqueued,
+    long Processing,
+    long Scheduled
+);

--- a/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using Transcendence.Service.Core.Services.Admin.Implementations;
+using Transcendence.Service.Core.Services.Admin.Interfaces;
 using Transcendence.Service.Core.Services.Analysis.Implementations;
 using Transcendence.Service.Core.Services.Analysis.Interfaces;
 using Transcendence.Service.Core.Services.Analytics.Implementations;
@@ -52,6 +54,20 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ITftStaticDataService, TftStaticDataService>();
         services.AddScoped<ITftAnalyticsComputeService, TftAnalyticsComputeService>();
         services.AddScoped<ITftAnalyticsService, TftAnalyticsService>();
+
+        return services;
+    }
+
+    // Admin-operations facades that decompose AdminOperationsController (P10.1). Registered
+    // separately from AddTranscendenceCore because they depend on the Hangfire job-storage graph
+    // (JobStorage, IRecurringJobManager, IWorkerRecurringJobPolicy) which only the WebAPI host
+    // configures; keeping them out of AddTranscendenceCore preserves that method's Hangfire-free
+    // DI-validation contract.
+    public static IServiceCollection AddAdminOperationsFacades(this IServiceCollection services)
+    {
+        services.AddScoped<IAdminJobsFacade, AdminJobsFacade>();
+        services.AddScoped<IAdminOverviewFacade, AdminOverviewFacade>();
+        services.AddScoped<IAdminLogsFacade, AdminLogsFacade>();
 
         return services;
     }

--- a/Transcendence.WebAPI/Controllers/AdminOperationsController.cs
+++ b/Transcendence.WebAPI/Controllers/AdminOperationsController.cs
@@ -1,25 +1,12 @@
 using System.Security.Claims;
-using System.Text;
-using System.Text.Json;
-using System.ComponentModel.DataAnnotations;
-using Hangfire;
-using Hangfire.Common;
-using Hangfire.Storage;
-using Hangfire.Storage.Monitoring;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
-using Transcendence.Data;
-using Transcendence.Data.Models.LoL.Match;
+using Transcendence.Service.Core.Services.Admin.Implementations;
+using Transcendence.Service.Core.Services.Admin.Interfaces;
 using Transcendence.Service.Core.Services.Analytics.Interfaces;
 using Transcendence.Service.Core.Services.Auth.Interfaces;
 using Transcendence.Service.Core.Services.Auth.Models;
-using Transcendence.Service.Core.Services.Diagnostics;
-using Transcendence.Service.Core.Services.Jobs.Configuration;
-using Transcendence.Service.Core.Services.RiotApi;
 using Transcendence.WebAPI.Security;
 
 namespace Transcendence.WebAPI.Controllers;
@@ -28,333 +15,31 @@ namespace Transcendence.WebAPI.Controllers;
 [Route("api/admin")]
 [Authorize(Policy = AuthPolicies.AdminOnly)]
 public class AdminOperationsController(
-    JobStorage jobStorage,
-    IConfiguration configuration,
-    IOptions<WorkerJobScheduleOptions> workerScheduleOptions,
-    IOptions<ChampionAnalyticsIngestionJobOptions> ingestionOptions,
-    IOptions<MultiRegionIngestionOptions> multiRegionOptions,
-    IRecurringJobManager recurringJobManager,
-    IWorkerRecurringJobPolicy recurringJobPolicy,
-    TranscendenceContext db,
+    IAdminJobsFacade jobsFacade,
+    IAdminOverviewFacade overviewFacade,
+    IAdminLogsFacade logsFacade,
     IChampionAnalyticsService analyticsService,
     IAdminAuditService adminAuditService) : ControllerBase
 {
-    private const int DefaultJobScanLimit = 5000;
-    private const int DefaultJobScanPageSize = 250;
-    private static readonly HashSet<string> AllowedServiceLogKeys = ["webapi", "service"];
-    private static readonly HashSet<string> BulkDeletableStates = ["enqueued", "scheduled", "failed"];
-    private static readonly HashSet<string> SupportedListStates = ["enqueued", "processing", "scheduled", "failed"];
-    private static readonly HashSet<string> PausableRecurringJobIds =
-    [
-        WorkerRecurringJobPolicy.ChampionAnalyticsIngestionJobId,
-        WorkerRecurringJobPolicy.SummonerMaintenanceJobId,
-        WorkerRecurringJobPolicy.MatchTimelineBackfillJobId,
-        WorkerRecurringJobPolicy.RetryFailedMatchesJobId
-    ];
-
-    private static readonly string[] KnownPlatformRegions =
-    [
-        "NA1", "EUW1", "EUN1", "KR", "BR1", "JP1", "LA1", "LA2", "OC1", "TR1", "RU", "PH2", "SG2", "TH2", "TW2",
-        "VN2"
-    ];
-
     [HttpGet("overview")]
     [ProducesResponseType(typeof(AdminOverviewResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetOverview(CancellationToken ct)
     {
-        var monitoring = jobStorage.GetMonitoringApi();
-        var stats = monitoring.GetStatistics();
-        var queues = monitoring.Queues()
-            .Select(q => new AdminQueueSnapshot(
-                q.Name,
-                q.Length,
-                q.Fetched))
-            .OrderByDescending(x => x.Length)
-            .ToList();
-        var servers = monitoring.Servers()
-            .Select(s => new AdminServerSnapshot(
-                s.Name,
-                s.WorkersCount,
-                s.StartedAt,
-                s.Heartbeat,
-                s.Queues.ToList()))
-            .OrderBy(x => x.Name, StringComparer.Ordinal)
-            .ToList();
-
-        var dbConnected = await db.Database.CanConnectAsync(ct);
-        return Ok(new AdminOverviewResponse(
-            DateTime.UtcNow,
-            dbConnected,
-            stats.Enqueued,
-            stats.Processing,
-            stats.Scheduled,
-            stats.Failed,
-            stats.Succeeded,
-            stats.Recurring,
-            stats.Deleted,
-            servers.Sum(x => x.WorkersCount),
-            servers,
-            queues));
+        return Ok(await overviewFacade.GetOverviewAsync(ct));
     }
 
     [HttpGet("metrics/analysis")]
     [ProducesResponseType(typeof(AdminAnalysisMetricsResponse), StatusCodes.Status200OK)]
     public async Task<IActionResult> GetAnalysisMetrics(CancellationToken ct)
     {
-        var generatedAtUtc = DateTime.UtcNow;
-        var monitoring = jobStorage.GetMonitoringApi();
-        var backlogByRegion = BuildBacklogByRegion(
-            ScanJobs(monitoring, ["enqueued", "processing", "scheduled"], scanLimit: 2500, out _));
-
-        var enabledRegions = GetEnabledRegions();
-        var activePatch = await db.Patches
-            .AsNoTracking()
-            .Where(p => p.IsActive)
-            .Select(p => new { p.Version, p.ReleaseDate })
-            .FirstOrDefaultAsync(ct);
-
-        var activePatchVersion = activePatch?.Version;
-        var staleAfterMinutes = Math.Max(15, ingestionOptions.Value.DataStaleAfterMinutes);
-        var staleCutoffUtc = generatedAtUtc.AddMinutes(-staleAfterMinutes);
-
-        var summonerCounts = (await db.Summoners
-                .AsNoTracking()
-                .GroupBy(x => x.PlatformRegion)
-                .Select(g => new { Region = g.Key, Count = g.LongCount() })
-                .ToListAsync(ct))
-            .ToDictionary(x => NormalizeRegionKey(x.Region), x => x.Count, StringComparer.OrdinalIgnoreCase);
-
-        var proCounts = (await db.TrackedProSummoners
-                .AsNoTracking()
-                .Where(x => x.IsActive)
-                .GroupBy(x => x.PlatformRegion)
-                .Select(g => new { Region = g.Key, Count = g.LongCount() })
-                .ToListAsync(ct))
-            .ToDictionary(x => NormalizeRegionKey(x.Region), x => x.Count, StringComparer.OrdinalIgnoreCase);
-
-        Dictionary<string, RegionMatchAggregate> matchAggregates;
-        Dictionary<string, RegionTimelineAggregate> timelineAggregates;
-        long totalMatches;
-        long currentPatchSuccessfulMatches;
-        long currentPatchRankedMatches;
-        long currentPatchTimelineSuccess;
-        long currentPatchTimelineEligible;
-
-        if (string.IsNullOrWhiteSpace(activePatchVersion))
-        {
-            matchAggregates = new Dictionary<string, RegionMatchAggregate>(StringComparer.OrdinalIgnoreCase);
-            timelineAggregates = new Dictionary<string, RegionTimelineAggregate>(StringComparer.OrdinalIgnoreCase);
-            totalMatches = await db.Matches.IgnoreQueryFilters().AsNoTracking().LongCountAsync(ct);
-            currentPatchSuccessfulMatches = 0;
-            currentPatchRankedMatches = 0;
-            currentPatchTimelineSuccess = 0;
-            currentPatchTimelineEligible = 0;
-        }
-        else
-        {
-            totalMatches = await db.Matches.IgnoreQueryFilters().AsNoTracking().LongCountAsync(ct);
-
-            matchAggregates = (await db.Matches
-                    .IgnoreQueryFilters()
-                    .AsNoTracking()
-                    .Where(x => x.Patch == activePatchVersion)
-                    .GroupBy(x => x.PlatformRegion)
-                    .Select(g => new
-                    {
-                        Region = g.Key,
-                        Total = g.LongCount(),
-                        Successful = g.LongCount(x => x.Status == FetchStatus.Success),
-                        TemporaryFailure = g.LongCount(x => x.Status == FetchStatus.TemporaryFailure),
-                        Unfetched = g.LongCount(x => x.Status == FetchStatus.Unfetched),
-                        PermanentlyUnfetchable = g.LongCount(x => x.Status == FetchStatus.PermanentlyUnfetchable),
-                        OutsideRetention = g.LongCount(x => x.Status == FetchStatus.OutsideRetentionWindow),
-                        RankedSuccessful =
-                            g.LongCount(x => x.Status == FetchStatus.Success &&
-                                             x.QueueId == QueueCatalog.RankedSoloDuoQueueId),
-                        LatestSuccessfulFetchUtc =
-                            g.Where(x => x.Status == FetchStatus.Success && x.FetchedAt != null).Max(x => x.FetchedAt)
-                    })
-                    .ToListAsync(ct))
-                .ToDictionary(
-                    x => NormalizeRegionKey(x.Region),
-                    x => new RegionMatchAggregate(
-                        NormalizeRegionKey(x.Region),
-                        x.Total,
-                        x.Successful,
-                        x.TemporaryFailure,
-                        x.Unfetched,
-                        x.PermanentlyUnfetchable,
-                        x.OutsideRetention,
-                        x.RankedSuccessful,
-                        x.LatestSuccessfulFetchUtc),
-                    StringComparer.OrdinalIgnoreCase);
-
-            timelineAggregates = (await db.MatchTimelineFetchStates
-                    .AsNoTracking()
-                    .Where(x => x.Match.Patch == activePatchVersion && x.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId)
-                    .GroupBy(x => x.Match.PlatformRegion)
-                    .Select(g => new
-                    {
-                        Region = g.Key,
-                        Successful = g.LongCount(x => x.Status == MatchTimelineFetchStatus.Success),
-                        Pending = g.LongCount(x => x.Status == MatchTimelineFetchStatus.Unfetched),
-                        TemporaryFailure = g.LongCount(x => x.Status == MatchTimelineFetchStatus.TemporaryFailure),
-                        PermanentFailure = g.LongCount(x => x.Status == MatchTimelineFetchStatus.PermanentlyFailed),
-                        NotApplicable = g.LongCount(x => x.Status == MatchTimelineFetchStatus.NotApplicable)
-                    })
-                    .ToListAsync(ct))
-                .ToDictionary(
-                    x => NormalizeRegionKey(x.Region),
-                    x => new RegionTimelineAggregate(
-                        NormalizeRegionKey(x.Region),
-                        x.Successful,
-                        x.Pending,
-                        x.TemporaryFailure,
-                        x.PermanentFailure,
-                        x.NotApplicable),
-                    StringComparer.OrdinalIgnoreCase);
-
-            currentPatchSuccessfulMatches = matchAggregates.Values.Sum(x => x.Successful);
-            currentPatchRankedMatches = matchAggregates.Values.Sum(x => x.RankedSuccessful);
-            currentPatchTimelineSuccess = timelineAggregates.Values.Sum(x => x.Successful);
-            currentPatchTimelineEligible = timelineAggregates.Values.Sum(x =>
-                x.Successful + x.Pending + x.TemporaryFailure + x.PermanentFailure);
-        }
-
-        var refreshLockSnapshot = await db.RefreshLocks
-            .AsNoTracking()
-            .GroupBy(_ => 1)
-            .Select(g => new
-            {
-                Active = g.Count(x => x.LockedUntilUtc >= generatedAtUtc),
-                Expired = g.Count(x => x.LockedUntilUtc < generatedAtUtc)
-            })
-            .FirstOrDefaultAsync(ct);
-
-        var allRegions = enabledRegions
-            .Concat(summonerCounts.Keys)
-            .Concat(matchAggregates.Keys)
-            .Concat(timelineAggregates.Keys)
-            .Concat(proCounts.Keys)
-            .Concat(backlogByRegion.Keys)
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        var regions = allRegions
-            .Select(region =>
-            {
-                matchAggregates.TryGetValue(region, out var matchAggregate);
-                timelineAggregates.TryGetValue(region, out var timelineAggregate);
-                backlogByRegion.TryGetValue(region, out var backlogAggregate);
-                summonerCounts.TryGetValue(region, out var regionSummoners);
-                proCounts.TryGetValue(region, out var regionPros);
-
-                var successful = matchAggregate?.Successful ?? 0;
-                var latestSuccessfulFetchUtc = matchAggregate?.LatestSuccessfulFetchUtc;
-                var hasBacklog = (backlogAggregate?.Enqueued ?? 0) + (backlogAggregate?.Processing ?? 0) +
-                    (backlogAggregate?.Scheduled ?? 0) > 0;
-                var isStale = !latestSuccessfulFetchUtc.HasValue || latestSuccessfulFetchUtc.Value < staleCutoffUtc;
-                var health = successful >= Math.Max(1, ingestionOptions.Value.MinimumSuccessfulMatchesForCurrentPatch) &&
-                    !isStale
-                    ? "healthy"
-                    : hasBacklog && (backlogAggregate?.Processing ?? 0) > 0
-                        ? "catching_up"
-                        : hasBacklog
-                            ? "blocked"
-                            : "stale";
-
-                return new AdminAnalysisRegionMetricsDto(
-                    Region: region,
-                    Enabled: enabledRegions.Contains(region),
-                    Summoners: regionSummoners,
-                    CurrentPatchTotalMatches: matchAggregate?.Total ?? 0,
-                    CurrentPatchSuccessfulMatches: successful,
-                    CurrentPatchTemporaryFailures: matchAggregate?.TemporaryFailure ?? 0,
-                    CurrentPatchUnfetchedMatches: matchAggregate?.Unfetched ?? 0,
-                    CurrentPatchPermanentlyUnfetchableMatches: matchAggregate?.PermanentlyUnfetchable ?? 0,
-                    CurrentPatchOutsideRetentionMatches: matchAggregate?.OutsideRetention ?? 0,
-                    RankedCurrentPatchMatches: matchAggregate?.RankedSuccessful ?? 0,
-                    LatestSuccessfulFetchUtc: latestSuccessfulFetchUtc,
-                    TimelineSuccessfulMatches: timelineAggregate?.Successful ?? 0,
-                    TimelinePendingMatches: timelineAggregate?.Pending ?? 0,
-                    TimelineTemporaryFailures: timelineAggregate?.TemporaryFailure ?? 0,
-                    TimelinePermanentFailures: timelineAggregate?.PermanentFailure ?? 0,
-                    TrackedProSummoners: regionPros,
-                    EnqueuedJobs: backlogAggregate?.Enqueued ?? 0,
-                    ProcessingJobs: backlogAggregate?.Processing ?? 0,
-                    ScheduledJobs: backlogAggregate?.Scheduled ?? 0,
-                    Health: health);
-            })
-            .ToList();
-
-        return Ok(new AdminAnalysisMetricsResponse(
-            GeneratedAtUtc: generatedAtUtc,
-            ActivePatchVersion: activePatchVersion,
-            ActivePatchReleasedAtUtc: activePatch?.ReleaseDate,
-            Summary: new AdminAnalysisSummaryDto(
-                Summoners: summonerCounts.Values.Sum(),
-                Matches: totalMatches,
-                CurrentPatchSuccessfulMatches: currentPatchSuccessfulMatches,
-                CurrentPatchRankedMatches: currentPatchRankedMatches,
-                TimelineCoverageRatio: currentPatchTimelineEligible <= 0
-                    ? 0
-                    : Math.Round((double)currentPatchTimelineSuccess / currentPatchTimelineEligible, 4),
-                ActiveRefreshLocks: refreshLockSnapshot?.Active ?? 0,
-                ExpiredRefreshLocks: refreshLockSnapshot?.Expired ?? 0,
-                TrackedProSummoners: proCounts.Values.Sum()),
-            Regions: regions));
+        return Ok(await overviewFacade.GetAnalysisMetricsAsync(ct));
     }
 
     [HttpGet("jobs/recurring")]
     [ProducesResponseType(typeof(IReadOnlyList<AdminRecurringJobDto>), StatusCodes.Status200OK)]
     public IActionResult GetRecurringJobs()
     {
-        using var connection = jobStorage.GetConnection();
-        var storedJobs = connection.GetRecurringJobs()
-            .ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
-        var descriptors = recurringJobPolicy.BuildDescriptors(workerScheduleOptions.Value);
-        var jobs = new List<AdminRecurringJobDto>();
-
-        foreach (var descriptor in descriptors.OrderBy(x => x.JobId, StringComparer.Ordinal))
-        {
-            storedJobs.TryGetValue(descriptor.JobId, out var stored);
-            jobs.Add(new AdminRecurringJobDto(
-                Id: descriptor.JobId,
-                Queue: stored?.Queue ?? "default",
-                Cron: stored?.Cron ?? descriptor.CronExpression,
-                NextExecution: stored?.NextExecution,
-                LastExecution: stored?.LastExecution,
-                LastJobId: stored?.LastJobId,
-                LastJobState: stored?.LastJobState,
-                Error: stored?.Error,
-                IsPresentInStorage: stored is not null,
-                IsEnabledByConfiguration: descriptor.IsEnabled,
-                IsPaused: descriptor.IsEnabled && stored is null,
-                IsPausable: PausableRecurringJobIds.Contains(descriptor.JobId)));
-        }
-
-        foreach (var extra in storedJobs.Values
-                     .Where(x => descriptors.All(d => !string.Equals(d.JobId, x.Id, StringComparison.OrdinalIgnoreCase)))
-                     .OrderBy(x => x.Id, StringComparer.Ordinal))
-        {
-            jobs.Add(new AdminRecurringJobDto(
-                Id: extra.Id,
-                Queue: extra.Queue ?? "default",
-                Cron: extra.Cron,
-                NextExecution: extra.NextExecution,
-                LastExecution: extra.LastExecution,
-                LastJobId: extra.LastJobId,
-                LastJobState: extra.LastJobState,
-                Error: extra.Error,
-                IsPresentInStorage: true,
-                IsEnabledByConfiguration: false,
-                IsPaused: false,
-                IsPausable: false));
-        }
-
-        return Ok(jobs);
+        return Ok(jobsFacade.GetRecurringJobs());
     }
 
     [HttpPost("jobs/recurring/{id}/trigger")]
@@ -366,23 +51,21 @@ public class AdminOperationsController(
         if (string.IsNullOrWhiteSpace(id))
             return BadRequest("Recurring job id is required.");
 
-        try
+        var result = jobsFacade.TriggerRecurring(id);
+        if (result.IsSuccess)
         {
-            RecurringJob.TriggerJob(id.Trim());
             await WriteAuditAsync("jobs.recurring.trigger", "recurring-job", id, true, null, ct);
             return Ok(new { message = "Recurring job triggered.", id });
         }
-        catch (Exception ex)
-        {
-            await WriteAuditAsync(
-                "jobs.recurring.trigger",
-                "recurring-job",
-                id,
-                false,
-                new { error = ex.Message },
-                ct);
-            return BadRequest(new { message = "Unable to trigger recurring job.", detail = ex.Message });
-        }
+
+        await WriteAuditAsync(
+            "jobs.recurring.trigger",
+            "recurring-job",
+            id,
+            false,
+            new { error = result.Error },
+            ct);
+        return BadRequest(new { message = "Unable to trigger recurring job.", detail = result.Error });
     }
 
     [HttpPost("jobs/recurring/{id}/pause")]
@@ -392,26 +75,24 @@ public class AdminOperationsController(
     public async Task<IActionResult> PauseRecurring([FromRoute] string id, CancellationToken ct)
     {
         var normalizedId = id.Trim();
-        if (!PausableRecurringJobIds.Contains(normalizedId))
+        if (!AdminJobsFacade.IsPausableRecurringJob(normalizedId))
             return BadRequest(new { message = "Only producer recurring jobs can be paused from admin." });
 
-        try
+        var result = jobsFacade.PauseRecurring(id);
+        if (result.IsSuccess)
         {
-            RecurringJob.RemoveIfExists(normalizedId);
             await WriteAuditAsync("jobs.recurring.pause", "recurring-job", normalizedId, true, null, ct);
             return Ok(new { message = "Recurring job paused.", id = normalizedId });
         }
-        catch (Exception ex)
-        {
-            await WriteAuditAsync(
-                "jobs.recurring.pause",
-                "recurring-job",
-                normalizedId,
-                false,
-                new { error = ex.Message },
-                ct);
-            return BadRequest(new { message = "Unable to pause recurring job.", detail = ex.Message });
-        }
+
+        await WriteAuditAsync(
+            "jobs.recurring.pause",
+            "recurring-job",
+            normalizedId,
+            false,
+            new { error = result.Error },
+            ct);
+        return BadRequest(new { message = "Unable to pause recurring job.", detail = result.Error });
     }
 
     [HttpPost("jobs/recurring/{id}/resume")]
@@ -421,65 +102,34 @@ public class AdminOperationsController(
     public async Task<IActionResult> ResumeRecurring([FromRoute] string id, CancellationToken ct)
     {
         var normalizedId = id.Trim();
-        var descriptor = recurringJobPolicy
-            .BuildDescriptors(workerScheduleOptions.Value)
-            .FirstOrDefault(x => string.Equals(x.JobId, normalizedId, StringComparison.OrdinalIgnoreCase));
-        if (descriptor is null || !PausableRecurringJobIds.Contains(normalizedId))
+        var validation = jobsFacade.ValidateResume(normalizedId);
+        if (validation.Kind == AdminResumeValidationKind.NotPausable)
             return BadRequest(new { message = "Only producer recurring jobs can be resumed from admin." });
-        if (!descriptor.IsEnabled)
+        if (validation.Kind == AdminResumeValidationKind.DisabledByConfiguration)
             return BadRequest(new { message = "Recurring job is disabled by configuration and cannot be resumed." });
 
-        try
+        var result = jobsFacade.ResumeRecurring(id);
+        if (result.IsSuccess)
         {
-            descriptor.Apply(recurringJobManager);
             await WriteAuditAsync("jobs.recurring.resume", "recurring-job", normalizedId, true, null, ct);
             return Ok(new { message = "Recurring job resumed.", id = normalizedId });
         }
-        catch (Exception ex)
-        {
-            await WriteAuditAsync(
-                "jobs.recurring.resume",
-                "recurring-job",
-                normalizedId,
-                false,
-                new { error = ex.Message },
-                ct);
-            return BadRequest(new { message = "Unable to resume recurring job.", detail = ex.Message });
-        }
+
+        await WriteAuditAsync(
+            "jobs.recurring.resume",
+            "recurring-job",
+            normalizedId,
+            false,
+            new { error = result.Error },
+            ct);
+        return BadRequest(new { message = "Unable to resume recurring job.", detail = result.Error });
     }
 
     [HttpGet("jobs/queues")]
     [ProducesResponseType(typeof(AdminQueueSummaryResponse), StatusCodes.Status200OK)]
-    public IActionResult GetQueueSummary([FromQuery] int scanLimit = DefaultJobScanLimit)
+    public IActionResult GetQueueSummary([FromQuery] int scanLimit = 5000)
     {
-        var monitoring = jobStorage.GetMonitoringApi();
-        var safeScanLimit = Math.Clamp(scanLimit, 100, 50000);
-        var jobs = ScanJobs(monitoring, ["enqueued", "processing", "scheduled", "failed"], safeScanLimit, out var truncated);
-        var groups = jobs
-            .GroupBy(x => new { x.State, x.Queue, x.JobType, x.JobMethod, x.Region })
-            .Select(g => new AdminJobGroupDto(
-                State: g.Key.State,
-                Queue: g.Key.Queue,
-                JobType: g.Key.JobType,
-                JobMethod: g.Key.JobMethod,
-                Region: g.Key.Region,
-                Count: g.LongCount(),
-                OldestSeenAtUtc: g.Min(x => x.StateChangedAtUtc),
-                NewestSeenAtUtc: g.Max(x => x.StateChangedAtUtc)))
-            .OrderByDescending(x => x.Count)
-            .ThenBy(x => x.State, StringComparer.Ordinal)
-            .Take(25)
-            .ToList();
-
-        return Ok(new AdminQueueSummaryResponse(
-            GeneratedAtUtc: DateTime.UtcNow,
-            Truncated: truncated,
-            ScanLimit: safeScanLimit,
-            Queues: monitoring.Queues()
-                .Select(q => new AdminQueueSnapshot(q.Name, q.Length, q.Fetched))
-                .OrderByDescending(x => x.Length)
-                .ToList(),
-            TopGroups: groups));
+        return Ok(jobsFacade.GetQueueSummary(scanLimit));
     }
 
     [HttpGet("jobs/list")]
@@ -493,47 +143,20 @@ public class AdminOperationsController(
         [FromQuery] int? olderThanMinutes = null,
         [FromQuery] int from = 0,
         [FromQuery] int count = 25,
-        [FromQuery] int scanLimit = DefaultJobScanLimit)
+        [FromQuery] int scanLimit = 5000)
     {
-        var normalizedStates = NormalizeRequestedStates([state]);
-        if (normalizedStates.Count == 0)
+        var lookup = jobsFacade.GetJobs(state, queue, type, region, q, olderThanMinutes, from, count, scanLimit);
+        if (!lookup.StatesValid)
             return BadRequest(new { message = "Unsupported state. Allowed values: enqueued, processing, scheduled, failed." });
 
-        var safeFrom = Math.Max(0, from);
-        var safeCount = Math.Clamp(count, 1, 200);
-        var safeScanLimit = Math.Clamp(scanLimit, 100, 50000);
-        var monitoring = jobStorage.GetMonitoringApi();
-        var jobs = ScanJobs(monitoring, normalizedStates, safeScanLimit, out var truncated);
-        var filtered = ApplyJobFilters(jobs, queue, type, region, q, olderThanMinutes).ToList();
-        var page = filtered.Skip(safeFrom).Take(safeCount).ToList();
-
-        return Ok(new AdminJobListResponse(
-            GeneratedAtUtc: DateTime.UtcNow,
-            From: safeFrom,
-            Count: safeCount,
-            TotalMatched: filtered.Count,
-            Truncated: truncated,
-            ScanLimit: safeScanLimit,
-            Items: page));
+        return Ok(lookup.Response);
     }
 
     [HttpGet("jobs/failed")]
     [ProducesResponseType(typeof(IReadOnlyList<AdminFailedJobDto>), StatusCodes.Status200OK)]
     public IActionResult GetFailedJobs([FromQuery] int from = 0, [FromQuery] int count = 25)
     {
-        var monitoring = jobStorage.GetMonitoringApi();
-        var safeFrom = Math.Max(0, from);
-        var safeCount = Math.Clamp(count, 1, 100);
-        var failed = monitoring.FailedJobs(safeFrom, safeCount)
-            .Select(x => new AdminFailedJobDto(
-                x.Key,
-                x.Value.Reason,
-                x.Value.ExceptionType,
-                x.Value.ExceptionMessage,
-                x.Value.FailedAt))
-            .ToList();
-
-        return Ok(failed);
+        return Ok(jobsFacade.GetFailedJobs(from, count));
     }
 
     [HttpGet("jobs/inspect/{jobId}")]
@@ -544,7 +167,7 @@ public class AdminOperationsController(
         if (string.IsNullOrWhiteSpace(jobId))
             return NotFound();
 
-        var dto = BuildJobDetail(jobId.Trim());
+        var dto = jobsFacade.GetJobDetail(jobId.Trim());
         return dto is null
             ? NotFound(new { message = "Job not found.", jobId = jobId.Trim() })
             : Ok(dto);
@@ -558,7 +181,7 @@ public class AdminOperationsController(
         if (string.IsNullOrWhiteSpace(jobId))
             return NotFound();
 
-        var dto = BuildJobDetail(jobId.Trim());
+        var dto = jobsFacade.GetJobDetail(jobId.Trim());
         if (dto is null)
             return NotFound(new { message = "Job not found.", jobId = jobId.Trim() });
         if (!string.Equals(dto.CurrentState, "Failed", StringComparison.OrdinalIgnoreCase))
@@ -576,23 +199,21 @@ public class AdminOperationsController(
         if (string.IsNullOrWhiteSpace(jobId))
             return BadRequest("Job id is required.");
 
-        try
+        var result = jobsFacade.RetryFailedJob(jobId);
+        if (result.IsSuccess)
         {
-            BackgroundJob.Requeue(jobId.Trim());
             await WriteAuditAsync("jobs.failed.retry", "background-job", jobId, true, null, ct);
             return Ok(new { message = "Failed job re-queued.", jobId });
         }
-        catch (Exception ex)
-        {
-            await WriteAuditAsync(
-                "jobs.failed.retry",
-                "background-job",
-                jobId,
-                false,
-                new { error = ex.Message },
-                ct);
-            return BadRequest(new { message = "Unable to re-queue failed job.", detail = ex.Message });
-        }
+
+        await WriteAuditAsync(
+            "jobs.failed.retry",
+            "background-job",
+            jobId,
+            false,
+            new { error = result.Error },
+            ct);
+        return BadRequest(new { message = "Unable to re-queue failed job.", detail = result.Error });
     }
 
     [HttpPost("jobs/inspect/{jobId}/delete")]
@@ -610,43 +231,27 @@ public class AdminOperationsController(
         var normalizedId = jobId.Trim();
         var expectedState = string.IsNullOrWhiteSpace(request?.ExpectedState) ? null : request.ExpectedState.Trim();
 
-        try
-        {
-            var detailBeforeDelete = BuildJobDetail(normalizedId);
-            var deleted = string.IsNullOrWhiteSpace(expectedState)
-                ? BackgroundJob.Delete(normalizedId)
-                : BackgroundJob.Delete(normalizedId, expectedState);
-            var currentState = deleted
-                ? "Deleted"
-                : BuildJobDetail(normalizedId)?.CurrentState ?? detailBeforeDelete?.CurrentState;
-            var message = BuildDeleteMessage(normalizedId, deleted, expectedState, currentState);
-            await WriteAuditAsync(
-                "jobs.delete",
-                "background-job",
-                normalizedId,
-                deleted,
-                new { expectedState, currentState, request?.Reason, message },
-                ct);
-            return Ok(new AdminDeleteJobResultDto
-            {
-                JobId = normalizedId,
-                Deleted = deleted,
-                ExpectedState = expectedState,
-                CurrentState = currentState,
-                Message = message
-            });
-        }
-        catch (Exception ex)
+        var outcome = jobsFacade.DeleteJob(normalizedId, expectedState);
+        if (outcome.ThrewError is null && outcome.Result is not null)
         {
             await WriteAuditAsync(
                 "jobs.delete",
                 "background-job",
                 normalizedId,
-                false,
-                new { expectedState, request?.Reason, error = ex.Message },
+                outcome.Deleted,
+                new { expectedState, currentState = outcome.CurrentState, request?.Reason, message = outcome.Message },
                 ct);
-            return BadRequest(new { message = "Unable to delete job.", detail = ex.Message });
+            return Ok(outcome.Result);
         }
+
+        await WriteAuditAsync(
+            "jobs.delete",
+            "background-job",
+            normalizedId,
+            false,
+            new { expectedState, request?.Reason, error = outcome.ThrewError },
+            ct);
+        return BadRequest(new { message = "Unable to delete job.", detail = outcome.ThrewError });
     }
 
     [HttpPost("jobs/bulk-delete")]
@@ -655,8 +260,8 @@ public class AdminOperationsController(
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> BulkDeleteJobs([FromBody] AdminBulkDeleteJobsRequest request, CancellationToken ct)
     {
-        var states = NormalizeRequestedStates(request.States?.Count > 0 ? request.States : ["enqueued", "scheduled", "failed"]);
-        if (states.Count == 0 || states.Any(x => !BulkDeletableStates.Contains(x)))
+        var validation = AdminJobsFacade.ValidateBulkDeleteStates(request.States);
+        if (!validation.IsValid)
         {
             return BadRequest(new
             {
@@ -664,63 +269,32 @@ public class AdminOperationsController(
             });
         }
 
-        var safeLimit = Math.Clamp(request.Limit ?? 500, 1, 5000);
-        var safeScanLimit = Math.Clamp(request.ScanLimit ?? DefaultJobScanLimit, 100, 50000);
-        var monitoring = jobStorage.GetMonitoringApi();
-        var candidates = ApplyJobFilters(
-                ScanJobs(monitoring, states, safeScanLimit, out var truncated),
-                queue: null,
-                request.JobType,
-                request.Region,
-                request.Query,
-                request.OlderThanMinutes,
-                request.Queues)
-            .Take(safeLimit)
-            .ToList();
-
-        var deleted = 0;
-        var failed = 0;
-        if (!request.DryRun)
-        {
-            foreach (var candidate in candidates)
-            {
-                if (BackgroundJob.Delete(candidate.JobId, candidate.State))
-                    deleted++;
-                else
-                    failed++;
-            }
-        }
+        var outcome = jobsFacade.BulkDeleteJobs(request);
 
         await WriteAuditAsync(
             "jobs.bulk-delete",
             "background-job",
             null,
-            isSuccess: !request.DryRun ? failed == 0 : true,
+            isSuccess: !request.DryRun ? outcome.Failed == 0 : true,
             metadata: new
             {
-                states,
+                states = outcome.States,
                 request.Queues,
                 request.JobType,
                 request.Region,
                 request.Query,
                 request.OlderThanMinutes,
-                limit = safeLimit,
-                scanLimit = safeScanLimit,
+                limit = outcome.SafeLimit,
+                scanLimit = outcome.SafeScanLimit,
                 request.DryRun,
-                matched = candidates.Count,
-                deleted,
-                failed,
-                truncated
+                matched = outcome.Matched,
+                deleted = outcome.Deleted,
+                failed = outcome.Failed,
+                truncated = outcome.Truncated
             },
             ct: ct);
 
-        return Ok(new AdminBulkDeleteJobsResultDto(
-            DryRun: request.DryRun,
-            Truncated: truncated,
-            Matched: candidates.Count,
-            Deleted: deleted,
-            Failed: failed,
-            SampleJobIds: candidates.Take(20).Select(x => x.JobId).ToList()));
+        return Ok(outcome.Result);
     }
 
     [HttpPost("cache/invalidate")]
@@ -752,8 +326,8 @@ public class AdminOperationsController(
         [FromQuery] DateTime? untilUtc = null,
         [FromQuery] int limit = 200)
     {
-        var serviceKey = service.Trim().ToLowerInvariant();
-        if (!AllowedServiceLogKeys.Contains(serviceKey))
+        var lookup = logsFacade.GetServiceLogs(service, level, q, sinceUtc, untilUtc, limit);
+        if (!lookup.ServiceAllowed)
         {
             return BadRequest(new
             {
@@ -761,474 +335,7 @@ public class AdminOperationsController(
             });
         }
 
-        var safeLimit = Math.Clamp(limit, 1, 500);
-        var directory = ResolveOperationalLogDirectory(serviceKey);
-        var logFiles = directory is null
-            ? []
-            : GetOperationalLogFiles(directory, serviceKey).ToList();
-        if (logFiles.Count == 0)
-        {
-            return Ok(new AdminServiceLogsResponse(
-                new AdminLogSourceDto(
-                    Service: serviceKey,
-                    Available: false,
-                    FilesScanned: 0,
-                    LatestTimestampUtc: null,
-                    Truncated: false),
-                Array.Empty<AdminServiceLogDto>()));
-        }
-
-        var normalizedLevel = string.IsNullOrWhiteSpace(level)
-            ? null
-            : level.Trim().ToUpperInvariant();
-        var search = string.IsNullOrWhiteSpace(q) ? null : q.Trim();
-
-        var entries = new List<AdminServiceLogDto>(safeLimit);
-        DateTime? latestTimestampUtc = null;
-        var truncated = false;
-
-        foreach (var path in logFiles)
-        {
-            foreach (var line in ReadMostRecentLines(path, maxLines: 4000))
-            {
-                if (!TryParseOperationalLogLine(line, out var parsed))
-                    continue;
-
-                latestTimestampUtc ??= parsed.TimestampUtc;
-
-                if (normalizedLevel is not null && !string.Equals(parsed.Level, normalizedLevel, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                if (sinceUtc.HasValue && parsed.TimestampUtc < sinceUtc.Value)
-                    continue;
-
-                if (untilUtc.HasValue && parsed.TimestampUtc > untilUtc.Value)
-                    continue;
-
-                if (search is not null &&
-                    !ContainsSearch(parsed.Message, search) &&
-                    !ContainsSearch(parsed.Category, search) &&
-                    !ContainsSearch(parsed.Exception, search))
-                    continue;
-
-                entries.Add(parsed);
-                if (entries.Count >= safeLimit)
-                {
-                    truncated = true;
-                    break;
-                }
-            }
-
-            if (entries.Count >= safeLimit)
-                break;
-        }
-
-        return Ok(new AdminServiceLogsResponse(
-            new AdminLogSourceDto(
-                Service: serviceKey,
-                Available: true,
-                FilesScanned: logFiles.Count,
-                LatestTimestampUtc: latestTimestampUtc,
-                Truncated: truncated),
-            entries));
-    }
-
-    private AdminJobDetailDto? BuildJobDetail(string safeJobId)
-    {
-        var monitoring = jobStorage.GetMonitoringApi();
-        var details = monitoring.JobDetails(safeJobId);
-        if (details is null)
-            return null;
-
-        var history = details.History ?? [];
-        var states = history
-            .Select(MapStateTransition)
-            .OrderByDescending(x => x.CreatedAtUtc)
-            .ToList();
-        var currentState = states.FirstOrDefault();
-        var failedState = states.FirstOrDefault(x => string.Equals(x.StateName, "Failed", StringComparison.OrdinalIgnoreCase));
-        var processingState = states.FirstOrDefault(x => string.Equals(x.StateName, "Processing", StringComparison.OrdinalIgnoreCase));
-        var enqueuedState = states.FirstOrDefault(x => string.Equals(x.StateName, "Enqueued", StringComparison.OrdinalIgnoreCase));
-        var scheduledState = states.FirstOrDefault(x => string.Equals(x.StateName, "Scheduled", StringComparison.OrdinalIgnoreCase));
-        var deletedState = states.FirstOrDefault(x => string.Equals(x.StateName, "Deleted", StringComparison.OrdinalIgnoreCase));
-
-        var queue = GetDictionaryValue(currentState?.Data, "Queue") ??
-            GetDictionaryValue(enqueuedState?.Data, "Queue") ??
-            GetDictionaryValue(scheduledState?.Data, "Queue") ??
-            "default";
-
-        return new AdminJobDetailDto(
-            JobId: safeJobId,
-            CurrentState: currentState?.StateName,
-            Queue: queue,
-            JobType: details.Job?.Type?.FullName,
-            JobMethod: details.Job?.Method?.Name,
-            Arguments: details.Job?.Args?.Select(SafeSerialize).ToList() ?? [],
-            Region: InferRegion(details.Job),
-            CreatedAtUtc: details.CreatedAt,
-            EnqueuedAtUtc: enqueuedState?.CreatedAtUtc,
-            ScheduledAtUtc: scheduledState?.CreatedAtUtc,
-            StartedAtUtc: processingState?.CreatedAtUtc,
-            StateChangedAtUtc: currentState?.CreatedAtUtc,
-            FailedAtUtc: failedState?.CreatedAtUtc,
-            DeletedAtUtc: deletedState?.CreatedAtUtc,
-            ServerId: GetDictionaryValue(processingState?.Data, "ServerId") ??
-                GetDictionaryValue(currentState?.Data, "ServerId"),
-            Reason: failedState?.Reason ?? currentState?.Reason,
-            ExceptionType: GetDictionaryValue(failedState?.Data, "ExceptionType"),
-            ExceptionMessage: GetDictionaryValue(failedState?.Data, "ExceptionMessage"),
-            ExceptionDetails: GetDictionaryValue(failedState?.Data, "ExceptionDetails"),
-            FailedCount: states.Count(x => string.Equals(x.StateName, "Failed", StringComparison.OrdinalIgnoreCase)),
-            States: states,
-            Properties: details.Properties is null
-                ? new Dictionary<string, string>(StringComparer.Ordinal)
-                : new Dictionary<string, string>(details.Properties, StringComparer.Ordinal));
-    }
-
-    private static string BuildDeleteMessage(
-        string jobId,
-        bool deleted,
-        string? expectedState,
-        string? currentState)
-    {
-        if (deleted)
-            return $"Job {jobId} deleted.";
-
-        if (!string.IsNullOrWhiteSpace(expectedState) && !string.IsNullOrWhiteSpace(currentState))
-        {
-            return
-                $"Job {jobId} was not deleted because it is now in state {currentState} instead of {expectedState}.";
-        }
-
-        if (!string.IsNullOrWhiteSpace(currentState))
-            return $"Job {jobId} was not deleted. Current state: {currentState}.";
-
-        return $"Job {jobId} was not deleted because it no longer exists or its state could not be resolved.";
-    }
-
-    private IReadOnlyList<string> GetEnabledRegions()
-    {
-        var multiRegion = multiRegionOptions.Value;
-        if (multiRegion.Enabled && multiRegion.Regions.Count > 0)
-        {
-            return multiRegion.Regions
-                .Where(x => x.Enabled && !string.IsNullOrWhiteSpace(x.Region))
-                .Select(x => NormalizeRegionKey(x.Region))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-        }
-
-        return KnownPlatformRegions.ToList();
-    }
-
-    private IReadOnlyDictionary<string, AdminBacklogRegionAggregate> BuildBacklogByRegion(
-        IReadOnlyList<AdminJobListItemDto> jobs)
-    {
-        return jobs
-            .Where(x => !string.IsNullOrWhiteSpace(x.Region))
-            .GroupBy(x => NormalizeRegionKey(x.Region))
-            .ToDictionary(
-                g => g.Key,
-                g => new AdminBacklogRegionAggregate(
-                    Enqueued: g.LongCount(x => string.Equals(x.State, "Enqueued", StringComparison.OrdinalIgnoreCase)),
-                    Processing: g.LongCount(x => string.Equals(x.State, "Processing", StringComparison.OrdinalIgnoreCase)),
-                    Scheduled: g.LongCount(x => string.Equals(x.State, "Scheduled", StringComparison.OrdinalIgnoreCase))),
-                StringComparer.OrdinalIgnoreCase);
-    }
-
-    private IReadOnlyList<AdminJobListItemDto> ScanJobs(
-        IMonitoringApi monitoring,
-        IReadOnlyCollection<string> requestedStates,
-        int scanLimit,
-        out bool truncated)
-    {
-        var items = new List<AdminJobListItemDto>(Math.Min(scanLimit, 2000));
-        var truncatedLocal = false;
-
-        bool Add(AdminJobListItemDto item)
-        {
-            items.Add(item);
-            if (items.Count < scanLimit)
-                return true;
-
-            truncatedLocal = true;
-            return false;
-        }
-
-        if (requestedStates.Contains("enqueued"))
-        {
-            foreach (var queue in monitoring.Queues())
-            {
-                for (var offset = 0; offset < queue.Length; offset += DefaultJobScanPageSize)
-                {
-                    foreach (var row in monitoring.EnqueuedJobs(queue.Name, offset, DefaultJobScanPageSize))
-                    {
-                        if (!Add(MapEnqueuedJob(queue.Name, row)))
-                        {
-                            truncated = truncatedLocal;
-                            return items;
-                        }
-                    }
-                }
-            }
-        }
-
-        if (requestedStates.Contains("processing"))
-        {
-            var total = monitoring.ProcessingCount();
-            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
-            {
-                foreach (var row in monitoring.ProcessingJobs(offset, DefaultJobScanPageSize))
-                {
-                        if (!Add(MapProcessingJob(row)))
-                        {
-                            truncated = truncatedLocal;
-                            return items;
-                        }
-                }
-            }
-        }
-
-        if (requestedStates.Contains("scheduled"))
-        {
-            var total = monitoring.ScheduledCount();
-            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
-            {
-                foreach (var row in monitoring.ScheduledJobs(offset, DefaultJobScanPageSize))
-                {
-                        if (!Add(MapScheduledJob(row)))
-                        {
-                            truncated = truncatedLocal;
-                            return items;
-                        }
-                }
-            }
-        }
-
-        if (requestedStates.Contains("failed"))
-        {
-            var total = monitoring.FailedCount();
-            for (var offset = 0; offset < total; offset += DefaultJobScanPageSize)
-            {
-                foreach (var row in monitoring.FailedJobs(offset, DefaultJobScanPageSize))
-                {
-                        if (!Add(MapFailedJob(row)))
-                        {
-                            truncated = truncatedLocal;
-                            return items;
-                        }
-                }
-            }
-        }
-
-        truncated = truncatedLocal;
-        return items;
-    }
-
-    private IEnumerable<AdminJobListItemDto> ApplyJobFilters(
-        IReadOnlyList<AdminJobListItemDto> jobs,
-        string? queue,
-        string? jobType,
-        string? region,
-        string? query,
-        int? olderThanMinutes,
-        IReadOnlyCollection<string>? queues = null)
-    {
-        var normalizedQueue = string.IsNullOrWhiteSpace(queue) ? null : queue.Trim();
-        var normalizedType = string.IsNullOrWhiteSpace(jobType) ? null : jobType.Trim();
-        var normalizedRegion = string.IsNullOrWhiteSpace(region) ? null : NormalizeRegionKey(region);
-        var normalizedQuery = string.IsNullOrWhiteSpace(query) ? null : query.Trim();
-        var queueSet = queues?
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Select(x => x.Trim())
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var olderThanCutoffUtc = olderThanMinutes.HasValue && olderThanMinutes.Value > 0
-            ? DateTime.UtcNow.AddMinutes(-olderThanMinutes.Value)
-            : (DateTime?)null;
-
-        return jobs.Where(job =>
-        {
-            if (normalizedQueue is not null && !string.Equals(job.Queue, normalizedQueue, StringComparison.OrdinalIgnoreCase))
-                return false;
-            if (queueSet is not null && queueSet.Count > 0 && !queueSet.Contains(job.Queue))
-                return false;
-            if (normalizedType is not null &&
-                !(job.JobType?.Contains(normalizedType, StringComparison.OrdinalIgnoreCase) ?? false))
-                return false;
-            if (normalizedRegion is not null &&
-                !string.Equals(job.Region, normalizedRegion, StringComparison.OrdinalIgnoreCase))
-                return false;
-            if (olderThanCutoffUtc.HasValue &&
-                job.StateChangedAtUtc.HasValue &&
-                job.StateChangedAtUtc.Value > olderThanCutoffUtc.Value)
-                return false;
-            if (normalizedQuery is null)
-                return true;
-
-            var haystack = string.Join(
-                " ",
-                [
-                    job.JobId,
-                    job.State,
-                    job.Queue,
-                    job.JobType ?? string.Empty,
-                    job.JobMethod ?? string.Empty,
-                    job.Region ?? string.Empty,
-                    job.Reason ?? string.Empty,
-                    job.ExceptionType ?? string.Empty,
-                    job.ExceptionMessage ?? string.Empty,
-                    string.Join(" ", job.Arguments)
-                ]);
-            return haystack.Contains(normalizedQuery, StringComparison.OrdinalIgnoreCase);
-        });
-    }
-
-    private AdminJobListItemDto MapEnqueuedJob(string queueName, KeyValuePair<string, EnqueuedJobDto> row)
-    {
-        var dto = row.Value;
-        return new AdminJobListItemDto(
-            JobId: row.Key,
-            State: "Enqueued",
-            Queue: queueName,
-            JobType: dto.Job?.Type?.FullName,
-            JobMethod: dto.Job?.Method?.Name,
-            Region: InferRegion(dto.Job),
-            CreatedAtUtc: null,
-            StateChangedAtUtc: dto.EnqueuedAt,
-            StartedAtUtc: null,
-            ServerId: null,
-            Reason: dto.State,
-            ExceptionType: null,
-            ExceptionMessage: null,
-            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
-    }
-
-    private AdminJobListItemDto MapProcessingJob(KeyValuePair<string, ProcessingJobDto> row)
-    {
-        var dto = row.Value;
-        return new AdminJobListItemDto(
-            JobId: row.Key,
-            State: "Processing",
-            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
-            JobType: dto.Job?.Type?.FullName,
-            JobMethod: dto.Job?.Method?.Name,
-            Region: InferRegion(dto.Job),
-            CreatedAtUtc: null,
-            StateChangedAtUtc: dto.StartedAt,
-            StartedAtUtc: dto.StartedAt,
-            ServerId: dto.ServerId,
-            Reason: null,
-            ExceptionType: null,
-            ExceptionMessage: null,
-            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
-    }
-
-    private AdminJobListItemDto MapScheduledJob(KeyValuePair<string, ScheduledJobDto> row)
-    {
-        var dto = row.Value;
-        return new AdminJobListItemDto(
-            JobId: row.Key,
-            State: "Scheduled",
-            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
-            JobType: dto.Job?.Type?.FullName,
-            JobMethod: dto.Job?.Method?.Name,
-            Region: InferRegion(dto.Job),
-            CreatedAtUtc: null,
-            StateChangedAtUtc: dto.ScheduledAt ?? dto.EnqueueAt,
-            StartedAtUtc: null,
-            ServerId: null,
-            Reason: $"Enqueue at {dto.EnqueueAt:u}",
-            ExceptionType: null,
-            ExceptionMessage: null,
-            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
-    }
-
-    private AdminJobListItemDto MapFailedJob(KeyValuePair<string, FailedJobDto> row)
-    {
-        var dto = row.Value;
-        return new AdminJobListItemDto(
-            JobId: row.Key,
-            State: "Failed",
-            Queue: GetDictionaryValue(dto.StateData, "Queue") ?? "default",
-            JobType: dto.Job?.Type?.FullName,
-            JobMethod: dto.Job?.Method?.Name,
-            Region: InferRegion(dto.Job),
-            CreatedAtUtc: null,
-            StateChangedAtUtc: dto.FailedAt,
-            StartedAtUtc: null,
-            ServerId: GetDictionaryValue(dto.StateData, "ServerId"),
-            Reason: dto.Reason,
-            ExceptionType: dto.ExceptionType,
-            ExceptionMessage: dto.ExceptionMessage,
-            Arguments: dto.Job?.Args?.Select(SafeSerialize).ToList() ?? []);
-    }
-
-    private string? InferRegion(Job? job)
-    {
-        if (job?.Args is null || job.Args.Count == 0)
-            return null;
-
-        var enabledRegions = GetEnabledRegions()
-            .Concat(KnownPlatformRegions)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var arg in job.Args)
-        {
-            if (arg is null)
-                continue;
-
-            if (arg is string raw)
-            {
-                var normalized = NormalizeRegionKey(raw);
-                if (enabledRegions.Contains(normalized))
-                    return normalized;
-
-                foreach (var token in raw.Split([':', '/', '|', ',', ' '], StringSplitOptions.RemoveEmptyEntries))
-                {
-                    normalized = NormalizeRegionKey(token);
-                    if (enabledRegions.Contains(normalized))
-                        return normalized;
-                }
-
-                continue;
-            }
-
-            var asString = arg.ToString();
-            if (string.IsNullOrWhiteSpace(asString))
-                continue;
-
-            var parsed = NormalizeRegionKey(asString);
-            if (enabledRegions.Contains(parsed))
-                return parsed;
-        }
-
-        return null;
-    }
-
-    private static IReadOnlyCollection<string> NormalizeRequestedStates(IReadOnlyCollection<string> states)
-    {
-        return states
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Select(x => x.Trim().ToLowerInvariant())
-            .Where(SupportedListStates.Contains)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-    }
-
-    private static string NormalizeRegionKey(string? region)
-    {
-        return string.IsNullOrWhiteSpace(region) ? "UNKNOWN" : region.Trim().ToUpperInvariant();
-    }
-
-    private static string? GetDictionaryValue(IDictionary<string, string>? data, string key)
-    {
-        return data is not null && data.TryGetValue(key, out var value) ? value : null;
-    }
-
-    private static string? GetDictionaryValue(IReadOnlyDictionary<string, string>? data, string key)
-    {
-        return data is not null && data.TryGetValue(key, out var value) ? value : null;
+        return Ok(lookup.Response);
     }
 
     private async Task WriteAuditAsync(
@@ -1259,419 +366,4 @@ public class AdminOperationsController(
         var value = User.FindFirstValue(claimType);
         return Guid.TryParse(value, out var parsed) ? parsed : null;
     }
-
-    private static string SafeSerialize(object? arg)
-    {
-        if (arg is null)
-            return "null";
-
-        try
-        {
-            return JsonSerializer.Serialize(arg);
-        }
-        catch
-        {
-            return arg.ToString() ?? "<unserializable>";
-        }
-    }
-
-    private static AdminJobStateTransitionDto MapStateTransition(StateHistoryDto state)
-    {
-        var data = state.Data ?? new Dictionary<string, string>(StringComparer.Ordinal);
-        return new AdminJobStateTransitionDto(
-            state.StateName,
-            state.CreatedAt,
-            state.Reason,
-            new Dictionary<string, string>(data, StringComparer.Ordinal));
-    }
-
-    private static IEnumerable<string> ReadMostRecentLines(string path, int maxLines)
-    {
-        if (maxLines <= 0)
-            return [];
-
-        var lines = new List<string>(maxLines);
-        var reversedLineBuffer = new List<byte>(1024);
-        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        if (stream.Length == 0)
-            return lines;
-
-        const int readBufferSize = 4096;
-        var readBuffer = new byte[readBufferSize];
-        var position = stream.Length;
-
-        while (position > 0 && lines.Count < maxLines)
-        {
-            var bytesToRead = (int)Math.Min(readBufferSize, position);
-            position -= bytesToRead;
-            stream.Seek(position, SeekOrigin.Begin);
-            var bytesRead = stream.Read(readBuffer, 0, bytesToRead);
-
-            for (var i = bytesRead - 1; i >= 0 && lines.Count < maxLines; i--)
-            {
-                var current = readBuffer[i];
-                if (current == (byte)'\n')
-                {
-                    AddLineFromReversedBytes(reversedLineBuffer, lines);
-                    continue;
-                }
-
-                reversedLineBuffer.Add(current);
-            }
-        }
-
-        if (lines.Count < maxLines)
-            AddLineFromReversedBytes(reversedLineBuffer, lines);
-
-        return lines;
-    }
-
-    private static void AddLineFromReversedBytes(List<byte> reversedBytes, List<string> lines)
-    {
-        if (reversedBytes.Count == 0)
-            return;
-
-        var lineBytes = reversedBytes.ToArray();
-        Array.Reverse(lineBytes);
-        reversedBytes.Clear();
-
-        var line = Encoding.UTF8.GetString(lineBytes).TrimEnd('\r');
-        if (line.Length > 0)
-            lines.Add(line);
-    }
-
-    private static bool TryParseOperationalLogLine(string line, out AdminServiceLogDto dto)
-    {
-        dto = default!;
-        try
-        {
-            var entry = JsonSerializer.Deserialize<OperationalLogEntry>(line);
-            if (entry is null)
-                return false;
-
-            dto = new AdminServiceLogDto(
-                entry.TimestampUtc,
-                entry.Service,
-                entry.Level,
-                entry.Category,
-                entry.EventId,
-                entry.Message,
-                entry.Exception);
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
-
-    private static bool ContainsSearch(string? value, string search)
-    {
-        return !string.IsNullOrWhiteSpace(value) &&
-               value.Contains(search, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private string? ResolveOperationalLogDirectory(string serviceKey)
-    {
-        var sourceSpecificDirectory = configuration[$"AdminLogs:Sources:{serviceKey}:DirectoryPath"];
-        if (!string.IsNullOrWhiteSpace(sourceSpecificDirectory))
-            return sourceSpecificDirectory.Trim();
-
-        var sharedDirectory = configuration["OperationalLogs:DirectoryPath"];
-        if (!string.IsNullOrWhiteSpace(sharedDirectory))
-            return sharedDirectory.Trim();
-
-        return string.Equals(serviceKey, "webapi", StringComparison.OrdinalIgnoreCase)
-            ? Path.Combine(AppContext.BaseDirectory, "logs")
-            : null;
-    }
-
-    private static IEnumerable<string> GetOperationalLogFiles(string directory, string serviceKey)
-    {
-        if (!Directory.Exists(directory))
-            yield break;
-
-        var candidates = Directory.EnumerateFiles(directory, $"{serviceKey}.log*")
-            .Select(path => new
-            {
-                Path = path,
-                SortOrder = GetLogFileSortOrder(path, serviceKey)
-            })
-            .Where(x => x.SortOrder.HasValue)
-            .OrderBy(x => x.SortOrder!.Value)
-            .Select(x => x.Path);
-
-        foreach (var candidate in candidates)
-            yield return candidate;
-    }
-
-    private static int? GetLogFileSortOrder(string path, string serviceKey)
-    {
-        var fileName = Path.GetFileName(path);
-        var liveName = $"{serviceKey}.log";
-        if (string.Equals(fileName, liveName, StringComparison.OrdinalIgnoreCase))
-            return 0;
-
-        var prefix = $"{liveName}.";
-        if (!fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
-            return null;
-
-        return int.TryParse(fileName[prefix.Length..], out var parsedSuffix)
-            ? parsedSuffix
-            : null;
-    }
-
-    private sealed record RegionMatchAggregate(
-        string Region,
-        long Total,
-        long Successful,
-        long TemporaryFailure,
-        long Unfetched,
-        long PermanentlyUnfetchable,
-        long OutsideRetention,
-        long RankedSuccessful,
-        DateTime? LatestSuccessfulFetchUtc);
-
-    private sealed record RegionTimelineAggregate(
-        string Region,
-        long Successful,
-        long Pending,
-        long TemporaryFailure,
-        long PermanentFailure,
-        long NotApplicable);
 }
-
-public record AdminOverviewResponse(
-    DateTime GeneratedAtUtc,
-    bool DatabaseConnected,
-    long Enqueued,
-    long Processing,
-    long Scheduled,
-    long Failed,
-    long Succeeded,
-    long Recurring,
-    long Deleted,
-    int EffectiveConcurrency,
-    IReadOnlyList<AdminServerSnapshot> Servers,
-    IReadOnlyList<AdminQueueSnapshot> Queues
-);
-
-public record AdminServerSnapshot(
-    string Name,
-    int WorkersCount,
-    DateTime StartedAtUtc,
-    DateTime? HeartbeatUtc,
-    IReadOnlyList<string> Queues
-);
-
-public record AdminQueueSnapshot(string Name, long Length, long? Fetched);
-
-public record AdminAnalysisMetricsResponse(
-    DateTime GeneratedAtUtc,
-    string? ActivePatchVersion,
-    DateTime? ActivePatchReleasedAtUtc,
-    AdminAnalysisSummaryDto Summary,
-    IReadOnlyList<AdminAnalysisRegionMetricsDto> Regions
-);
-
-public record AdminAnalysisSummaryDto(
-    long Summoners,
-    long Matches,
-    long CurrentPatchSuccessfulMatches,
-    long CurrentPatchRankedMatches,
-    double TimelineCoverageRatio,
-    int ActiveRefreshLocks,
-    int ExpiredRefreshLocks,
-    long TrackedProSummoners
-);
-
-public record AdminAnalysisRegionMetricsDto(
-    string Region,
-    bool Enabled,
-    long Summoners,
-    long CurrentPatchTotalMatches,
-    long CurrentPatchSuccessfulMatches,
-    long CurrentPatchTemporaryFailures,
-    long CurrentPatchUnfetchedMatches,
-    long CurrentPatchPermanentlyUnfetchableMatches,
-    long CurrentPatchOutsideRetentionMatches,
-    long RankedCurrentPatchMatches,
-    DateTime? LatestSuccessfulFetchUtc,
-    long TimelineSuccessfulMatches,
-    long TimelinePendingMatches,
-    long TimelineTemporaryFailures,
-    long TimelinePermanentFailures,
-    long TrackedProSummoners,
-    long EnqueuedJobs,
-    long ProcessingJobs,
-    long ScheduledJobs,
-    string Health
-);
-
-public record AdminRecurringJobDto(
-    string Id,
-    string Queue,
-    string Cron,
-    DateTime? NextExecution,
-    DateTime? LastExecution,
-    string? LastJobId,
-    string? LastJobState,
-    string? Error,
-    bool IsPresentInStorage,
-    bool IsEnabledByConfiguration,
-    bool IsPaused,
-    bool IsPausable
-);
-
-public record AdminJobGroupDto(
-    string State,
-    string Queue,
-    string? JobType,
-    string? JobMethod,
-    string? Region,
-    long Count,
-    DateTime? OldestSeenAtUtc,
-    DateTime? NewestSeenAtUtc
-);
-
-public record AdminQueueSummaryResponse(
-    DateTime GeneratedAtUtc,
-    bool Truncated,
-    int ScanLimit,
-    IReadOnlyList<AdminQueueSnapshot> Queues,
-    IReadOnlyList<AdminJobGroupDto> TopGroups
-);
-
-public record AdminJobListItemDto(
-    string JobId,
-    string State,
-    string Queue,
-    string? JobType,
-    string? JobMethod,
-    string? Region,
-    DateTime? CreatedAtUtc,
-    DateTime? StateChangedAtUtc,
-    DateTime? StartedAtUtc,
-    string? ServerId,
-    string? Reason,
-    string? ExceptionType,
-    string? ExceptionMessage,
-    IReadOnlyList<string> Arguments
-);
-
-public record AdminJobListResponse(
-    DateTime GeneratedAtUtc,
-    int From,
-    int Count,
-    int TotalMatched,
-    bool Truncated,
-    int ScanLimit,
-    IReadOnlyList<AdminJobListItemDto> Items
-);
-
-public record AdminFailedJobDto(
-    string JobId,
-    string? Reason,
-    string? ExceptionType,
-    string? ExceptionMessage,
-    DateTime? FailedAt
-);
-
-public record AdminJobDetailDto(
-    string JobId,
-    string? CurrentState,
-    string Queue,
-    string? JobType,
-    string? JobMethod,
-    IReadOnlyList<string> Arguments,
-    string? Region,
-    DateTime? CreatedAtUtc,
-    DateTime? EnqueuedAtUtc,
-    DateTime? ScheduledAtUtc,
-    DateTime? StartedAtUtc,
-    DateTime? StateChangedAtUtc,
-    DateTime? FailedAtUtc,
-    DateTime? DeletedAtUtc,
-    string? ServerId,
-    string? Reason,
-    string? ExceptionType,
-    string? ExceptionMessage,
-    string? ExceptionDetails,
-    int FailedCount,
-    IReadOnlyList<AdminJobStateTransitionDto> States,
-    IReadOnlyDictionary<string, string> Properties
-);
-
-public record AdminJobStateTransitionDto(
-    string StateName,
-    DateTime CreatedAtUtc,
-    string? Reason,
-    IReadOnlyDictionary<string, string> Data
-);
-
-public record AdminDeleteJobRequest(string? ExpectedState, string? Reason);
-
-public sealed class AdminDeleteJobResultDto
-{
-    [Required]
-    public string JobId { get; init; } = string.Empty;
-
-    public bool Deleted { get; init; }
-
-    public string? ExpectedState { get; init; }
-
-    public string? CurrentState { get; init; }
-
-    [Required]
-    public string Message { get; init; } = string.Empty;
-}
-
-public record AdminBulkDeleteJobsRequest(
-    IReadOnlyList<string>? States,
-    IReadOnlyList<string>? Queues,
-    string? JobType,
-    string? Region,
-    string? Query,
-    int? OlderThanMinutes,
-    int? Limit,
-    int? ScanLimit,
-    bool DryRun
-);
-
-public record AdminBulkDeleteJobsResultDto(
-    bool DryRun,
-    bool Truncated,
-    int Matched,
-    int Deleted,
-    int Failed,
-    IReadOnlyList<string> SampleJobIds
-);
-
-public record AdminServiceLogDto(
-    DateTime TimestampUtc,
-    string Service,
-    string Level,
-    string Category,
-    int EventId,
-    string? Message,
-    string? Exception
-);
-
-public record AdminLogSourceDto(
-    string Service,
-    bool Available,
-    int FilesScanned,
-    DateTime? LatestTimestampUtc,
-    bool Truncated
-);
-
-public record AdminServiceLogsResponse(
-    AdminLogSourceDto Source,
-    IReadOnlyList<AdminServiceLogDto> Items
-);
-
-public record AdminBacklogRegionAggregate(
-    long Enqueued,
-    long Processing,
-    long Scheduled
-);

--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -217,6 +217,7 @@ builder.Services.Configure<WorkerJobScheduleOptions>(builder.Configuration.GetSe
 builder.Services.Configure<WorkerSchedulingProfileOptions>(builder.Configuration.GetSection("Jobs:SchedulingProfiles"));
 builder.Services.Configure<AdminBootstrapOptions>(builder.Configuration.GetSection("Auth:AdminBootstrap"));
 builder.Services.AddSingleton<IWorkerRecurringJobPolicy, WorkerRecurringJobPolicy>();
+builder.Services.AddAdminOperationsFacades();
 builder.Services.AddSingleton<IAdaptiveThroughputBudgetPolicy, AdaptiveThroughputBudgetPolicy>();
 builder.Services.AddSingleton<IStarvationGuardrailPolicy, StarvationGuardrailPolicy>();
 

--- a/tests/Transcendence.WebAPI.Tests/AdminOperationsControllerTests.cs
+++ b/tests/Transcendence.WebAPI.Tests/AdminOperationsControllerTests.cs
@@ -13,6 +13,7 @@ using Moq;
 using Transcendence.Data;
 using Transcendence.Data.Models.LoL.Match;
 using Transcendence.Data.Models.LoL.Static;
+using Transcendence.Service.Core.Services.Admin.Implementations;
 using Transcendence.Service.Core.Services.Analytics.Interfaces;
 using Transcendence.Service.Core.Services.Auth.Interfaces;
 using Transcendence.Service.Core.Services.Diagnostics;
@@ -354,24 +355,35 @@ public class AdminOperationsControllerTests
             .Build();
 
         var recurringPolicy = new WorkerRecurringJobPolicy(Options.Create(new WorkerSchedulingProfileOptions()));
+        var workerScheduleOptions = Options.Create(new WorkerJobScheduleOptions());
+        var ingestionOptions = Options.Create(new ChampionAnalyticsIngestionJobOptions());
+        var multiRegionOptions = Options.Create(new MultiRegionIngestionOptions
+        {
+            Enabled = true,
+            Regions =
+            [
+                new() { Region = "NA1", Enabled = true },
+                new() { Region = "EUW1", Enabled = true }
+            ]
+        });
+
+        var jobsFacade = new AdminJobsFacade(
+            storage.Object,
+            workerScheduleOptions,
+            multiRegionOptions,
+            Mock.Of<IRecurringJobManager>(),
+            recurringPolicy);
+        var overviewFacade = new AdminOverviewFacade(
+            storage.Object,
+            ingestionOptions,
+            multiRegionOptions,
+            db);
+        var logsFacade = new AdminLogsFacade(configuration);
 
         return new AdminOperationsController(
-            storage.Object,
-            configuration,
-            Options.Create(new WorkerJobScheduleOptions()),
-            Options.Create(new ChampionAnalyticsIngestionJobOptions()),
-            Options.Create(new MultiRegionIngestionOptions
-            {
-                Enabled = true,
-                Regions =
-                [
-                    new() { Region = "NA1", Enabled = true },
-                    new() { Region = "EUW1", Enabled = true }
-                ]
-            }),
-            Mock.Of<IRecurringJobManager>(),
-            recurringPolicy,
-            db,
+            jobsFacade,
+            overviewFacade,
+            logsFacade,
             Mock.Of<IChampionAnalyticsService>(),
             Mock.Of<IAdminAuditService>())
         {


### PR DESCRIPTION
## Summary

Decomposes the 1677-line `AdminOperationsController` into a **thin** controller (validate request -> call facade -> record audit event -> map to `IActionResult`/ProblemDetails) backed by three new facade services in `Transcendence.Service.Core`. Closes the admin half of roadmap item **P10.1**.

The controller drops from **1677 -> 369 lines** and its primary-ctor deps shrink from 10 to 5 (the 3 facades + `IChampionAnalyticsService` + `IAdminAuditService`).

## The 3 facades

- **`IAdminJobsFacade` / `AdminJobsFacade`** — all `jobs/*` logic: recurring list + trigger/pause/resume, queues, list, failed, `inspect/{id}`, `failed/{id}`, retry, `inspect/{id}/delete`, bulk-delete. Owns `JobStorage`, `IRecurringJobManager`, `IWorkerRecurringJobPolicy`, `WorkerJobScheduleOptions`, `MultiRegionIngestionOptions` and the jobs-only consts/sets. Returns result/DTO records (not `IActionResult`) so the controller keeps HTTP-status mapping + audit recording. Validation/NotFound/BadRequest paths are surfaced via small discriminated result records (`AdminMutationResult`, `AdminJobListLookup`, `AdminResumeValidation`, `AdminDeleteJobOutcome`, `AdminBulkDeleteJobsOutcome`).
- **`IAdminOverviewFacade` / `AdminOverviewFacade`** — `overview` + `metrics/analysis`. Owns the EF context, ingestion/multi-region options and `JobStorage` (for the per-region backlog snapshot).
- **`IAdminLogsFacade` / `AdminLogsFacade`** — `logs/services` tail. Owns `IConfiguration` + the allowed service-log keys.

## Placement & DI

Facades placed in **`Transcendence.Service.Core/Services/Admin/`** — Service.Core already references `Hangfire.Core` (1.8.22, same version as WebAPI), so `JobStorage`, `IRecurringJobManager`, `Hangfire.Storage.Monitoring.*`, `BackgroundJob`/`RecurringJob` all resolve there; no new package ref needed. The admin DTO contracts moved into Service.Core but **stay in the `Transcendence.WebAPI.Controllers` namespace** so the public OpenAPI schema names and the controller call sites are unchanged.

Registered via a new `AddAdminOperationsFacades()` in `ServiceCollectionExtensions.cs`, called from the WebAPI host — deliberately kept **out of `AddTranscendenceCore`** so that method's Hangfire-free DI-validation test (`ServiceCollectionExtensionsTests`) stays green.

`cache/invalidate` and `audit-log` stay thin (direct `analyticsService`/`adminAuditService` calls); mutating-op audit recording stays cross-cutting in the controller.

## Behavior preservation

Routes, request validation, response shapes/DTOs, status codes, NotFound/BadRequest paths and audit-event metadata are byte-for-byte equivalent. Logic moved verbatim. Gated by `AdminOperationsControllerTests` (its `BuildController` helper now constructs the real facades; assertions untouched).

## Validation

- `dotnet build Transcendence.sln` -> 0 errors, only baseline warnings (migrations CS8981, Program.cs CS0618/ASPDEPR005).
- WebAPI tests: **40/40 pass** (incl. all 5 admin tests).
- Service.Core tests: **183/183 pass**.
- OpenAPI spec unchanged (no admin route/return-type/DTO change; all admin paths + DTO schemas verified identical to the committed `openapi/transcendence.v1.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)