### PR TITLE
feat(web): hide low-sample champions in the tier list by default

### DIFF
--- a/apps/web/app/lol/champions/page.tsx
+++ b/apps/web/app/lol/champions/page.tsx
@@ -67,7 +67,7 @@ export default async function ChampionsPage({
   // Build a map of championId -> best tier/role/winRate from the tier list
   const tierMap = new Map<
     number,
-    { tier: UITierGrade; role: string; winRate: number; games: number }
+    { tier: UITierGrade | null; role: string; winRate: number; games: number }
   >();
 
   if (tierListRes.ok && tierListRes.body) {
@@ -77,7 +77,8 @@ export default async function ChampionsPage({
       // Keep the entry with the most games (most relevant role)
       if (!existing || entry.games > existing.games) {
         tierMap.set(entry.championId, {
-          tier: entry.tier,
+          // Low-sample champions are below the games floor — show their win rate but no (misleading) grade.
+          tier: entry.isLowSample ? null : entry.tier,
           role: entry.role,
           winRate: entry.winRate,
           games: entry.games

--- a/apps/web/components/TierListTable.tsx
+++ b/apps/web/components/TierListTable.tsx
@@ -100,6 +100,7 @@ export function TierListTable({
   const [sortCol, setSortCol] = useState<SortColumn>("rank");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [focusTier, setFocusTier] = useState<TierListFocusTier>("ALL");
+  const [showLowSample, setShowLowSample] = useState(false);
   const [activeTierSection, setActiveTierSection] = useState<UITierGrade>("S");
   const sectionRefs = useRef<Record<UITierGrade, HTMLElement | null>>({
     S: null,
@@ -109,9 +110,18 @@ export function TierListTable({
     D: null
   });
 
+  const lowSampleCount = useMemo(() => entries.filter((entry) => entry.isLowSample).length, [entries]);
+
+  // Hide low-sample champions by default. On thin / early-patch data most champion-role cells fall below the
+  // games floor (capped at B) and bury the few with real signal; the toggle reveals them.
+  const baseEntries = useMemo(
+    () => (showLowSample ? entries : entries.filter((entry) => !entry.isLowSample)),
+    [entries, showLowSample]
+  );
+
   const entriesWithRank = useMemo<RowEntry[]>(
-    () => entries.map((entry, index) => ({ ...entry, rank: index + 1 })),
-    [entries]
+    () => baseEntries.map((entry, index) => ({ ...entry, rank: index + 1 })),
+    [baseEntries]
   );
 
   const filteredEntries = useMemo(
@@ -404,6 +414,18 @@ export function TierListTable({
               Avg WR {formatPercent(summary.averageWinRate, { decimals: 2 })}
             </span>
           ) : null}
+          {lowSampleCount > 0 ? (
+            <Button
+              variant={showLowSample ? "outline" : "ghost"}
+              size="sm"
+              onClick={() => setShowLowSample((value) => !value)}
+              className="ml-1 h-8 px-3"
+              aria-pressed={showLowSample}
+              title="Low-sample champions are below the games floor (capped at B) — hidden by default"
+            >
+              {showLowSample ? "Hide" : "Show"} low-sample ({lowSampleCount})
+            </Button>
+          ) : null}
           <Button
             variant={sortCol === "contestedScore" ? "outline" : "ghost"}
             size="sm"
@@ -424,11 +446,25 @@ export function TierListTable({
 
       {summary.visibleCount === 0 ? (
         <Card className="grid gap-3 p-6">
-          <p className="type-section text-fg">No champions match this view.</p>
-          <p className="type-ui text-muted">Reset the board to bring every tier back into the table.</p>
-          <Button variant="outline" size="sm" onClick={resetView} className="w-fit">
-            Reset board view
-          </Button>
+          {!showLowSample && lowSampleCount > 0 ? (
+            <>
+              <p className="type-section text-fg">Every champion in this view is low-sample.</p>
+              <p className="type-ui text-muted">
+                Not enough games yet for a confident grade. Show them (capped at B) or pick a wider scope.
+              </p>
+              <Button variant="outline" size="sm" onClick={() => setShowLowSample(true)} className="w-fit">
+                Show {lowSampleCount} low-sample
+              </Button>
+            </>
+          ) : (
+            <>
+              <p className="type-section text-fg">No champions match this view.</p>
+              <p className="type-ui text-muted">Reset the board to bring every tier back into the table.</p>
+              <Button variant="outline" size="sm" onClick={resetView} className="w-fit">
+                Reset board view
+              </Button>
+            </>
+          )}
         </Card>
       ) : (
         <div className={cn("grid gap-4", showTierRail ? "xl:grid-cols-[180px_minmax(0,1fr)]" : "")}>

--- a/apps/web/lib/tierlist.test.ts
+++ b/apps/web/lib/tierlist.test.ts
@@ -93,7 +93,8 @@ describe("normalizeTierListEntries", () => {
         movement: "UP",
         previousTier: "A",
         strengthScore: 0.032,
-        contestedScore: 0.21
+        contestedScore: 0.21,
+        isLowSample: false
       }
     ]);
   });
@@ -123,7 +124,8 @@ describe("normalizeTierListEntries", () => {
         movement: "DOWN",
         previousTier: "S",
         strengthScore: 0,
-        contestedScore: 0
+        contestedScore: 0,
+        isLowSample: false
       }
     ]);
   });

--- a/apps/web/lib/tierlist.ts
+++ b/apps/web/lib/tierlist.ts
@@ -15,6 +15,7 @@ export type UITierListEntry = {
   previousTier: UITierGrade | null;
   strengthScore: number;
   contestedScore: number;
+  isLowSample: boolean;
 };
 
 // The champion's grade for a specific (role, scope) — the SAME grade the tier list shows. Decoded from the
@@ -138,7 +139,8 @@ export function normalizeTierListEntries(
       movement: decodeTierMovement(raw.movement),
       previousTier: decodeTierGrade(raw.previousTier),
       strengthScore: asFiniteNumber(raw.strengthScore, 0),
-      contestedScore: asFiniteNumber(raw.contestedScore, 0)
+      contestedScore: asFiniteNumber(raw.contestedScore, 0),
+      isLowSample: raw.isLowSample === true
     });
   }
 


### PR DESCRIPTION
## Why

The tiering data shows the "everything is B" clutter is a **presentation** problem, not a methodology one. On the current patch (16.13, ~5 days old / Maturing), the live Emerald+ numbers are:

- median **~63 games** per champion-role cell
- **~71%** of cells are below the 500-game floor → capped at `B` / `isLowSample`
- the few real S/A are well-sampled champions (~2,000 games) buried under the low-sample long tail

The empirical-Bayes shrinkage is working correctly — there's no cutoff to recalibrate yet (that needs a steadier, higher-volume patch). The fast win is to stop showing the unreliable entries by default.

## What

- **Tier list:** hide `isLowSample` champions by default behind a **"Show low-sample (N)"** toggle. The empty state offers to reveal them when an entire view is low-sample. Ranks/summary/pills reflect the visible set.
- **Champions grid:** low-sample champions render as **unrated** (win rate kept, no misleading `B` badge) instead of a confident grade.
- Threads `isLowSample` through `UITierListEntry` + `normalizeTierListEntries`.

Frontend-only — **no contract or migration change**. Independent of (and complementary to) any future `Analytics:Tiering:*` calibration.

## Verification

web **114/114** · lint clean (`max-warnings=0`) · `web:build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)