### PR TITLE
feat(infra): auto-apply pending EF migrations on startup (Database:AutoMigrate)

### DIFF
--- a/Transcendence.Service.Core/Services/Database/DatabaseMigrator.cs
+++ b/Transcendence.Service.Core/Services/Database/DatabaseMigrator.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Transcendence.Data;
+
+namespace Transcendence.Service.Core.Services.Database;
+
+/// <summary>
+/// Applies pending EF Core migrations at startup when <c>Database:AutoMigrate</c> is enabled, so a deploy
+/// brings the schema up to date without a manual <c>dotnet ef database update</c> (the gap that previously
+/// 500'd analytics after a migration-bearing release).
+/// <para>
+/// EF Core 9+ acquires a database-wide migration lock for the whole apply, so this is safe to call from BOTH
+/// hosts on a simultaneous deploy: whichever acquires the lock first applies the migrations; the other waits,
+/// then finds nothing pending. Disabled by default; the OpenAPI export host (which boots against a throwaway
+/// connection just to dump swagger) force-disables it via <c>--Database:AutoMigrate=false</c>.
+/// </para>
+/// </summary>
+public static class DatabaseMigrator
+{
+    public static async Task MigrateIfEnabledAsync(
+        IServiceProvider services, bool enabled, ILogger logger, CancellationToken ct = default)
+    {
+        if (!enabled)
+            return;
+
+        await using var scope = services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<TranscendenceContext>();
+
+        var pending = (await db.Database.GetPendingMigrationsAsync(ct)).ToList();
+        if (pending.Count == 0)
+        {
+            logger.LogInformation("AutoMigrate enabled: database schema already up to date.");
+            return;
+        }
+
+        logger.LogInformation(
+            "AutoMigrate enabled: applying {Count} pending migration(s): {Migrations}",
+            pending.Count, string.Join(", ", pending));
+        await db.Database.MigrateAsync(ct);
+        logger.LogInformation("AutoMigrate: applied {Count} migration(s).", pending.Count);
+    }
+}

--- a/Transcendence.Service/Program.cs
+++ b/Transcendence.Service/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration.Json;
 using Transcendence.Data;
 using Transcendence.Data.Extensions;
 using Transcendence.Service.Core.Services.Analytics.Models;
+using Transcendence.Service.Core.Services.Database;
 using Transcendence.Service.Core.Services.Diagnostics;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -202,6 +203,14 @@ builder.Services.Configure<TftAnalyticsComputeOptions>(builder.Configuration.Get
 builder.Services.AddProjectSyndraRepositories();
 
 var host = builder.Build();
+
+// Apply pending EF migrations before the worker starts (gated by Database:AutoMigrate). EF Core's migration
+// lock makes this safe even though the WebAPI host runs the same step on a simultaneous deploy.
+await DatabaseMigrator.MigrateIfEnabledAsync(
+    host.Services,
+    builder.Configuration.GetValue("Database:AutoMigrate", false),
+    host.Services.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(DatabaseMigrator)));
+
 host.Run();
 
 static void ConfigureSharedBackendConfiguration(ConfigurationManager configuration, IHostEnvironment environment)

--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -25,6 +25,7 @@ using Transcendence.Service.Core.Services.Auth.Implementations;
 using Transcendence.Service.Core.Services.Auth.Interfaces;
 using Transcendence.Service.Core.Services.Auth.Models;
 using Transcendence.Service.Core.Services.Analytics.Models;
+using Transcendence.Service.Core.Services.Database;
 using Transcendence.Service.Core.Services.Diagnostics;
 using Transcendence.Service.Core.Services.Extensions;
 using Transcendence.Service.Core.Services.Jobs.Configuration;
@@ -342,6 +343,13 @@ using (var scope = app.Services.CreateScope())
     else
         bootstrapLogger.LogInformation("Admin bootstrap: no new grants.");
 }
+
+// Apply pending EF migrations before serving (gated by Database:AutoMigrate). EF Core's migration lock makes
+// this safe even though the worker host runs the same step on a simultaneous deploy.
+await DatabaseMigrator.MigrateIfEnabledAsync(
+    app.Services,
+    builder.Configuration.GetValue("Database:AutoMigrate", false),
+    app.Services.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(DatabaseMigrator)));
 
 app.Run();
 

--- a/config/backend.shared.json
+++ b/config/backend.shared.json
@@ -3,6 +3,9 @@
     "MainDatabase": "Host=localhost;Port=5432;Database=transcendence;Username=postgres;Password=changme",
     "Redis": "localhost:6379"
   },
+  "Database": {
+    "AutoMigrate": true
+  },
   "RiotApi": {
     "League": {
       "ApiKey": "RGAPI-00000000-0000-0000-0000-000000000000"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -232,7 +232,7 @@ The discovery lane stalls when all workers park on a few long, non-stoppable job
 
 ### Deployment & rollback
 
-The stack ships continuously: a push to `main` triggers the `Docker Images` workflow, which builds and pushes the changed component images to GHCR tagged both `:main` (the moving tag) and `:sha-<short>` (immutable, one per commit). On the prod host (`root@192.168.0.221`) **wud** (what's-up-docker, polling each minute) detects the new `:main` digest and recreates the affected container, so a merge is live within a few minutes. Prod never auto-applies EF migrations.
+The stack ships continuously: a push to `main` triggers the `Docker Images` workflow, which builds and pushes the changed component images to GHCR tagged both `:main` (the moving tag) and `:sha-<short>` (immutable, one per commit). On the prod host (`root@192.168.0.221`) **wud** (what's-up-docker, polling each minute) detects the new `:main` digest and recreates the affected container, so a merge is live within a few minutes. On startup both hosts apply any pending EF migrations (`Database:AutoMigrate`, enabled in `config/backend.shared.json`); EF Core's migration lock makes the two hosts migrating concurrently safe, so a migration-bearing deploy no longer needs a manual `dotnet ef database update`. Hot-table index migrations remain the exception and must be applied out-of-band before the deploy (see DEVELOPMENT.md).
 
 **Rollback (break-glass).** Because every build also publishes an immutable `:sha-<short>` tag, rolling back is re-pointing the stack at a known-good commit instead of reverting and waiting for a rebuild:
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -150,6 +150,11 @@ Migration policy:
 - Generate migrations only via EF CLI (for example: `dotnet ef migrations add <Name> --project Transcendence.Service --startup-project Transcendence.Service`).
 - **Hot-table index/DDL is applied out-of-band, not via `database update`** — see the recipe below. CI (the migration-safety check) fails a PR that adds a non-concurrent `CreateIndex` or a defaulted `AddColumn` on `Summoners` / `Matches` / `MatchParticipants` / `MatchParticipantTimelineSnapshots` and points back here.
 
+Automatic migrations on startup (`Database:AutoMigrate`):
+- Both hosts apply pending migrations on startup when `Database:AutoMigrate` is `true` (set in `config/backend.shared.json`, so it ships baked into the image). EF Core 9+ takes a database-wide migration lock, so the WebAPI and worker applying concurrently on the same deploy is safe — one applies, the other finds nothing pending. This removes the manual post-deploy `dotnet ef database update` step that a migration-bearing release used to require.
+- Locally, `dotnet run` with the shared config also auto-migrates your dev DB, so the manual `database update` above is optional; override with `Database:AutoMigrate=false` (user-secrets / `appsettings.Development.json`) if you want manual control. The OpenAPI export host force-disables it (`--Database:AutoMigrate=false`) since it boots against a throwaway connection.
+- **Hot-table index migrations are the exception** — auto-migrate would run them as a blocking `CREATE INDEX`. Apply them via the out-of-band recipe below (create the index concurrently, then record the migration in `__EFMigrationsHistory`) **before** the deploy so the migration is already applied and auto-migrate skips it. The migration-safety CI gate failing your PR is the signal to use the recipe.
+
 #### Applying index migrations to hot tables
 
 `Summoners` (~4M+ rows), `Matches`, `MatchParticipants`, and `MatchParticipantTimelineSnapshots` (~22.5M rows) are large and continuously written by ingestion. EF's generated `CreateIndex` emits a plain `CREATE INDEX`, which holds a `SHARE` lock for the entire build and blocks ingestion writes for its duration. **Do not** apply such a migration with `dotnet ef database update`. Split the apply instead:

--- a/scripts/openapi/export.sh
+++ b/scripts/openapi/export.sh
@@ -44,6 +44,8 @@ APP_ARGS=(
   "--ConnectionStrings:Redis=$ConnectionStrings__Redis"
   "--Auth:Jwt:Key=$Auth__Jwt__Key"
   "--Swagger:Enable=$Swagger__Enable"
+  # The export only boots the API to dump swagger against a throwaway connection — never migrate.
+  "--Database:AutoMigrate=false"
 )
 
 SWAGGER_URL="${SWAGGER_URL:-http://127.0.0.1:5057/swagger/v1/swagger.json}"


### PR DESCRIPTION
## Why

Prod has no auto-migrate, so a migration-bearing release deploys the new code against the **old schema** and 500s until the migration is applied by hand — exactly what happened after #106 added `ChampionScopeGradeStats` (`relation … does not exist`). The containers stay "healthy", so it's silent until you hit the surface.

## What

An opt-in startup migrator.

- `DatabaseMigrator.MigrateIfEnabledAsync` runs `Database.MigrateAsync()` when `Database:AutoMigrate` is set; called from **both** hosts after `Build()`, before they serve.
- **Concurrency-safe:** EF Core 9+ takes a database-wide migration lock for the whole apply, so the WebAPI + worker migrating on a simultaneous deploy is safe — one applies, the other finds nothing pending (confirmed via EF Core docs).
- Enabled in `config/backend.shared.json` (baked into the image → reaches prod via wud).
- The **OpenAPI export** host force-disables it (`--Database:AutoMigrate=false`) since it boots against a throwaway connection just to dump swagger.
- Default `false`. The test suite doesn't boot the host, so it's unaffected. This PR adds **no migration**, so on deploy it'll find prod already up to date (no-op).
- **Hot-table index migrations** still follow the out-of-band recipe (the migration-safety gate enforces it), so auto-migrate never runs a blocking `CREATE INDEX`.

## Verification

- Service.Core **196/196** · WebAPI **40/40** · migration-safety green (no new migration).
- Solution build clean; OpenAPI export still succeeds with auto-migrate guarded off (no contract drift).

Docs updated: `DEVELOPMENT.md` (migration section) + `ARCHITECTURE.md` (deploy). Removes the manual post-deploy `dotnet ef database update` step for additive migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)