### PR TITLE
feat(web): confidence layer, post-game insights, and additive build pick-rate

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildComputeService.cs
@@ -236,7 +236,8 @@ public sealed class ChampionBuildComputeService : IChampionBuildComputeService
             build.RuneInfo.SubRunes,
             build.RuneInfo.StatShards,
             build.Games,
-            build.WinRate
+            build.WinRate,
+            totalGames > 0 ? (double)build.Games / totalGames : 0
         )).ToList();
 
         // Sectioned, timing-aware build path (spells, skill order, starters, boots, ordered core

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildPathBuilder.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionBuildPathBuilder.cs
@@ -200,7 +200,7 @@ internal sealed class ChampionBuildPathBuilder
             .Where(s => s.Spell1Id > 0 && s.Spell2Id > 0)
             .Select(s => new { s.Win, Lo = Math.Min(s.Spell1Id, s.Spell2Id), Hi = Math.Max(s.Spell1Id, s.Spell2Id) })
             .GroupBy(s => new { s.Lo, s.Hi })
-            .Select(g => new SummonerSpellPairDto(g.Key.Lo, g.Key.Hi, g.Count(), (double)g.Count(x => x.Win) / g.Count()))
+            .Select(g => new SummonerSpellPairDto(g.Key.Lo, g.Key.Hi, g.Count(), (double)g.Count(x => x.Win) / g.Count(), (double)g.Count() / samples.Count))
             .Where(p => p.Games >= minGames)
             .OrderByDescending(p => p.Games)
             .ThenByDescending(p => p.WinRate)
@@ -225,7 +225,8 @@ internal sealed class ChampionBuildPathBuilder
                 dominantFirstThree,
                 dominantMax.Key,
                 dominantMax.Count(),
-                (double)dominantMax.Count(x => x.Win) / dominantMax.Count());
+                (double)dominantMax.Count(x => x.Win) / dominantMax.Count(),
+                (double)dominantMax.Count() / skillSamples.Count);
         }
 
         var startingItems = samples
@@ -243,7 +244,7 @@ internal sealed class ChampionBuildPathBuilder
             })
             .Where(x => x.Set.Count > 0)
             .GroupBy(x => string.Join(",", x.Set))
-            .Select(g => new StarterItemSetDto(g.First().Set, g.Count(), (double)g.Count(x => x.Win) / g.Count()))
+            .Select(g => new StarterItemSetDto(g.First().Set, g.Count(), (double)g.Count(x => x.Win) / g.Count(), coveredCount > 0 ? (double)g.Count() / coveredCount : 0))
             .Where(x => x.Games >= purchaseMinGames)
             .OrderByDescending(x => x.Games)
             .ThenByDescending(x => x.WinRate)
@@ -262,7 +263,7 @@ internal sealed class ChampionBuildPathBuilder
             })
             .Where(x => x.BootId.HasValue)
             .GroupBy(x => x.BootId!.Value)
-            .Select(g => new ItemChoiceDto(g.Key, g.Count(), (double)g.Count(x => x.Win) / g.Count()))
+            .Select(g => new ItemChoiceDto(g.Key, g.Count(), (double)g.Count(x => x.Win) / g.Count(), coveredCount > 0 ? (double)g.Count() / coveredCount : 0))
             .Where(x => x.Games >= purchaseMinGames)
             .OrderByDescending(x => x.Games)
             .ThenByDescending(x => x.WinRate)
@@ -317,7 +318,8 @@ internal sealed class ChampionBuildPathBuilder
                 pick.ItemId,
                 pick.Games,
                 (double)pick.Wins / pick.Games,
-                pick.SumMinutes / pick.Games));
+                pick.SumMinutes / pick.Games,
+                coveredCount > 0 ? (double)pick.Games / coveredCount : 0));
         }
 
         var situationalSlots = new List<SituationalSlotDto>();
@@ -331,7 +333,7 @@ internal sealed class ChampionBuildPathBuilder
                 .OrderByDescending(kvp => kvp.Value.Games)
                 .ThenByDescending(kvp => (double)kvp.Value.Wins / kvp.Value.Games)
                 .Take(4)
-                .Select(kvp => new ItemChoiceDto(kvp.Key, kvp.Value.Games, (double)kvp.Value.Wins / kvp.Value.Games))
+                .Select(kvp => new ItemChoiceDto(kvp.Key, kvp.Value.Games, (double)kvp.Value.Wins / kvp.Value.Games, coveredCount > 0 ? (double)kvp.Value.Games / coveredCount : 0))
                 .ToList();
 
             if (options.Count > 0)

--- a/Transcendence.Service.Core/Services/Analytics/Models/ChampionBuildDto.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/ChampionBuildDto.cs
@@ -13,7 +13,8 @@ public record ChampionBuildDto(
     List<int> SubRunes,           // 2 runes from sub tree
     List<int> StatShards,         // 3 stat shards
     int Games,                    // Number of games with this exact build
-    double WinRate                // Win rate for this build (0.0 to 1.0)
+    double WinRate,               // Win rate for this build (0.0 to 1.0)
+    double PickRate = 0           // Share of all scoped games on this exact build (0.0 to 1.0)
 );
 
 /// <summary>
@@ -23,7 +24,8 @@ public record SummonerSpellPairDto(
     int Spell1Id,
     int Spell2Id,
     int Games,
-    double WinRate
+    double WinRate,
+    double PickRate = 0
 );
 
 /// <summary>
@@ -32,7 +34,8 @@ public record SummonerSpellPairDto(
 public record StarterItemSetDto(
     List<int> Items,
     int Games,
-    double WinRate
+    double WinRate,
+    double PickRate = 0
 );
 
 /// <summary>
@@ -41,7 +44,8 @@ public record StarterItemSetDto(
 public record ItemChoiceDto(
     int ItemId,
     int Games,
-    double WinRate
+    double WinRate,
+    double PickRate = 0
 );
 
 /// <summary>
@@ -51,7 +55,8 @@ public record CoreItemStepDto(
     int ItemId,
     int Games,
     double WinRate,
-    double AvgCompletionMinute
+    double AvgCompletionMinute,
+    double PickRate = 0
 );
 
 /// <summary>
@@ -135,5 +140,6 @@ public record SkillOrderDto(
     string FirstThree,            // e.g., "QWE" or "QEW"
     string MaxOrder,              // e.g., "Q>E>W"
     int Games = 0,
-    double WinRate = 0
+    double WinRate = 0,
+    double PickRate = 0
 );

--- a/apps/web/app/lol/champions/[championId]/page.tsx
+++ b/apps/web/app/lol/champions/[championId]/page.tsx
@@ -8,6 +8,7 @@ import { AnalyticsSampleBanner } from "@/components/AnalyticsSampleBanner";
 import { BuildBreakdown } from "@/components/BuildBreakdown";
 import { ChampionPortrait } from "@/components/ChampionPortrait";
 import { FilterBar } from "@/components/FilterBar";
+import { MatchupsTable, type MatchupRow } from "@/components/MatchupsTable";
 import { ItemBuildDisplay } from "@/components/ItemBuildDisplay";
 import { RuneTreeDisplay } from "@/components/RuneTreeDisplay";
 import { StatsBar } from "@/components/StatsBar";
@@ -17,6 +18,7 @@ import { WinRateText } from "@/components/WinRateText";
 import { Card } from "@/components/ui/Card";
 import { DataBar } from "@/components/ui/DataBar";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { fetchBackendJson } from "@/lib/backendCall";
 import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { pickMostSevereAnalyticsSample, type AnalyticsSampleLike } from "@/lib/analyticsSample";
@@ -33,6 +35,7 @@ import {
   fetchRunesReforged,
   fetchSummonerSpellMap
 } from "@/lib/staticData";
+import { formatEbStory } from "@/lib/confidence";
 import { decodeGrade, formatStrengthDelta } from "@/lib/tierlist";
 
 type ChampionWinRateDto = components["schemas"]["ChampionWinRateDto"];
@@ -262,18 +265,28 @@ async function ChampionHeroMeta({
     <>
       <div className="flex flex-wrap items-center gap-2">
         {heroTier ? (
-          <span className="flex items-center gap-2">
-            <TierBadge tier={heroTier} size="md" />
-            {heroGrade ? (
-              <span
-                className="type-tabular tabular-nums text-xs text-muted"
-                title="Win rate vs the role average — the value the tier is based on"
-              >
-                {formatStrengthDelta(heroGrade.strengthScore)}
-                {heroGrade.isLowSample ? " · low sample" : ""}
+          heroGrade ? (
+            <Tooltip
+              content={formatEbStory({
+                winRate: heroGrade.winRate,
+                roleBaseline: heroGrade.roleBaseline,
+                strengthScore: heroGrade.strengthScore,
+                games: heroGrade.games
+              })}
+            >
+              <span className="flex items-center gap-2">
+                <TierBadge tier={heroTier} size="md" />
+                <span className="type-tabular tabular-nums text-xs text-muted">
+                  {formatStrengthDelta(heroGrade.strengthScore)}
+                  {heroGrade.isLowSample ? " · low sample" : ""}
+                </span>
               </span>
-            ) : null}
-          </span>
+            </Tooltip>
+          ) : (
+            <span className="flex items-center gap-2">
+              <TierBadge tier={heroTier} size="md" />
+            </span>
+          )
         ) : (
           <span className="rounded-control border border-border/60 px-2 py-1 text-xs font-medium text-muted">
             Unrated
@@ -410,25 +423,28 @@ async function ChampionSections({
   const globalCoreItems = builds?.globalCoreItems ?? [];
   const counters = matchups?.counters ?? [];
   const favorableMatchups = matchups?.favorableMatchups ?? [];
-  const matchupSortKey = searchParams.sort === "games" ? "games" : "winRate";
+  // Confidence threshold for build variants (omit -> Confidence falls back to DEFAULT_MIN_GAMES).
+  const buildMinGames = builds?.sample?.minimumRecommendedSampleSize;
   const allMatchups = [...counters, ...favorableMatchups]
     .filter((m): m is MatchupEntryDto => Boolean(m?.opponentChampionId))
     .filter(
       (entry, idx, rows) =>
         rows.findIndex((candidate) => candidate.opponentChampionId === entry.opponentChampionId) === idx
     )
-    .sort((a, b) =>
-      matchupSortKey === "games"
-        ? (b.games ?? 0) - (a.games ?? 0)
-        : (a.winRate ?? 0) - (b.winRate ?? 0)
-    );
-  const buildMatchupSortHref = (sort: string) => {
-    const sortParams = new URLSearchParams({ role: effectiveRole, sort });
-    if (normalizedRankTier) sortParams.set("rankTier", normalizedRankTier);
-    if (activeRegion !== "ALL") sortParams.set("region", activeRegion);
-    if (selectedPatch) sortParams.set("patch", selectedPatch);
-    return `/lol/champions/${championId}?${sortParams.toString()}#matchups`;
-  };
+    // Default order: toughest first (ascending win rate). The table re-sorts client-side from here.
+    .sort((a, b) => (a.winRate ?? 0) - (b.winRate ?? 0));
+  const matchupRows: MatchupRow[] = allMatchups.map((entry) => {
+    const opponentId = entry.opponentChampionId ?? 0;
+    const opponent = champions[String(opponentId)];
+    return {
+      opponentChampionId: opponentId,
+      winRate: entry.winRate ?? null,
+      games: entry.games ?? null,
+      opponentSlug: opponent?.id ?? "Unknown",
+      opponentName: opponent?.name ?? `Champion ${opponentId}`,
+      verdict: matchupVerdict(entry.winRate)
+    };
+  });
   const linkParams = new URLSearchParams();
   if (normalizedRankTier) linkParams.set("rankTier", normalizedRankTier);
   if (activeRegion !== "ALL") linkParams.set("region", activeRegion);
@@ -518,6 +534,7 @@ async function ChampionSections({
                 items={items}
                 spellVersion={spellStatic.version}
                 spells={spellStatic.spells}
+                minGames={buildMinGames}
               />
 
               {/* Global Core Items */}
@@ -624,9 +641,7 @@ async function ChampionSections({
                               className="min-w-0"
                             />
                           </Link>
-                          <span className="shrink-0">
-                            <DataBar value={m.winRate} decimals={1} />
-                          </span>
+                          <DataBar value={m.winRate} decimals={1} games={m.games} className="shrink-0 justify-end" />
                         </li>
                       );
                     })}
@@ -669,9 +684,7 @@ async function ChampionSections({
                               className="min-w-0"
                             />
                           </Link>
-                          <span className="shrink-0">
-                            <DataBar value={m.winRate} decimals={1} />
-                          </span>
+                          <DataBar value={m.winRate} decimals={1} games={m.games} className="shrink-0 justify-end" />
                         </li>
                       );
                     })}
@@ -685,90 +698,13 @@ async function ChampionSections({
 
       {/* ── All Matchups (full table) ── */}
       <Card className="p-5" id="matchups">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <h2 className="type-section">All Matchups</h2>
-            <p className="mt-1 text-xs text-muted">
-              Lane matchups for {champName} as {roleDisplayLabel(effectiveRole)}
-            </p>
-          </div>
-          <div className="flex items-center gap-2 text-xs">
-            <Link
-              href={buildMatchupSortHref("winRate")}
-              scroll={false}
-              className="control-tab type-ui px-3 py-2"
-              data-active={matchupSortKey === "winRate"}
-            >
-              Sort by Win Rate
-            </Link>
-            <Link
-              href={buildMatchupSortHref("games")}
-              scroll={false}
-              className="control-tab type-ui px-3 py-2"
-              data-active={matchupSortKey === "games"}
-            >
-              Sort by Games
-            </Link>
-          </div>
-        </div>
-        <div className="mt-4 overflow-x-auto">
-          <table className="w-full min-w-[640px] text-left text-sm">
-            <thead className="type-overline text-muted">
-              <tr className="border-b border-border/30">
-                <th className="py-2 pr-4">Opponent</th>
-                <th className="py-2 pr-4 text-right">Win Rate</th>
-                <th className="py-2 pr-4 text-right">Games</th>
-                <th className="py-2 pr-4 text-right">Verdict</th>
-              </tr>
-            </thead>
-            <tbody>
-              {allMatchups.length === 0 ? (
-                <tr>
-                  <td colSpan={4} className="py-4 text-sm text-muted">
-                    No matchup data is available for the selected filters yet.
-                  </td>
-                </tr>
-              ) : (
-                allMatchups.map((entry, idx) => {
-                  const opponentId = entry.opponentChampionId ?? 0;
-                  const opponent = champions[String(opponentId)];
-                  const verdict = matchupVerdict(entry.winRate);
-                  const verdictClass =
-                    verdict === "Favored"
-                      ? "text-win"
-                      : verdict === "Unfavored"
-                        ? "text-loss"
-                        : "text-muted";
-                  return (
-                    <tr key={`${opponentId}-${idx}`} className="border-b border-border/40 transition hover:bg-surface-2/40">
-                      <td className="py-2.5 pr-4">
-                        <Link
-                          href={`/lol/champions/${opponentId}${linkQuery ? `?${linkQuery}` : ""}`}
-                          className="hover:underline"
-                        >
-                          <ChampionPortrait
-                            championSlug={opponent?.id ?? "Unknown"}
-                            championName={opponent?.name ?? `Champion ${opponentId}`}
-                            version={version}
-                            size={24}
-                            showName
-                          />
-                        </Link>
-                      </td>
-                      <td className="py-2.5 pr-4 text-right">
-                        <DataBar value={entry.winRate} decimals={1} className="justify-end" />
-                      </td>
-                      <td className="type-tabular py-2.5 pr-4 text-right tabular-nums text-fg/70">
-                        {formatGames(entry.games)}
-                      </td>
-                      <td className={`py-2.5 pr-4 text-right font-medium ${verdictClass}`}>{verdict}</td>
-                    </tr>
-                  );
-                })
-              )}
-            </tbody>
-          </table>
-        </div>
+        <MatchupsTable
+          title="All Matchups"
+          subtitle={`Lane matchups for ${champName} as ${roleDisplayLabel(effectiveRole)}`}
+          rows={matchupRows}
+          version={version}
+          linkQuery={linkQuery}
+        />
       </Card>
     </>
   );

--- a/apps/web/app/lol/tierlist/page.tsx
+++ b/apps/web/app/lol/tierlist/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/analyticsRegionFallback";
 import { fetchBackendJson } from "@/lib/backendCall";
 import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
-import { type AnalyticsSampleLike } from "@/lib/analyticsSample";
+import { normalizeAnalyticsSample, type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { GLOBAL_ANALYTICS_REGION } from "@/lib/analyticsRegionShared";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
@@ -115,6 +115,25 @@ export default async function TierListPage({
       ? tierlist.rankTier
       : null;
 
+  const sample = (tierlist as { sample?: unknown } | null)?.sample as AnalyticsSampleLike;
+  // The per-row "Stable" threshold for the confidence layer: the patch sample's
+  // recommended games floor. Undefined when no sample (confidence falls back to its default).
+  const minGames = normalizeAnalyticsSample(sample)?.minimumRecommendedSampleSize;
+
+  // roleBaseline (the role-average win rate) rides the wire on each TierListEntry but is
+  // dropped by normalizeTierListEntries; re-attach it by (champion, role) so the EB trust
+  // hover can name the role average without re-fetching.
+  const roleBaselineByKey = new Map<string, number>();
+  for (const raw of tierlist.entries ?? []) {
+    if (typeof raw.championId !== "number" || typeof raw.roleBaseline !== "number") continue;
+    const role = typeof raw.role === "string" && raw.role ? raw.role.toUpperCase() : "ALL";
+    roleBaselineByKey.set(`${raw.championId}-${role}`, raw.roleBaseline);
+  }
+  const entriesWithBaseline = normalizedEntries.map((entry) => ({
+    ...entry,
+    roleBaseline: roleBaselineByKey.get(`${entry.championId}-${entry.role.toUpperCase()}`) ?? 0
+  }));
+
   return (
     <div className="grid gap-4">
       <Toolbar
@@ -156,17 +175,22 @@ export default async function TierListPage({
       />
 
       {fallbackMessage ? <p className="type-ui px-1 text-muted">{fallbackMessage}</p> : null}
+
+      {/* Single freshness readout that stays docked below the header while the table scrolls. */}
       <AnalyticsSampleBanner
-        sample={(tierlist as { sample?: unknown } | null)?.sample as AnalyticsSampleLike}
+        sample={sample}
+        variant="strip"
+        className="sticky top-24 z-30 rounded-lg border border-border bg-surface/92 px-3 py-2 shadow-soft backdrop-blur-md"
       />
 
       <TierListTable
-        entries={normalizedEntries}
+        entries={entriesWithBaseline}
         champions={champions}
         version={version}
         rankTierValue={rankTierValue}
         activeRegion={effectiveRegion}
         activePatch={selectedPatch}
+        minGames={minGames}
       />
     </div>
   );

--- a/apps/web/components/AnalyticsSampleBanner.tsx
+++ b/apps/web/components/AnalyticsSampleBanner.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
+import { cn } from "@/lib/cn";
 import {
   analyticsSampleCoveragePercent,
   analyticsSampleShortfall,
@@ -9,9 +10,20 @@ import {
 
 type AnalyticsSampleBannerProps = {
   sample: AnalyticsSampleLike;
+  /**
+   * "card" (default) is the full Card readout. "strip" is a condensed single-line
+   * row of the same badges + chips, for a page to dock/stick above its content.
+   */
+  variant?: "card" | "strip";
+  /** Passthrough so the page can position the banner (e.g. sticky), unset by default. */
+  className?: string;
 };
 
-export function AnalyticsSampleBanner({ sample }: AnalyticsSampleBannerProps) {
+export function AnalyticsSampleBanner({
+  sample,
+  variant = "card",
+  className
+}: AnalyticsSampleBannerProps) {
   const normalized = normalizeAnalyticsSample(sample);
   if (!normalized) return null;
 
@@ -55,8 +67,33 @@ export function AnalyticsSampleBanner({ sample }: AnalyticsSampleBannerProps) {
           ? "Patch maturing"
           : "Patch stable";
 
+  const chips = (
+    <>
+      <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
+        {normalized.sampleSize} games
+      </span>
+      <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
+        {patchAgeLabel}
+      </span>
+      <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
+        {coverage}% of target
+      </span>
+    </>
+  );
+
+  if (variant === "strip") {
+    return (
+      <div className={cn("flex flex-wrap items-center gap-2", className)}>
+        <Badge className={tone.badge}>{tone.kicker}</Badge>
+        <Badge>{phaseLabel}</Badge>
+        <span className="hidden type-ui text-fg/75 sm:inline">{tone.summary}</span>
+        <div className="ml-auto flex flex-wrap items-center gap-2">{chips}</div>
+      </div>
+    );
+  }
+
   return (
-    <Card className={`overflow-hidden px-4 py-3 md:px-4 md:py-3.5 ${tone.card}`}>
+    <Card className={cn("overflow-hidden px-4 py-3 md:px-4 md:py-3.5", tone.card, className)}>
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
@@ -66,17 +103,7 @@ export function AnalyticsSampleBanner({ sample }: AnalyticsSampleBannerProps) {
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
-            {normalized.sampleSize} games
-          </span>
-          <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
-            {patchAgeLabel}
-          </span>
-          <span className="surface-chip rounded-full px-3 py-1.5 text-xs text-fg/72">
-            {coverage}% of target
-          </span>
-        </div>
+        <div className="flex flex-wrap items-center gap-2">{chips}</div>
       </div>
     </Card>
   );

--- a/apps/web/components/BuildBreakdown.tsx
+++ b/apps/web/components/BuildBreakdown.tsx
@@ -4,6 +4,7 @@ import type { components } from "@transcendence/api-client";
 
 import { cn } from "@/lib/cn";
 import { WinRateText } from "@/components/WinRateText";
+import { Confidence } from "@/components/ui/Confidence";
 import { itemIconUrl, summonerSpellIconUrl } from "@/lib/staticData";
 
 type SummonerSpellPairDto = components["schemas"]["SummonerSpellPairDto"];
@@ -160,6 +161,7 @@ export function BuildBreakdown({
   items,
   spellVersion,
   spells,
+  minGames,
   className
 }: {
   summonerSpells?: SummonerSpellPairDto[] | null;
@@ -172,6 +174,8 @@ export function BuildBreakdown({
   items: ItemMap;
   spellVersion: string;
   spells: SpellMap;
+  /** Sample-size threshold for the per-variant confidence pips (falls back to the default). */
+  minGames?: number;
   className?: string;
 }) {
   const spellPairs = summonerSpells ?? [];
@@ -210,7 +214,10 @@ export function BuildBreakdown({
                     version={spellVersion}
                     spells={spells}
                   />
-                  <WinRateText value={pair.winRate} games={pair.games} className="text-xs" />
+                  <span className="flex items-center gap-1.5">
+                    <WinRateText value={pair.winRate} games={pair.games} pickRate={pair.pickRate} className="text-xs" />
+                    {pair.games != null ? <Confidence games={pair.games} minGames={minGames} /> : null}
+                  </span>
                 </div>
               ))}
             </div>
@@ -229,11 +236,17 @@ export function BuildBreakdown({
                   </Fragment>
                 ))}
                 {skillOrder?.winRate != null ? (
-                  <WinRateText
-                    value={skillOrder.winRate}
-                    games={skillOrder.games}
-                    className="ml-1 text-xs"
-                  />
+                  <>
+                    <WinRateText
+                      value={skillOrder.winRate}
+                      games={skillOrder.games}
+                      pickRate={skillOrder.pickRate}
+                      className="ml-1 text-xs"
+                    />
+                    {skillOrder.games != null ? (
+                      <Confidence games={skillOrder.games} minGames={minGames} />
+                    ) : null}
+                  </>
                 ) : null}
               </div>
               {firstThreeLetters.length > 0 ? (
@@ -264,7 +277,10 @@ export function BuildBreakdown({
                       />
                     ))}
                   </div>
-                  <WinRateText value={set.winRate} games={set.games} className="text-xs" />
+                  <span className="flex items-center gap-1.5">
+                    <WinRateText value={set.winRate} games={set.games} pickRate={set.pickRate} className="text-xs" />
+                    {set.games != null ? <Confidence games={set.games} minGames={minGames} /> : null}
+                  </span>
                 </div>
               ))}
             </div>
@@ -277,7 +293,10 @@ export function BuildBreakdown({
               {bootOptions.slice(0, 3).map((boot, idx) => (
                 <div key={idx} className="flex items-center justify-between gap-2">
                   <ItemIcon itemId={boot.itemId ?? 0} version={itemVersion} items={items} size={26} />
-                  <WinRateText value={boot.winRate} games={boot.games} className="text-xs" />
+                  <span className="flex items-center gap-1.5">
+                    <WinRateText value={boot.winRate} games={boot.games} pickRate={boot.pickRate} className="text-xs" />
+                    {boot.games != null ? <Confidence games={boot.games} minGames={minGames} /> : null}
+                  </span>
                 </div>
               ))}
             </div>
@@ -328,6 +347,7 @@ export function BuildBreakdown({
                       <WinRateText
                         value={option.winRate}
                         games={option.games}
+                        pickRate={option.pickRate}
                         className="text-[11px]"
                       />
                     </div>

--- a/apps/web/components/LiveGameCard.tsx
+++ b/apps/web/components/LiveGameCard.tsx
@@ -1,17 +1,169 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { cn } from "@/lib/cn";
+import { formatDurationSeconds, formatPercent, winRateColorClass } from "@/lib/format";
+import { rankTierColorClass } from "@/lib/ranks";
+import { championSquareIconUrlById } from "@/lib/staticData";
+import type { components } from "@transcendence/api-client";
 
-type LiveGameResponseDto = {
-  state?: string;
-  message?: string;
-  requestId?: string;
-  detail?: string;
-  [k: string]: unknown;
-};
+type LiveGameResponse = components["schemas"]["LiveGameResponseDto"];
+type LiveGameParticipant = components["schemas"]["LiveGameParticipantDto"];
+type LiveGameParticipantAnalysis = components["schemas"]["LiveGameParticipantAnalysisDto"];
+type TeamAnalysis = components["schemas"]["TeamAnalysisDto"];
+
+// The BFF error envelope carries message/requestId, which the success DTO lacks.
+type LiveGameErrorFields = { message?: string | null; requestId?: string | null };
+
+const TEAMS: ReadonlyArray<{ id: number; label: string }> = [
+  { id: 100, label: "Blue Side" },
+  { id: 200, label: "Red Side" }
+];
+
+function titleCaseTier(value: string | null | undefined): string {
+  if (!value) return "";
+  return value.charAt(0).toUpperCase() + value.slice(1).toLowerCase();
+}
+
+function formatRankLabel(analysis: LiveGameParticipantAnalysis | undefined): string {
+  if (!analysis?.rankTier) return "Unranked";
+  const tier = titleCaseTier(analysis.rankTier);
+  const division = analysis.rankDivision ? ` ${analysis.rankDivision}` : "";
+  const lp = analysis.leaguePoints != null ? ` · ${analysis.leaguePoints} LP` : "";
+  return `${tier}${division}${lp}`;
+}
+
+function ScoutChip({ tone, children }: { tone: "success" | "warning"; children: string }) {
+  return (
+    <span
+      className={cn(
+        "rounded-control px-2 py-0.5 text-[11px] leading-tight",
+        tone === "success" ? "bg-success/10 text-success" : "bg-warning/10 text-warning"
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ParticipantRow({
+  participant,
+  analysis
+}: {
+  participant: LiveGameParticipant;
+  analysis: LiveGameParticipantAnalysis | undefined;
+}) {
+  const name = participant.riotId?.trim() || "Unknown player";
+  const recentWinRate = analysis?.recentWinRate;
+
+  return (
+    <li className="flex items-center gap-3 rounded-control border border-border bg-surface-2 px-2.5 py-2">
+      {participant.championId != null ? (
+        <Image
+          src={championSquareIconUrlById(participant.championId)}
+          alt={`Champion ${participant.championId}`}
+          width={36}
+          height={36}
+          className="size-9 shrink-0 rounded-control border border-border bg-surface"
+        />
+      ) : (
+        <span className="grid size-9 shrink-0 place-items-center rounded-control border border-border bg-surface text-[11px] font-medium text-muted">
+          ?
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="type-ui truncate text-fg">{name}</p>
+        <p className={cn("text-xs leading-tight", rankTierColorClass(analysis?.rankTier))}>
+          {formatRankLabel(analysis)}
+        </p>
+      </div>
+      {recentWinRate != null ? (
+        <div className="shrink-0 text-right">
+          <p className={cn("text-sm font-medium tabular-nums", winRateColorClass(recentWinRate))}>
+            {formatPercent(recentWinRate, { decimals: 0 })}
+          </p>
+          <p className="text-[10px] uppercase tracking-wide text-muted">recent WR</p>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function TeamBlock({
+  label,
+  participants,
+  analysisByPuuid,
+  teamAnalysis
+}: {
+  label: string;
+  participants: LiveGameParticipant[];
+  analysisByPuuid: Map<string, LiveGameParticipantAnalysis>;
+  teamAnalysis: TeamAnalysis | undefined;
+}) {
+  const strengths = teamAnalysis?.strengths ?? [];
+  const weaknesses = teamAnalysis?.weaknesses ?? [];
+
+  return (
+    <section className="rounded-card border border-border bg-surface p-3">
+      <div className="flex items-baseline justify-between gap-2">
+        <h4 className="type-ui font-medium text-fg">{label}</h4>
+        {teamAnalysis?.estimatedWinProbability != null ? (
+          <span className="text-xs text-muted">
+            Win prob{" "}
+            <span
+              className={cn(
+                "font-medium tabular-nums",
+                winRateColorClass(teamAnalysis.estimatedWinProbability)
+              )}
+            >
+              {formatPercent(teamAnalysis.estimatedWinProbability)}
+            </span>
+          </span>
+        ) : null}
+      </div>
+
+      {teamAnalysis?.averageRecentWinRate != null ? (
+        <p className="mt-1 text-xs text-muted">
+          Avg recent WR{" "}
+          <span
+            className={cn("tabular-nums", winRateColorClass(teamAnalysis.averageRecentWinRate))}
+          >
+            {formatPercent(teamAnalysis.averageRecentWinRate)}
+          </span>
+        </p>
+      ) : null}
+
+      {strengths.length > 0 || weaknesses.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {strengths.map((item, index) => (
+            <ScoutChip key={`s-${index}-${item}`} tone="success">
+              {item}
+            </ScoutChip>
+          ))}
+          {weaknesses.map((item, index) => (
+            <ScoutChip key={`w-${index}-${item}`} tone="warning">
+              {item}
+            </ScoutChip>
+          ))}
+        </div>
+      ) : null}
+
+      <ul className="mt-3 flex flex-col gap-1.5">
+        {participants.map((participant, index) => (
+          <ParticipantRow
+            key={participant.puuid ?? `${participant.championId ?? "?"}-${index}`}
+            participant={participant}
+            analysis={participant.puuid ? analysisByPuuid.get(participant.puuid) : undefined}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
 
 export function LiveGameCard({
   region,
@@ -23,7 +175,8 @@ export function LiveGameCard({
   tagLine: string;
 }) {
   const [busy, setBusy] = useState(false);
-  const [data, setData] = useState<LiveGameResponseDto | null>(null);
+  const [checked, setChecked] = useState(false);
+  const [data, setData] = useState<LiveGameResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function check() {
@@ -37,11 +190,11 @@ export function LiveGameCard({
         { cache: "no-store" }
       );
 
-      const json = (await res.json().catch(() => null)) as LiveGameResponseDto | null;
+      const json = (await res.json().catch(() => null)) as
+        | (LiveGameResponse & LiveGameErrorFields)
+        | null;
       if (!res.ok) {
-        const msg =
-          (json?.message as string | undefined) ??
-          `Live game request failed (${res.status}).`;
+        const msg = json?.message ?? `Live game request failed (${res.status}).`;
         const rid = json?.requestId ? ` Request ID: ${json.requestId}` : "";
         setError(`${msg}${rid}`);
         return;
@@ -52,16 +205,32 @@ export function LiveGameCard({
       setError(e instanceof Error ? e.message : "Live game error.");
     } finally {
       setBusy(false);
+      setChecked(true);
     }
   }
+
+  const participants = data?.participants ?? [];
+  const inGame = data?.state === "IN_PROGRESS" || participants.length > 0;
+
+  const analysisByPuuid = new Map<string, LiveGameParticipantAnalysis>();
+  for (const entry of data?.analysis?.participants ?? []) {
+    if (entry.puuid) analysisByPuuid.set(entry.puuid, entry);
+  }
+
+  const teamAnalysisById = new Map<number, TeamAnalysis>();
+  for (const team of data?.analysis?.teams ?? []) {
+    if (team.teamId != null) teamAnalysisById.set(team.teamId, team);
+  }
+
+  const metaParts = [data?.queueType, data?.map].filter(
+    (part): part is string => Boolean(part && part.trim())
+  );
 
   return (
     <Card className="p-5">
       <div className="flex items-center justify-between">
         <div>
-          <h3 className="type-section">
-            Live Game
-          </h3>
+          <h3 className="type-section">Live Game</h3>
           <p className="type-ui mt-2 text-fg/75">
             Check whether this player is currently in a game.
           </p>
@@ -73,16 +242,51 @@ export function LiveGameCard({
 
       {error ? <p className="type-ui mt-3 text-danger">{error}</p> : null}
 
-      {data ? (
-        <pre className="mt-4 max-h-[360px] overflow-auto rounded-lg border border-border/60 bg-surface-2/70 p-3 text-xs text-fg/85">
-          {JSON.stringify(data, null, 2)}
-        </pre>
-      ) : (
-        <p className="type-ui mt-4 text-muted">
-          No live game data loaded yet.
-        </p>
-      )}
+      {!error && checked ? (
+        inGame ? (
+          <div className="mt-4">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <span className="inline-flex items-center gap-1.5 type-ui text-fg">
+                <span className="relative flex size-2">
+                  <span className="absolute inline-flex size-2 animate-ping rounded-full bg-success/60 motion-reduce:hidden" />
+                  <span className="relative inline-flex size-2 rounded-full bg-success" />
+                </span>
+                Live
+              </span>
+              {metaParts.map((part) => (
+                <span key={part} className="type-ui text-fg/80">
+                  <span className="mr-3 text-muted">{"·"}</span>
+                  {part}
+                </span>
+              ))}
+              <span className="text-muted">{"·"}</span>
+              <span className="type-ui tabular-nums text-fg/80">
+                {formatDurationSeconds(data?.gameLengthSeconds)}
+              </span>
+            </div>
+
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              {TEAMS.map((team) => {
+                const teamParticipants = participants.filter((p) => p.teamId === team.id);
+                if (teamParticipants.length === 0) return null;
+                return (
+                  <TeamBlock
+                    key={team.id}
+                    label={team.label}
+                    participants={teamParticipants}
+                    analysisByPuuid={analysisByPuuid}
+                    teamAnalysis={teamAnalysisById.get(team.id)}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <p className="type-ui mt-4 text-muted">Not currently in a game.</p>
+        )
+      ) : !error ? (
+        <p className="type-ui mt-4 text-muted">No live game data loaded yet.</p>
+      ) : null}
     </Card>
   );
 }
-

--- a/apps/web/components/MatchupsTable.tsx
+++ b/apps/web/components/MatchupsTable.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+import { ChampionPortrait } from "@/components/ChampionPortrait";
+import { DataBar } from "@/components/ui/DataBar";
+import { formatGames } from "@/lib/format";
+
+export type MatchupRow = {
+  opponentChampionId: number;
+  winRate: number | null;
+  games: number | null;
+  opponentSlug: string;
+  opponentName: string;
+  verdict: string;
+};
+
+type SortKey = "winRate" | "games";
+
+// Client island for the full matchup table: sorting happens in-memory on the rows
+// already streamed with the page, so toggling Win Rate / Games is instant with no
+// navigation or refetch. Opponent slug/name/verdict are resolved server-side and
+// passed in, so this stays a thin presentational sorter.
+export function MatchupsTable({
+  title,
+  subtitle,
+  rows,
+  version,
+  linkQuery
+}: {
+  title: string;
+  subtitle: string;
+  rows: MatchupRow[];
+  version: string;
+  linkQuery: string;
+}) {
+  const [sortKey, setSortKey] = useState<SortKey>("winRate");
+
+  const sorted = [...rows].sort((a, b) =>
+    sortKey === "games"
+      ? (b.games ?? 0) - (a.games ?? 0)
+      : (a.winRate ?? 0) - (b.winRate ?? 0)
+  );
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="type-section">{title}</h2>
+          <p className="mt-1 text-xs text-muted">{subtitle}</p>
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <button
+            type="button"
+            onClick={() => setSortKey("winRate")}
+            className="control-tab type-ui px-3 py-2"
+            data-active={sortKey === "winRate"}
+          >
+            Sort by Win Rate
+          </button>
+          <button
+            type="button"
+            onClick={() => setSortKey("games")}
+            className="control-tab type-ui px-3 py-2"
+            data-active={sortKey === "games"}
+          >
+            Sort by Games
+          </button>
+        </div>
+      </div>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full min-w-[640px] text-left text-sm">
+          <thead className="type-overline text-muted">
+            <tr className="border-b border-border/30">
+              <th className="py-2 pr-4">Opponent</th>
+              <th className="py-2 pr-4 text-right">Win Rate</th>
+              <th className="py-2 pr-4 text-right">Games</th>
+              <th className="py-2 pr-4 text-right">Verdict</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="py-4 text-sm text-muted">
+                  No matchup data is available for the selected filters yet.
+                </td>
+              </tr>
+            ) : (
+              sorted.map((entry) => {
+                const verdictClass =
+                  entry.verdict === "Favored"
+                    ? "text-win"
+                    : entry.verdict === "Unfavored"
+                      ? "text-loss"
+                      : "text-muted";
+                return (
+                  <tr
+                    key={entry.opponentChampionId}
+                    className="border-b border-border/40 transition hover:bg-surface-2/40"
+                  >
+                    <td className="py-2.5 pr-4">
+                      <Link
+                        href={`/lol/champions/${entry.opponentChampionId}${linkQuery ? `?${linkQuery}` : ""}`}
+                        className="hover:underline"
+                      >
+                        <ChampionPortrait
+                          championSlug={entry.opponentSlug}
+                          championName={entry.opponentName}
+                          version={version}
+                          size={24}
+                          showName
+                        />
+                      </Link>
+                    </td>
+                    <td className="py-2.5 pr-4 text-right">
+                      <DataBar
+                        value={entry.winRate}
+                        decimals={1}
+                        games={entry.games ?? undefined}
+                        className="justify-end"
+                      />
+                    </td>
+                    <td className="type-tabular py-2.5 pr-4 text-right tabular-nums text-fg/70">
+                      {formatGames(entry.games)}
+                    </td>
+                    <td className={`py-2.5 pr-4 text-right font-medium ${verdictClass}`}>
+                      {entry.verdict}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useReducedMotion } from "framer-motion";
 
 import { MatchHistorySection } from "@/components/lol-profile/MatchHistorySection";
+import { PerformanceCard } from "@/components/lol-profile/PerformanceCard";
 import { ProfileHeroCard } from "@/components/lol-profile/ProfileHeroCard";
 import { ProfileSidebar } from "@/components/lol-profile/ProfileSidebar";
 import {
@@ -468,46 +469,53 @@ export function SummonerProfileClient({
             gameName={gameName}
             tagLine={tagLine}
           />
-          <MatchHistorySection
-            region={region}
-            gameName={gameName}
-            tagLine={tagLine}
-            summonerId={profile.summonerId ?? ""}
-            page={page}
-            queue={queue}
-            championFilter={championFilter}
-            sort={sort}
-            history={history}
-            historyBusy={historyBusy}
-            historyError={historyError}
-            visibleMatches={visibleMatches}
-            queueOptions={queueOptions}
-            championOptions={championOptions}
-            sortOptions={sortOptions}
-            expandedMatchId={expandedMatchId}
-            details={details}
-            detailBusy={detailBusy}
-            championStatic={championStatic}
-            itemStatic={itemStatic}
-            spellStatic={spellStatic}
-            runeStatic={runeStatic}
-            prefersReducedMotion={Boolean(prefersReducedMotion)}
-            onQueueChange={(value) => {
-              setQueue(value);
-              setPage(1);
-            }}
-            onChampionFilterChange={(value) => {
-              setChampionFilter(value);
-              setPage(1);
-            }}
-            onSortChange={(value) => {
-              setSort(value);
-              setPage(1);
-            }}
-            onToggleExpanded={toggleExpanded}
-            onPreviousPage={() => setPage((current) => Math.max(1, current - 1))}
-            onNextPage={() => setPage((current) => current + 1)}
-          />
+          <div className="grid gap-6">
+            <PerformanceCard
+              matches={history?.items ?? []}
+              overviewStats={profile.overviewStats}
+              topChampions={profile.topChampions}
+            />
+            <MatchHistorySection
+              region={region}
+              gameName={gameName}
+              tagLine={tagLine}
+              summonerId={profile.summonerId ?? ""}
+              page={page}
+              queue={queue}
+              championFilter={championFilter}
+              sort={sort}
+              history={history}
+              historyBusy={historyBusy}
+              historyError={historyError}
+              visibleMatches={visibleMatches}
+              queueOptions={queueOptions}
+              championOptions={championOptions}
+              sortOptions={sortOptions}
+              expandedMatchId={expandedMatchId}
+              details={details}
+              detailBusy={detailBusy}
+              championStatic={championStatic}
+              itemStatic={itemStatic}
+              spellStatic={spellStatic}
+              runeStatic={runeStatic}
+              prefersReducedMotion={Boolean(prefersReducedMotion)}
+              onQueueChange={(value) => {
+                setQueue(value);
+                setPage(1);
+              }}
+              onChampionFilterChange={(value) => {
+                setChampionFilter(value);
+                setPage(1);
+              }}
+              onSortChange={(value) => {
+                setSort(value);
+                setPage(1);
+              }}
+              onToggleExpanded={toggleExpanded}
+              onPreviousPage={() => setPage((current) => Math.max(1, current - 1))}
+              onNextPage={() => setPage((current) => current + 1)}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/components/TierListTable.tsx
+++ b/apps/web/components/TierListTable.tsx
@@ -8,10 +8,13 @@ import Link from "next/link";
 import { TierBadge } from "@/components/TierBadge";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
+import { ConfidenceBadge } from "@/components/ui/Confidence";
 import { DataBar } from "@/components/ui/DataBar";
 import { LaneIcon } from "@/components/ui/LaneIcon";
 import { TierSpine } from "@/components/ui/TierSpine";
+import { Tooltip } from "@/components/ui/Tooltip";
 import { cn } from "@/lib/cn";
+import { formatEbStory } from "@/lib/confidence";
 import { formatGames, formatPercent } from "@/lib/format";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl } from "@/lib/staticData";
@@ -32,7 +35,10 @@ import {
 
 type SortColumn = "rank" | "winRate" | "pickRate" | "banRate" | "games" | "contestedScore";
 type SortDir = "asc" | "desc";
-type RowEntry = UITierListEntry & { rank: number };
+// roleBaseline (role-average win rate) is threaded in from the page so the EB trust
+// hover can name the role average; it is not part of the normalized UI entry.
+type TierListTableEntry = UITierListEntry & { roleBaseline?: number };
+type RowEntry = TierListTableEntry & { rank: number };
 
 type DocumentWithViewTransition = Document & {
   startViewTransition?: typeof startTransition;
@@ -88,14 +94,17 @@ export function TierListTable({
   version,
   rankTierValue,
   activeRegion,
-  activePatch
+  activePatch,
+  minGames
 }: {
-  entries: UITierListEntry[];
+  entries: TierListTableEntry[];
   champions: TierListChampionMap;
   version: string;
   rankTierValue: string | null;
   activeRegion: string;
   activePatch?: string | null;
+  /** Games floor at which a row reads as a "Stable" sample (from the response sample). */
+  minGames?: number;
 }) {
   const [sortCol, setSortCol] = useState<SortColumn>("rank");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
@@ -283,7 +292,10 @@ export function TierListTable({
     return (
       <tr
         key={`${entry.tier}-${entry.role}-${entry.championId}`}
-        className="tierlist-row border-b border-border/40 text-sm last:border-0"
+        className={cn(
+          "tierlist-row border-b border-border/40 text-sm last:border-0",
+          entry.isLowSample && "opacity-70"
+        )}
       >
         <td className="px-2 py-2.5 text-center md:px-3">
           <span className={cn("type-tabular tabular-nums text-xs font-semibold", tierColorClass(entry.tier))}>
@@ -294,28 +306,38 @@ export function TierListTable({
           <TierBadge tier={entry.tier} />
         </td>
         <td className="px-2 py-2.5 md:px-3">
-          <Link
-            href={`/lol/champions/${entry.championId}?${rowQuery}`}
-            className="group flex items-center gap-2.5"
-          >
-            <Image
-              src={championIconUrl(version, championSlug)}
-              alt={championName}
-              width={30}
-              height={30}
-              className="rounded-md ring-1 ring-border/60"
-            />
-            <span className="min-w-0">
-              <span className="block truncate font-semibold text-fg group-hover:text-primary">
-                {championName}
-              </span>
-              {championSubtitle ? (
-                <span className="type-caption hidden truncate text-muted md:block">
-                  {championSubtitle}
+          <div className="flex items-center gap-2">
+            <Link
+              href={`/lol/champions/${entry.championId}?${rowQuery}`}
+              className="group flex min-w-0 items-center gap-2.5"
+            >
+              <Image
+                src={championIconUrl(version, championSlug)}
+                alt={championName}
+                width={30}
+                height={30}
+                className="rounded-md ring-1 ring-border/60"
+              />
+              <span className="min-w-0">
+                <span className="block truncate font-semibold text-fg group-hover:text-primary">
+                  {championName}
                 </span>
-              ) : null}
-            </span>
-          </Link>
+                {championSubtitle ? (
+                  <span className="type-caption hidden truncate text-muted md:block">
+                    {championSubtitle}
+                  </span>
+                ) : null}
+              </span>
+            </Link>
+            {entry.isLowSample ? (
+              <ConfidenceBadge
+                games={entry.games}
+                isLowSample={entry.isLowSample}
+                minGames={minGames}
+                className="shrink-0"
+              />
+            ) : null}
+          </div>
         </td>
         <td className="hidden px-2 py-2.5 sm:table-cell md:px-3">
           <span className="inline-flex items-center gap-1.5 text-xs text-muted">
@@ -324,21 +346,30 @@ export function TierListTable({
           </span>
         </td>
         <td className="px-2 py-2.5 text-right md:px-3">
-          <DataBar value={entry.winRate} decimals={2} className="justify-end" />
+          <DataBar value={entry.winRate} games={entry.games} decimals={2} className="justify-end" />
         </td>
         <td className="hidden px-3 py-2.5 text-right md:table-cell">
-          <span
-            className={cn(
-              "type-tabular tabular-nums text-xs font-medium",
-              entry.strengthScore > 0.0001
-                ? "text-wr-high"
-                : entry.strengthScore < -0.0001
-                  ? "text-wr-low"
-                  : "text-muted"
-            )}
+          <Tooltip
+            content={formatEbStory({
+              winRate: entry.winRate,
+              roleBaseline: entry.roleBaseline ?? 0,
+              strengthScore: entry.strengthScore,
+              games: entry.games
+            })}
           >
-            {formatStrengthDelta(entry.strengthScore)}
-          </span>
+            <span
+              className={cn(
+                "type-tabular cursor-help tabular-nums text-xs font-medium",
+                entry.strengthScore > 0.0001
+                  ? "text-wr-high"
+                  : entry.strengthScore < -0.0001
+                    ? "text-wr-low"
+                    : "text-muted"
+              )}
+            >
+              {formatStrengthDelta(entry.strengthScore)}
+            </span>
+          </Tooltip>
         </td>
         <td className="hidden px-3 py-2.5 text-right text-fg/70 lg:table-cell">
           {formatPercent(entry.pickRate, { decimals: 1 })}

--- a/apps/web/components/WinRateText.tsx
+++ b/apps/web/components/WinRateText.tsx
@@ -5,18 +5,25 @@ export function WinRateText({
   value,
   decimals = 1,
   games,
+  pickRate,
   className
 }: {
   value: number | null | undefined;
   decimals?: number;
   games?: number | null;
+  /** 0-1 share of games on this variant; rendered only when present and > 0. */
+  pickRate?: number | null;
   className?: string;
 }) {
+  const showPick = pickRate != null && Number.isFinite(pickRate) && pickRate > 0;
   return (
     <span className={cn(winRateColorClass(value), className)}>
       {formatPercent(value, { decimals })}
       {games != null && Number.isFinite(games) ? (
         <span className="ml-1 text-muted">({formatGames(games)})</span>
+      ) : null}
+      {showPick ? (
+        <span className="ml-1.5 text-muted">· {formatPercent(pickRate, { decimals: 0 })} pick</span>
       ) : null}
     </span>
   );

--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 
 import { ParticipantRuneCard } from "@/components/lol-profile/ParticipantRuneCard";
-import { ScoreboardTeamTable } from "@/components/lol-profile/ScoreboardTeamTable";
+import { ScoreboardTeamTable, type ScoreboardDensity } from "@/components/lol-profile/ScoreboardTeamTable";
 import { GoldDiffChart } from "@/components/lol-profile/GoldDiffChart";
 import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { cn } from "@/lib/cn";
+import { deriveMatchTakeaways, type Takeaway, type TakeawayTone } from "@/lib/matchInsights";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl } from "@/lib/staticData";
 import { buildLolPublicSummonerMatchTimelinePath } from "@/lib/lolPublicApi";
@@ -81,6 +83,61 @@ function RuneTabCell({
   );
 }
 
+const DENSITY_OPTIONS = [
+  { value: "compact" as const, label: "Compact" },
+  { value: "full" as const, label: "Detailed" }
+];
+
+const TAKEAWAY_TONE_CLASS: Record<TakeawayTone, string> = {
+  good: "text-success",
+  bad: "text-danger",
+  neutral: "text-muted"
+};
+
+function TakeawayIcon({ tone }: { tone: TakeawayTone }) {
+  const className = cn("mt-0.5 h-3.5 w-3.5 shrink-0", TAKEAWAY_TONE_CLASS[tone]);
+  if (tone === "good") {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="m3.5 8.5 3 3 6-7" />
+      </svg>
+    );
+  }
+  if (tone === "bad") {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true" className={className} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M8 2 1.5 13.5h13L8 2Z" />
+        <path d="M8 6.25v3.25" />
+        <path d="M8 11.75h.01" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 16 16" aria-hidden="true" className={className} fill="currentColor" stroke="none">
+      <circle cx="8" cy="8" r="2.75" />
+    </svg>
+  );
+}
+
+// Calm, scannable post-game summary — a tone-iconed strip of the most salient
+// facts about the viewing player's game. Renders nothing when there's no signal.
+function MatchTakeaways({ takeaways }: { takeaways: Takeaway[] }) {
+  if (takeaways.length === 0) return null;
+  return (
+    <div className="surface-subtle grid gap-1.5 rounded-control px-3 py-2.5">
+      <p className="type-overline text-muted">Takeaways</p>
+      <ul className="grid gap-x-4 gap-y-1 sm:grid-cols-2">
+        {takeaways.map((takeaway, idx) => (
+          <li key={idx} className="flex items-start gap-1.5">
+            <TakeawayIcon tone={takeaway.tone} />
+            <span className="text-sm leading-snug text-fg/90 tabular-nums">{takeaway.text}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 function TeamObjectivesSummary({ team, side }: { team: MatchTeamObjectives | undefined; side: "blue" | "red" }) {
   const items = team
     ? [
@@ -144,6 +201,7 @@ export function MatchScoreboard({
 }) {
   const [tab, setTab] = useState<ScoreboardTab>("overview");
   const [timeline, setTimeline] = useState<MatchTimeline | null>(null);
+  const [density, setDensity] = useState<ScoreboardDensity>("compact");
 
   // Lazy-load the gold/xp-diff curve once the scoreboard mounts (i.e. the match is expanded).
   // Optional decoration — only present for matches with ingested timeline frames.
@@ -173,6 +231,11 @@ export function MatchScoreboard({
   // Normalize damage bars to the whole lobby's top dealer so the carry reads across both teams.
   const matchMaxDamage = Math.max(1, ...participants.map((p) => p.totalDamageDealtToChampions));
   const alignedRows = buildAlignedParticipantRows(participants);
+  // overviewStats isn't threaded into the scoreboard — derive from in-match signal only.
+  const takeaways = useMemo(
+    () => deriveMatchTakeaways({ detail, gameName, tagLine, timeline }),
+    [detail, gameName, tagLine, timeline]
+  );
 
   return (
     <div className="flex flex-col gap-3">
@@ -186,6 +249,7 @@ export function MatchScoreboard({
 
       {tab === "overview" ? (
         <div className="flex flex-col gap-3">
+          <MatchTakeaways takeaways={takeaways} />
           {detail.objectives && detail.objectives.length > 0 ? (
             <ObjectivesStrip objectives={detail.objectives} />
           ) : null}
@@ -195,6 +259,15 @@ export function MatchScoreboard({
               <GoldDiffChart frames={timeline.frames} />
             </div>
           ) : null}
+          <div className="flex items-center justify-end px-1">
+            <SegmentedControl<ScoreboardDensity>
+              options={DENSITY_OPTIONS}
+              value={density}
+              onValueChange={setDensity}
+              ariaLabel="Scoreboard density"
+              className="w-fit"
+            />
+          </div>
           <ScoreboardTeamTable
             participants={blue}
             teamId={100}
@@ -204,6 +277,7 @@ export function MatchScoreboard({
             region={region}
             gameName={gameName}
             tagLine={tagLine}
+            density={density}
             championStatic={championStatic}
             itemStatic={itemStatic}
             spellStatic={spellStatic}
@@ -218,6 +292,7 @@ export function MatchScoreboard({
             region={region}
             gameName={gameName}
             tagLine={tagLine}
+            density={density}
             championStatic={championStatic}
             itemStatic={itemStatic}
             spellStatic={spellStatic}

--- a/apps/web/components/lol-profile/PerformanceCard.tsx
+++ b/apps/web/components/lol-profile/PerformanceCard.tsx
@@ -1,0 +1,143 @@
+import { Card } from "@/components/ui/Card";
+import { DataBar } from "@/components/ui/DataBar";
+import { LaneIcon } from "@/components/ui/LaneIcon";
+import { Stat } from "@/components/ui/Stat";
+import { cn } from "@/lib/cn";
+import { formatGames } from "@/lib/format";
+import { roleDisplayLabel } from "@/lib/roles";
+
+import {
+  matchKdaRatio,
+  normalizeRoleKey,
+  type MatchSummary,
+  type ProfileChampionStat,
+  type ProfileOverviewStats
+} from "@/components/lol-profile/shared";
+
+type RoleRow = {
+  role: string;
+  games: number;
+  winRate: number;
+  avgKda: number;
+  topChampion: string | null;
+};
+
+function formatStat(value: number | null | undefined, decimals: number): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return value.toFixed(decimals);
+}
+
+// Damage-to-champions averages run ~5k–40k; compact to keep the stat row tabular
+// and scannable rather than a wall of digits.
+function formatCompactNumber(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return Math.round(value).toLocaleString();
+}
+
+// An approachable "your performance" lens for the profile: a per-role split of
+// the loaded recent matches plus the player's own season averages. Complements
+// (does not duplicate) the sidebar "most played champions" — role is the angle
+// here, not champion. Purely presentational; safe to render before history loads
+// (averages still show from overviewStats).
+export function PerformanceCard({
+  matches,
+  overviewStats,
+  topChampions
+}: {
+  matches: MatchSummary[];
+  overviewStats?: ProfileOverviewStats | null;
+  topChampions?: ProfileChampionStat[] | null;
+}) {
+  // championId → name, sourced from the profile's aggregate champion stats so we
+  // can label each role's signature pick without depending on static asset data.
+  const championNameById = new Map<number, string>();
+  for (const champion of topChampions ?? []) {
+    championNameById.set(champion.championId, champion.championName);
+  }
+
+  const buckets = new Map<
+    string,
+    { games: number; wins: number; kdaSum: number; champCounts: Map<number, number> }
+  >();
+  for (const match of matches) {
+    const role = normalizeRoleKey(match.teamPosition);
+    const bucket = buckets.get(role) ?? { games: 0, wins: 0, kdaSum: 0, champCounts: new Map() };
+    bucket.games += 1;
+    if (match.win) bucket.wins += 1;
+    bucket.kdaSum += matchKdaRatio(match);
+    bucket.champCounts.set(match.championId, (bucket.champCounts.get(match.championId) ?? 0) + 1);
+    buckets.set(role, bucket);
+  }
+
+  // Drop UNKNOWN entirely — an "Unknown" role row teaches nothing. If every match
+  // is unknown the per-role section simply renders nothing.
+  const roleRows: RoleRow[] = [...buckets.entries()]
+    .filter(([role]) => role !== "UNKNOWN")
+    .map(([role, bucket]) => {
+      let topChampionId = -1;
+      let topCount = -1;
+      for (const [championId, count] of bucket.champCounts) {
+        if (count > topCount) {
+          topCount = count;
+          topChampionId = championId;
+        }
+      }
+      return {
+        role,
+        games: bucket.games,
+        winRate: bucket.wins / bucket.games,
+        avgKda: bucket.kdaSum / bucket.games,
+        topChampion: championNameById.get(topChampionId) ?? null
+      };
+    })
+    .sort((a, b) => b.games - a.games);
+
+  const hasRoles = roleRows.length > 0;
+  const hasAverages = overviewStats != null;
+  if (!hasRoles && !hasAverages) return null;
+
+  return (
+    <Card className="profile-section-card p-5">
+      <div>
+        <p className="type-kicker text-muted">Performance</p>
+        <h2 className="mt-2 type-section">How you play</h2>
+      </div>
+
+      {hasAverages ? (
+        <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <Stat label="CS / min" value={formatStat(overviewStats.avgCsPerMin, 1)} />
+          <Stat label="Vision" value={formatStat(overviewStats.avgVisionScore, 1)} />
+          <Stat label="KDA" value={formatStat(overviewStats.kdaRatio, 2)} />
+          <Stat label="Dmg / game" value={formatCompactNumber(overviewStats.avgDamageToChamps)} />
+        </div>
+      ) : null}
+
+      {hasRoles ? (
+        <div className={cn("grid gap-2", hasAverages && "mt-5 border-t border-border pt-5")}>
+          <div className="flex items-center justify-between gap-2">
+            <p className="type-overline text-muted">By role</p>
+            <p className="type-caption text-muted">From last {formatGames(matches.length)} games</p>
+          </div>
+          {roleRows.map((row) => (
+            <div key={row.role} className="surface-subtle grid gap-2 rounded-control px-3 py-2.5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-2">
+                  <LaneIcon role={row.role} className="h-4 w-4 shrink-0 text-muted" />
+                  <span className="truncate text-sm font-medium text-fg">{roleDisplayLabel(row.role)}</span>
+                </div>
+                <DataBar value={row.winRate} games={row.games} />
+              </div>
+              <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
+                <span className="min-w-0 truncate">
+                  {formatGames(row.games)} games{row.topChampion ? ` · ${row.topChampion}` : ""}
+                </span>
+                <span className="shrink-0 tabular-nums">{row.avgKda.toFixed(2)} KDA</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -29,6 +29,8 @@ import {
 
 const ROLE_ORDER: Record<string, number> = { TOP: 0, JUNGLE: 1, MIDDLE: 2, BOTTOM: 3, UTILITY: 4 };
 
+export type ScoreboardDensity = "compact" | "full";
+
 function formatGold(gold: number): string {
   return gold >= 1000 ? `${(gold / 1000).toFixed(1)}k` : String(gold);
 }
@@ -98,6 +100,7 @@ function ScoreboardRow({
   participant,
   durationSeconds,
   maxDamage,
+  density,
   region,
   gameName,
   tagLine,
@@ -109,6 +112,7 @@ function ScoreboardRow({
   participant: MatchParticipant;
   durationSeconds: number;
   maxDamage: number;
+  density: ScoreboardDensity;
   region: string;
   gameName: string;
   tagLine: string;
@@ -154,24 +158,26 @@ function ScoreboardRow({
             ) : null}
           </div>
 
-          <span className="flex shrink-0 flex-col gap-0.5" aria-label="Summoner spells">
-            {[participant.summonerSpell1Id, participant.summonerSpell2Id].map((spellId, spellIdx) => {
-              const spellMeta = spellStatic?.spells[String(spellId)];
-              return spellMeta && spellStatic ? (
-                <Image
-                  key={`${spellId}-${spellIdx}`}
-                  src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
-                  alt={spellMeta.name}
-                  title={spellMeta.name}
-                  width={16}
-                  height={16}
-                  className="rounded border border-border/40"
-                />
-              ) : (
-                <span key={`${spellId}-${spellIdx}`} className="h-4 w-4 rounded border border-border/40 bg-surface/60" />
-              );
-            })}
-          </span>
+          {density === "full" ? (
+            <span className="flex shrink-0 flex-col gap-0.5" aria-label="Summoner spells">
+              {[participant.summonerSpell1Id, participant.summonerSpell2Id].map((spellId, spellIdx) => {
+                const spellMeta = spellStatic?.spells[String(spellId)];
+                return spellMeta && spellStatic ? (
+                  <Image
+                    key={`${spellId}-${spellIdx}`}
+                    src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
+                    alt={spellMeta.name}
+                    title={spellMeta.name}
+                    width={16}
+                    height={16}
+                    className="rounded border border-border/40"
+                  />
+                ) : (
+                  <span key={`${spellId}-${spellIdx}`} className="h-4 w-4 rounded border border-border/40 bg-surface/60" />
+                );
+              })}
+            </span>
+          ) : null}
 
           <RuneTrigger participant={participant} runeStatic={runeStatic} />
 
@@ -231,13 +237,17 @@ function ScoreboardRow({
         ) : null}
       </Td>
 
-      <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
-        {participant.visionScore}
-      </Td>
+      {density === "full" ? (
+        <>
+          <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
+            {participant.visionScore}
+          </Td>
 
-      <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
-        {formatGold(participant.goldEarned)}
-      </Td>
+          <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
+            {formatGold(participant.goldEarned)}
+          </Td>
+        </>
+      ) : null}
 
       <Td>
         <div className="flex flex-wrap items-center gap-1">
@@ -277,6 +287,7 @@ export function ScoreboardTeamTable({
   region,
   gameName,
   tagLine,
+  density = "compact",
   championStatic,
   itemStatic,
   spellStatic,
@@ -290,6 +301,7 @@ export function ScoreboardTeamTable({
   region: string;
   gameName: string;
   tagLine: string;
+  density?: ScoreboardDensity;
   championStatic: ChampionStatic | null;
   itemStatic: ItemStatic | null;
   spellStatic: SpellStatic | null;
@@ -350,8 +362,12 @@ export function ScoreboardTeamTable({
               <Th align="right">KDA</Th>
               <Th align="right">CS</Th>
               <Th align="right">Damage</Th>
-              <Th align="right" className="hidden sm:table-cell">Vision</Th>
-              <Th align="right" className="hidden sm:table-cell">Gold</Th>
+              {density === "full" ? (
+                <>
+                  <Th align="right" className="hidden sm:table-cell">Vision</Th>
+                  <Th align="right" className="hidden sm:table-cell">Gold</Th>
+                </>
+              ) : null}
               <Th>Items</Th>
             </tr>
           </thead>
@@ -362,6 +378,7 @@ export function ScoreboardTeamTable({
                 participant={participant}
                 durationSeconds={durationSeconds}
                 maxDamage={maxDamage}
+                density={density}
                 region={region}
                 gameName={gameName}
                 tagLine={tagLine}

--- a/apps/web/components/ui/Confidence.tsx
+++ b/apps/web/components/ui/Confidence.tsx
@@ -1,0 +1,83 @@
+import { Badge } from "@/components/ui/Badge";
+import { Tooltip } from "@/components/ui/Tooltip";
+import { cn } from "@/lib/cn";
+import {
+  confidenceLevel,
+  confidenceSampleLabel,
+  type ConfidenceLevel
+} from "@/lib/confidence";
+import { formatGames } from "@/lib/format";
+
+// Small, data-driven "how much should I trust this?" markers. Server-compatible:
+// this file renders the client Tooltip as a child but holds no state itself, so
+// it stays a server component. Confidence is DATA, never decoration — neutral
+// tones, with a warning accent reserved for genuinely thin samples.
+
+const FILLED_PIPS: Record<ConfidenceLevel, number> = {
+  high: 3,
+  moderate: 2,
+  low: 1
+};
+
+// Staggered heights read as a signal-strength meter without adding chrome.
+const PIP_HEIGHTS = ["h-2", "h-2.5", "h-3"] as const;
+
+type ConfidenceInput = {
+  games: number;
+  isLowSample?: boolean;
+  minGames?: number;
+  className?: string;
+};
+
+export function Confidence({ games, isLowSample, minGames, className }: ConfidenceInput) {
+  const level = confidenceLevel({ games, isLowSample, minGames });
+  const filled = FILLED_PIPS[level];
+  const label = `${formatGames(games)} games · ${confidenceSampleLabel(level)} sample`;
+  const filledTone = level === "low" ? "bg-warning" : "bg-fg/70";
+
+  return (
+    <Tooltip content={label}>
+      <span
+        role="img"
+        aria-label={label}
+        tabIndex={0}
+        className={cn(
+          "inline-flex items-end gap-[2px] rounded-[2px] align-middle outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+          className
+        )}
+      >
+        {PIP_HEIGHTS.map((height, i) => (
+          <span
+            key={i}
+            aria-hidden="true"
+            className={cn(
+              "w-[3px] rounded-[1px]",
+              height,
+              i < filled ? filledTone : "bg-border"
+            )}
+          />
+        ))}
+      </span>
+    </Tooltip>
+  );
+}
+
+export function ConfidenceBadge({
+  games,
+  isLowSample,
+  minGames,
+  className
+}: ConfidenceInput) {
+  const level = confidenceLevel({ games, isLowSample, minGames });
+
+  return (
+    <Badge
+      className={cn(
+        level !== "high" && "border-warning/40 bg-warning/20 text-fg",
+        className
+      )}
+    >
+      {confidenceSampleLabel(level)}
+    </Badge>
+  );
+}

--- a/apps/web/components/ui/DataBar.tsx
+++ b/apps/web/components/ui/DataBar.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/cn";
+import { winRateIntervalPP } from "@/lib/confidence";
 import { formatPercent, toWinPercent } from "@/lib/format";
 
 // Diverging win-rate bar centered on 50%. Above 50 fills right (win color),
@@ -10,6 +11,7 @@ export function DataBar({
   domain = 8,
   decimals = 1,
   showValue = true,
+  games,
   className
 }: {
   value: number | null | undefined;
@@ -17,6 +19,12 @@ export function DataBar({
   domain?: number;
   decimals?: number;
   showValue?: boolean;
+  /**
+   * Optional sample size. When finite and > 0, draws a faint 95% CI whisker
+   * centered on the fill end so a thin sample reads as less certain. Omit (or
+   * pass <= 0) to render exactly as before.
+   */
+  games?: number;
   className?: string;
 }) {
   const pct = toWinPercent(value);
@@ -31,6 +39,14 @@ export function DataBar({
   const magnitude = Math.min(Math.abs(delta) / domain, 1) * 50; // 0–50% of track
   const positive = delta >= 0;
   const colorVar = positive ? "var(--t-win)" : "var(--t-loss)";
+
+  // Optional confidence whisker: a faint band the width of the 95% CI, centered
+  // on the fill end. Mapped onto the track the same way the fill magnitude is.
+  const hasGames = typeof games === "number" && Number.isFinite(games) && games > 0;
+  const ciHalf = hasGames
+    ? Math.min((winRateIntervalPP(pct, games) / domain) * 50, 50)
+    : 0;
+  const endPct = positive ? 50 + magnitude : 50 - magnitude;
 
   return (
     <span className={cn("inline-flex items-center gap-2", className)}>
@@ -48,6 +64,19 @@ export function DataBar({
               : { right: "50%", width: `${magnitude}%`, background: colorVar }
           }
         />
+        {hasGames ? (
+          <span
+            aria-hidden="true"
+            className="absolute inset-y-0"
+            style={{
+              left: `${endPct}%`,
+              width: `max(2px, ${ciHalf * 2}%)`,
+              transform: "translateX(-50%)",
+              background: "var(--t-border-strong)",
+              opacity: 0.5
+            }}
+          />
+        ) : null}
       </span>
       {showValue ? (
         <span

--- a/apps/web/lib/confidence.test.ts
+++ b/apps/web/lib/confidence.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  adjustedWinRatePercent,
+  confidenceLevel,
+  confidenceSampleLabel,
+  DEFAULT_MIN_GAMES,
+  formatEbStory,
+  winRateIntervalPP
+} from "@/lib/confidence";
+
+describe("confidenceLevel", () => {
+  it("is low when explicitly flagged low sample, regardless of game count", () => {
+    expect(confidenceLevel({ games: 100_000, isLowSample: true })).toBe("low");
+  });
+
+  it("is low at zero or negative games", () => {
+    expect(confidenceLevel({ games: 0 })).toBe("low");
+    expect(confidenceLevel({ games: -5 })).toBe("low");
+  });
+
+  it("is high at or above the minimum", () => {
+    expect(confidenceLevel({ games: 300, minGames: 300 })).toBe("high");
+    expect(confidenceLevel({ games: 301, minGames: 300 })).toBe("high");
+  });
+
+  it("is moderate in the band between 40% of min and the min", () => {
+    // min 300 -> moderate floor is max(20, 120) = 120
+    expect(confidenceLevel({ games: 120, minGames: 300 })).toBe("moderate");
+    expect(confidenceLevel({ games: 299, minGames: 300 })).toBe("moderate");
+    expect(confidenceLevel({ games: 119, minGames: 300 })).toBe("low");
+  });
+
+  it("falls back to DEFAULT_MIN_GAMES when minGames is missing or non-positive", () => {
+    expect(confidenceLevel({ games: DEFAULT_MIN_GAMES })).toBe("high");
+    expect(confidenceLevel({ games: DEFAULT_MIN_GAMES - 1 })).toBe("moderate");
+    // moderate floor = max(20, 0.4 * 200) = 80
+    expect(confidenceLevel({ games: 80 })).toBe("moderate");
+    expect(confidenceLevel({ games: 79 })).toBe("low");
+    // non-positive minGames is ignored in favor of the default
+    expect(confidenceLevel({ games: DEFAULT_MIN_GAMES, minGames: 0 })).toBe("high");
+  });
+
+  it("honors a small minimum via the max(20, ...) moderate floor", () => {
+    // min 30 -> moderate floor is max(20, 12) = 20
+    expect(confidenceLevel({ games: 30, minGames: 30 })).toBe("high");
+    expect(confidenceLevel({ games: 20, minGames: 30 })).toBe("moderate");
+    expect(confidenceLevel({ games: 19, minGames: 30 })).toBe("low");
+  });
+});
+
+describe("winRateIntervalPP", () => {
+  it("is zero with no games", () => {
+    expect(winRateIntervalPP(50, 0)).toBe(0);
+    expect(winRateIntervalPP(50, -10)).toBe(0);
+  });
+
+  it("narrows as the sample grows", () => {
+    const small = winRateIntervalPP(50, 100);
+    const large = winRateIntervalPP(50, 1000);
+    expect(large).toBeLessThan(small);
+    expect(small).toBeGreaterThan(0);
+  });
+
+  it("is widest near a coin-flip and narrower at the extremes", () => {
+    const middle = winRateIntervalPP(50, 200);
+    const skewed = winRateIntervalPP(90, 200);
+    expect(middle).toBeGreaterThan(skewed);
+  });
+
+  it("normalizes ratio and percent inputs identically", () => {
+    expect(winRateIntervalPP(0.5, 200)).toBeCloseTo(winRateIntervalPP(50, 200), 10);
+  });
+
+  it("clamps to a 25pp ceiling on tiny samples", () => {
+    expect(winRateIntervalPP(50, 1)).toBeLessThanOrEqual(25);
+    expect(winRateIntervalPP(50, 1)).toBe(25);
+  });
+});
+
+describe("adjustedWinRatePercent", () => {
+  it("adds a fractional strength delta to a ratio baseline (percent output)", () => {
+    expect(adjustedWinRatePercent({ roleBaseline: 0.504, strengthScore: 0.029 })).toBeCloseTo(
+      53.3,
+      10
+    );
+  });
+
+  it("adds a points-scaled strength delta to a percent baseline", () => {
+    expect(adjustedWinRatePercent({ roleBaseline: 50.4, strengthScore: 2.9 })).toBeCloseTo(
+      53.3,
+      10
+    );
+  });
+
+  it("handles negative deltas", () => {
+    expect(adjustedWinRatePercent({ roleBaseline: 0.5, strengthScore: -0.02 })).toBeCloseTo(
+      48,
+      10
+    );
+  });
+});
+
+describe("confidenceSampleLabel", () => {
+  it("maps levels onto the analytics sample vocabulary", () => {
+    expect(confidenceSampleLabel("high")).toBe("Stable");
+    expect(confidenceSampleLabel("moderate")).toBe("Light");
+    expect(confidenceSampleLabel("low")).toBe("Early");
+  });
+});
+
+describe("formatEbStory", () => {
+  it("renders the one-line EB trust story with the graded (shrunk) win rate", () => {
+    expect(
+      formatEbStory({ winRate: 0.58, roleBaseline: 0.504, strengthScore: 0.029, games: 120 })
+    ).toBe("Observed 58.0% over 120 games · role avg 50.4% · graded 53.3% (+2.9% vs role avg)");
+  });
+
+  it("omits the role-average clause when no baseline is on the wire", () => {
+    expect(
+      formatEbStory({ winRate: 0.58, roleBaseline: 0, strengthScore: 0.029, games: 120 })
+    ).toBe("Observed 58.0% over 120 games · graded +2.9% vs role average");
+  });
+});

--- a/apps/web/lib/confidence.ts
+++ b/apps/web/lib/confidence.ts
@@ -1,0 +1,107 @@
+import { formatGames, toWinPercent } from "@/lib/format";
+import { formatStrengthDelta } from "@/lib/tierlist";
+
+// Confidence layer: turns a raw game count (and the analytics low-sample flag)
+// into a small, trustworthy "how much should I believe this?" signal. Pure
+// helpers — the components/tests build on these. Win rates may arrive as a 0-1
+// ratio OR a 0-100 percent; everything routes through toWinPercent so callers
+// never have to guess the scale.
+
+export type ConfidenceLevel = "high" | "moderate" | "low";
+
+/** Default sample size at which a read is considered "Stable" when callers don't supply one. */
+export const DEFAULT_MIN_GAMES = 200;
+
+/**
+ * Bucket a sample into a confidence level. An explicit low-sample flag (from the
+ * analytics layer) or a non-positive game count always collapses to "low".
+ * Otherwise the count is compared against `minGames` (falling back to
+ * DEFAULT_MIN_GAMES), with a moderate band down to max(20, 40% of the minimum).
+ */
+export function confidenceLevel(input: {
+  games: number;
+  isLowSample?: boolean;
+  minGames?: number;
+}): ConfidenceLevel {
+  const { games, isLowSample, minGames } = input;
+
+  if (isLowSample === true || !(games > 0)) return "low";
+
+  const min = minGames && minGames > 0 ? minGames : DEFAULT_MIN_GAMES;
+  if (games >= min) return "high";
+  if (games >= Math.max(20, min * 0.4)) return "moderate";
+  return "low";
+}
+
+/**
+ * 95% Wald confidence half-width for a win rate, expressed in PERCENTAGE POINTS
+ * (so it can be drawn directly against a percent-scaled bar). Returns 0 with no
+ * games; widest near p=0.5 and clamped to 25pp to stay sane on tiny samples.
+ */
+export function winRateIntervalPP(winRatePercent: number, games: number): number {
+  if (!(games > 0)) return 0;
+
+  const pct = toWinPercent(winRatePercent) ?? 0;
+  const p = Math.min(1, Math.max(0, pct / 100));
+  const half = 1.96 * Math.sqrt((p * (1 - p)) / games) * 100;
+
+  return Math.min(25, Math.max(0, half));
+}
+
+/**
+ * The graded ("adjusted") win rate as a PERCENT number: the role baseline shifted
+ * by the signed strength delta. `strengthScore` may be a fraction (e.g. 0.029) or
+ * already in points (e.g. 2.9) — small magnitudes are treated as fractions.
+ */
+export function adjustedWinRatePercent(input: {
+  roleBaseline: number;
+  strengthScore: number;
+}): number {
+  const base = toWinPercent(input.roleBaseline) ?? 0;
+  const delta =
+    Math.abs(input.strengthScore) < 1.5
+      ? input.strengthScore * 100
+      : input.strengthScore;
+
+  return base + delta;
+}
+
+/** Map a confidence level onto the AnalyticsSampleBanner sample vocabulary. */
+export function confidenceSampleLabel(
+  level: ConfidenceLevel
+): "Stable" | "Light" | "Early" {
+  if (level === "high") return "Stable";
+  if (level === "moderate") return "Light";
+  return "Early";
+}
+
+/**
+ * One-line empirical-Bayes trust story for a tooltip, e.g.
+ * "Observed 58.0% over 120 games · role avg 50.4% · graded +2.9% vs role average".
+ */
+export function formatEbStory(input: {
+  winRate: number;
+  roleBaseline: number;
+  strengthScore: number;
+  games: number;
+}): string {
+  const observed = toWinPercent(input.winRate) ?? 0;
+  const delta = formatStrengthDelta(input.strengthScore);
+  const head = `Observed ${observed.toFixed(1)}% over ${formatGames(input.games)} games`;
+
+  const roleAvg = toWinPercent(input.roleBaseline);
+  if (roleAvg == null || !(roleAvg > 0)) {
+    // No role baseline on the wire — only assert what we can defend.
+    return `${head} · graded ${delta} vs role average`;
+  }
+
+  // Surface the empirical-Bayes shrinkage: the observed rate vs the graded
+  // (baseline + shrunk delta) the tier is actually cut on.
+  const adjusted = adjustedWinRatePercent({
+    roleBaseline: input.roleBaseline,
+    strengthScore: input.strengthScore
+  });
+  return `${head} · role avg ${roleAvg.toFixed(1)}% · graded ${adjusted.toFixed(
+    1
+  )}% (${delta} vs role avg)`;
+}

--- a/apps/web/lib/matchInsights.test.ts
+++ b/apps/web/lib/matchInsights.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveMatchTakeaways } from "@/lib/matchInsights";
+import type { MatchDetail, MatchParticipant, MatchTimeline } from "@/components/lol-profile/shared";
+
+const ME_NAME = "Tester";
+const ME_TAG = "EUW";
+const ROLES = ["TOP", "JUNGLE", "MIDDLE", "BOTTOM", "UTILITY"] as const;
+
+function makeParticipant(over: Partial<MatchParticipant> & { teamId: number; teamPosition: string }): MatchParticipant {
+  return {
+    puuid: null,
+    gameName: null,
+    tagLine: null,
+    championId: 1,
+    win: over.teamId === 100,
+    kills: 2,
+    deaths: 5,
+    assists: 3,
+    champLevel: 18,
+    goldEarned: 12000,
+    totalDamageDealtToChampions: 10000,
+    visionScore: 20,
+    totalMinionsKilled: 150,
+    neutralMinionsKilled: 0,
+    summonerSpell1Id: 4,
+    summonerSpell2Id: 7,
+    items: [],
+    runes: { primaryStyleId: 0, subStyleId: 0, primarySelections: [], subSelections: [], statShards: [] },
+    ...over
+  };
+}
+
+// Baseline 5v5 (30 min) tuned so NOTHING fires: lane CS even, KP 0.5, deaths even,
+// one teammate out-damages "me", and one enemy out-visions "me". Each test mutates
+// the viewing player to trip exactly one candidate.
+function baselineParticipants(): MatchParticipant[] {
+  const list: MatchParticipant[] = [];
+  for (const teamId of [100, 200] as const) {
+    ROLES.forEach((role) => {
+      const isMe = teamId === 100 && role === "BOTTOM";
+      list.push(
+        makeParticipant({
+          teamId,
+          teamPosition: role,
+          gameName: isMe ? ME_NAME : `P${teamId}${role}`,
+          tagLine: isMe ? ME_TAG : "EUW",
+          // A blue teammate out-damages me so top-team-damage stays silent by default.
+          totalDamageDealtToChampions: teamId === 100 && role === "TOP" ? 12000 : 10000,
+          // An enemy out-visions me so top-vision stays silent by default.
+          visionScore: teamId === 200 && role === "JUNGLE" ? 25 : 20
+        })
+      );
+    });
+  }
+  return list;
+}
+
+function makeDetail(participants: MatchParticipant[], over: Partial<MatchDetail> = {}): MatchDetail {
+  return {
+    matchId: "M1",
+    matchDate: 0,
+    duration: 1800,
+    queueId: 420,
+    queueType: "RANKED_SOLO_5x5",
+    participants,
+    ...over
+  };
+}
+
+function me(participants: MatchParticipant[]): MatchParticipant {
+  return participants.find((p) => p.gameName === ME_NAME)!;
+}
+
+function derive(participants: MatchParticipant[], timeline?: MatchTimeline | null, limit?: number) {
+  return deriveMatchTakeaways({
+    detail: makeDetail(participants),
+    gameName: ME_NAME,
+    tagLine: ME_TAG,
+    timeline,
+    limit
+  });
+}
+
+describe("deriveMatchTakeaways", () => {
+  it("returns nothing when the baseline is neutral", () => {
+    expect(derive(baselineParticipants())).toEqual([]);
+  });
+
+  it("returns empty when the viewing player is not in the lobby", () => {
+    const result = deriveMatchTakeaways({
+      detail: makeDetail(baselineParticipants()),
+      gameName: "Nobody",
+      tagLine: "NA1"
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("flags a CS lead over the lane opponent", () => {
+    const players = baselineParticipants();
+    me(players).totalMinionsKilled = 450; // 15 CS/min vs 5
+    const result = derive(players);
+    expect(result).toEqual([{ tone: "good", text: "+10.0 CS/min on your lane opponent" }]);
+  });
+
+  it("flags a CS deficit vs the lane opponent", () => {
+    const players = baselineParticipants();
+    me(players).totalMinionsKilled = 60; // 2 CS/min vs 5
+    const result = derive(players);
+    expect(result).toEqual([{ tone: "bad", text: "-3.0 CS/min behind your lane opponent" }]);
+  });
+
+  it("flags high kill participation", () => {
+    const players = baselineParticipants();
+    me(players).assists = 6; // (2 + 6) / 10 team kills = 0.8
+    const result = derive(players);
+    expect(result).toEqual([{ tone: "good", text: "80% kill participation" }]);
+  });
+
+  it("flags low kill participation as neutral", () => {
+    const players = baselineParticipants();
+    me(players).kills = 1;
+    me(players).assists = 1; // (1 + 1) / 9 team kills = 0.22
+    const result = derive(players);
+    expect(result).toEqual([{ tone: "neutral", text: "22% kill participation" }]);
+  });
+
+  it("flags deaths above the team average", () => {
+    const players = baselineParticipants();
+    me(players).deaths = 9; // team avg = (9 + 5*4) / 5 = 5.8
+    const result = derive(players);
+    expect(result).toEqual([{ tone: "bad", text: "Died 9 times, above your team average" }]);
+  });
+
+  it("flags leading the team in damage", () => {
+    const players = baselineParticipants();
+    me(players).totalDamageDealtToChampions = 20000; // top of 62k team total = 32%
+    const result = derive(players);
+    expect(result).toEqual([{ tone: "good", text: "Led your team in damage (32%)" }]);
+  });
+
+  it("flags the top vision score in the lobby", () => {
+    const players = baselineParticipants();
+    me(players).visionScore = 30; // beats the enemy jungle's 25
+    const result = derive(players);
+    expect(result).toEqual([{ tone: "good", text: "Top vision score in the lobby (30)" }]);
+  });
+
+  it("flags the deepest gold deficit from the timeline", () => {
+    const timeline: MatchTimeline = {
+      matchId: "M1",
+      duration: 1800,
+      frames: [
+        { minuteMark: 0, blueGold: 1000, redGold: 1000, blueXp: 0, redXp: 0 },
+        { minuteMark: 10, blueGold: 1000, redGold: 5000, blueXp: 0, redXp: 0 },
+        { minuteMark: 20, blueGold: 8000, redGold: 5000, blueXp: 0, redXp: 0 }
+      ]
+    };
+    const result = derive(baselineParticipants(), timeline);
+    expect(result).toEqual([{ tone: "bad", text: "Down 4.0k gold at 10:00" }]);
+  });
+
+  it("flags closing out a gold lead in a win", () => {
+    const timeline: MatchTimeline = {
+      matchId: "M1",
+      duration: 1800,
+      frames: [
+        { minuteMark: 0, blueGold: 1000, redGold: 1000, blueXp: 0, redXp: 0 },
+        { minuteMark: 25, blueGold: 6000, redGold: 1000, blueXp: 0, redXp: 0 }
+      ]
+    };
+    const result = derive(baselineParticipants(), timeline);
+    expect(result).toEqual([{ tone: "good", text: "Closed out a 5.0k gold lead" }]);
+  });
+
+  it("caps the output at the limit and sorts by salience", () => {
+    const players = baselineParticipants();
+    const player = me(players);
+    player.totalMinionsKilled = 450; // lane CS good, salience 10
+    player.assists = 6; // KP 0.8, salience 1.2
+    player.totalDamageDealtToChampions = 20000; // top damage, salience ~0.97
+    player.visionScore = 30; // top vision, salience 2
+    const timeline: MatchTimeline = {
+      matchId: "M1",
+      duration: 1800,
+      frames: [
+        { minuteMark: 0, blueGold: 1000, redGold: 1000, blueXp: 0, redXp: 0 },
+        { minuteMark: 25, blueGold: 6000, redGold: 1000, blueXp: 0, redXp: 0 } // closed lead, salience 2.5
+      ]
+    };
+
+    const result = derive(players, timeline);
+    // 5 candidates fire; default limit 4 drops the lowest-salience (damage).
+    expect(result).toHaveLength(4);
+    expect(result.map((t) => t.text)).toEqual([
+      "+10.0 CS/min on your lane opponent",
+      "Closed out a 5.0k gold lead",
+      "Top vision score in the lobby (30)",
+      "80% kill participation"
+    ]);
+    expect(result.some((t) => t.text.startsWith("Led your team in damage"))).toBe(false);
+
+    // Explicit limit is respected.
+    const top2 = derive(players, timeline, 2);
+    expect(top2.map((t) => t.text)).toEqual([
+      "+10.0 CS/min on your lane opponent",
+      "Closed out a 5.0k gold lead"
+    ]);
+  });
+});

--- a/apps/web/lib/matchInsights.ts
+++ b/apps/web/lib/matchInsights.ts
@@ -1,0 +1,158 @@
+import { formatDurationSeconds } from "@/lib/format";
+import {
+  isCurrentProfilePlayer,
+  normalizeRoleKey,
+  type MatchDetail,
+  type MatchParticipant,
+  type MatchTimeline,
+  type ProfileOverviewStats
+} from "@/components/lol-profile/shared";
+
+export type TakeawayTone = "good" | "bad" | "neutral";
+export type Takeaway = { tone: TakeawayTone; text: string };
+
+// Salience is an internal ranking weight only — never surfaced to the UI.
+type ScoredTakeaway = Takeaway & { salience: number };
+
+function csPerMinute(participant: MatchParticipant, minutes: number): number {
+  return (participant.totalMinionsKilled + participant.neutralMinionsKilled) / minutes;
+}
+
+// Pure, deterministic post-game summary. Builds a ranked set of plain-language
+// takeaways for the viewing player and returns the top `limit` by salience.
+export function deriveMatchTakeaways(input: {
+  detail: MatchDetail;
+  gameName: string;
+  tagLine: string;
+  timeline?: MatchTimeline | null;
+  overviewStats?: ProfileOverviewStats | null;
+  limit?: number;
+}): Takeaway[] {
+  const { detail, gameName, tagLine, timeline, overviewStats, limit = 4 } = input;
+
+  const me = detail.participants.find((p) => isCurrentProfilePlayer(p, gameName, tagLine));
+  if (!me) return [];
+
+  const minutes = Math.max(1, detail.duration / 60);
+  const team = detail.participants.filter((p) => p.teamId === me.teamId);
+  const enemies = detail.participants.filter((p) => p.teamId !== me.teamId);
+
+  const myCsPerMin = csPerMinute(me, minutes);
+  const myRole = normalizeRoleKey(me.teamPosition);
+  const laneOpp =
+    myRole !== "UNKNOWN" ? enemies.find((p) => normalizeRoleKey(p.teamPosition) === myRole) : undefined;
+
+  const teamKills = team.reduce((sum, p) => sum + p.kills, 0);
+  const kp = teamKills > 0 ? (me.kills + me.assists) / teamKills : 0;
+
+  const teamDamage = team.reduce((sum, p) => sum + p.totalDamageDealtToChampions, 0);
+  const myDmgShare = teamDamage > 0 ? me.totalDamageDealtToChampions / teamDamage : 0;
+  const maxTeamDamage = Math.max(...team.map((p) => p.totalDamageDealtToChampions));
+  const isTopTeamDamage = me.totalDamageDealtToChampions === maxTeamDamage && team.length > 1;
+
+  const teamAvgDeaths = team.reduce((sum, p) => sum + p.deaths, 0) / team.length;
+  const lobbyMaxVision = Math.max(...detail.participants.map((p) => p.visionScore));
+
+  const candidates: ScoredTakeaway[] = [];
+
+  // 1. Lane CS differential vs the role-aligned enemy.
+  if (laneOpp) {
+    const d = myCsPerMin - csPerMinute(laneOpp, minutes);
+    if (d >= 1) {
+      candidates.push({ tone: "good", text: `+${d.toFixed(1)} CS/min on your lane opponent`, salience: Math.abs(d) });
+    } else if (d <= -1) {
+      candidates.push({ tone: "bad", text: `${d.toFixed(1)} CS/min behind your lane opponent`, salience: Math.abs(d) });
+    }
+  }
+
+  // 2. CS vs the player's own running average.
+  if (overviewStats?.avgCsPerMin && overviewStats.avgCsPerMin > 0) {
+    const avg = overviewStats.avgCsPerMin;
+    const d = myCsPerMin - avg;
+    if (d >= 1) {
+      candidates.push({
+        tone: "good",
+        text: `${myCsPerMin.toFixed(1)} CS/min, above your ${avg.toFixed(1)} average`,
+        salience: Math.abs(d) * 0.8
+      });
+    } else if (d <= -1) {
+      candidates.push({
+        tone: "bad",
+        text: `${myCsPerMin.toFixed(1)} CS/min, below your ${avg.toFixed(1)} average`,
+        salience: Math.abs(d) * 0.8
+      });
+    }
+  }
+
+  // 3. Kill participation.
+  if (kp >= 0.65) {
+    candidates.push({ tone: "good", text: `${Math.round(kp * 100)}% kill participation`, salience: (kp - 0.5) * 4 });
+  } else if (kp <= 0.4 && teamKills > 0) {
+    candidates.push({ tone: "neutral", text: `${Math.round(kp * 100)}% kill participation`, salience: (0.5 - kp) * 3 });
+  }
+
+  // 4. Death count outlier (vs team, then vs own average).
+  if (me.deaths >= teamAvgDeaths + 2) {
+    candidates.push({
+      tone: "bad",
+      text: `Died ${me.deaths} times, above your team average`,
+      salience: me.deaths - teamAvgDeaths
+    });
+  } else if (overviewStats?.avgDeaths && me.deaths >= overviewStats.avgDeaths + 2) {
+    candidates.push({
+      tone: "bad",
+      text: `Died ${me.deaths} times vs your ${overviewStats.avgDeaths.toFixed(1)} average`,
+      salience: me.deaths - overviewStats.avgDeaths
+    });
+  }
+
+  // 5. Team damage lead.
+  if (isTopTeamDamage) {
+    candidates.push({
+      tone: "good",
+      text: `Led your team in damage (${Math.round(myDmgShare * 100)}%)`,
+      salience: myDmgShare * 3
+    });
+  }
+
+  // 6. Lobby-leading vision.
+  if (lobbyMaxVision > 0 && me.visionScore === lobbyMaxVision) {
+    candidates.push({ tone: "good", text: `Top vision score in the lobby (${me.visionScore})`, salience: 2 });
+  }
+
+  // 7. Gold-curve inflection (deepest deficit, or a closed-out lead in a win).
+  if (timeline && timeline.frames.length >= 2) {
+    const teamDiff = (frame: { blueGold: number; redGold: number }) =>
+      me.teamId === 100 ? frame.blueGold - frame.redGold : frame.redGold - frame.blueGold;
+
+    let minFrame = timeline.frames[0];
+    let minDiff = teamDiff(minFrame);
+    for (const frame of timeline.frames) {
+      const diff = teamDiff(frame);
+      if (diff < minDiff) {
+        minDiff = diff;
+        minFrame = frame;
+      }
+    }
+    const endDiff = teamDiff(timeline.frames[timeline.frames.length - 1]);
+
+    if (minDiff <= -2500) {
+      candidates.push({
+        tone: "bad",
+        text: `Down ${(Math.abs(minDiff) / 1000).toFixed(1)}k gold at ${formatDurationSeconds(minFrame.minuteMark * 60)}`,
+        salience: Math.abs(minDiff) / 2000
+      });
+    } else if (endDiff >= 2500 && me.win) {
+      candidates.push({
+        tone: "good",
+        text: `Closed out a ${(endDiff / 1000).toFixed(1)}k gold lead`,
+        salience: endDiff / 2000
+      });
+    }
+  }
+
+  return candidates
+    .sort((a, b) => b.salience - a.salience)
+    .slice(0, limit)
+    .map(({ tone, text }) => ({ tone, text }));
+}

--- a/apps/web/lib/staticData.ts
+++ b/apps/web/lib/staticData.ts
@@ -180,6 +180,12 @@ export function championIconUrl(version: string, champId: string) {
   return `https://ddragon.leagueoflegends.com/cdn/${version}/img/champion/${champId}.png`;
 }
 
+// CommunityDragon champion square keyed by NUMERIC champion id — for places that
+// only have the id (e.g. live-game scouting) without the ddragon slug map loaded.
+export function championSquareIconUrlById(championId: number) {
+  return `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/champion-icons/${championId}.png`;
+}
+
 export function profileIconUrl(version: string, profileIconId: number) {
   return `https://ddragon.leagueoflegends.com/cdn/${version}/img/profileicon/${profileIconId}.png`;
 }

--- a/apps/web/lib/tierlist.test.ts
+++ b/apps/web/lib/tierlist.test.ts
@@ -155,23 +155,29 @@ describe("filterTierListEntries", () => {
       championId: 266,
       role: "TOP",
       tier: "S",
-      compositeScore: 0.71,
       winRate: 0.52,
       pickRate: 0.13,
+      banRate: 0.05,
       games: 1240,
       movement: "UP",
-      previousTier: "A"
+      previousTier: "A",
+      strengthScore: 0.032,
+      contestedScore: 0.21,
+      isLowSample: false
     },
     {
       championId: 103,
       role: "MIDDLE",
       tier: "A",
-      compositeScore: 0.64,
       winRate: 0.5,
       pickRate: 0.08,
+      banRate: 0.03,
       games: 987,
       movement: "DOWN",
-      previousTier: "S"
+      previousTier: "S",
+      strengthScore: 0.012,
+      contestedScore: 0.14,
+      isLowSample: false
     }
   ] as const;
 
@@ -200,23 +206,29 @@ describe("summarizeTierListEntries", () => {
           championId: 266,
           role: "TOP",
           tier: "S",
-          compositeScore: 0.71,
           winRate: 0.52,
           pickRate: 0.13,
+          banRate: 0.05,
           games: 1240,
           movement: "UP",
-          previousTier: "A"
+          previousTier: "A",
+          strengthScore: 0.032,
+          contestedScore: 0.21,
+          isLowSample: false
         },
         {
           championId: 103,
           role: "MIDDLE",
           tier: "A",
-          compositeScore: 0.64,
           winRate: 0.5,
           pickRate: 0.08,
+          banRate: 0.03,
           games: 987,
           movement: "DOWN",
-          previousTier: "S"
+          previousTier: "S",
+          strengthScore: 0.012,
+          contestedScore: 0.14,
+          isLowSample: false
         }
       ])
     ).toEqual({

--- a/docs/API.md
+++ b/docs/API.md
@@ -182,15 +182,16 @@ Tier methodology (`GET /api/lol/analytics/tierlist`):
 `GET /api/lol/analytics/champions/{championId}/builds` includes full rune setup per build:
 - `primaryStyleId`, `subStyleId`
 - `primaryRunes` (4), `subRunes` (2), `statShards` (3)
+- Each build (and each build-path variant below) carries `games`, `winRate`, and `pickRate`. `pickRate` is the share of scoped games using that variant (0–1): main `builds[]` vs the champion+role+scope total; build-path sections vs their own section denominator. It is additive and defaults to `0` for snapshots computed before the field existed (clients hide a `0` pick rate); real values populate on the next analytics refresh.
 - Build item lists include only completed, build-impact items (no components, trinkets, wards, or consumables).
 - If patch item metadata is temporarily incomplete, the service uses a legacy exclusion fallback so builds still render while metadata refresh catches up.
 - The response also carries a sectioned, timeline-derived build path (all optional — `null`/empty when timeline data has not been ingested for the champion/patch):
-  - `summonerSpells[]` — top normalized spell pairs with `games`/`winRate`
-  - `skillOrder` — `{ firstThree, maxOrder, games, winRate }` (e.g. `firstThree: "QWE"`, `maxOrder: "Q>E>W"`)
-  - `startingItems[]` — top opening item sets with `games`/`winRate`
-  - `boots[]` — boots options with `games`/`winRate`
-  - `coreBuildPath[]` — the ordered 1st→2nd→3rd core items, each with `games`, `winRate`, and `avgCompletionMinute`
-  - `situationalSlots[]` — 4th/5th/6th slots, each with the top item `options[]`
+  - `summonerSpells[]` — top normalized spell pairs with `games`/`winRate`/`pickRate`
+  - `skillOrder` — `{ firstThree, maxOrder, games, winRate, pickRate }` (e.g. `firstThree: "QWE"`, `maxOrder: "Q>E>W"`)
+  - `startingItems[]` — top opening item sets with `games`/`winRate`/`pickRate`
+  - `boots[]` — boots options with `games`/`winRate`/`pickRate`
+  - `coreBuildPath[]` — the ordered 1st→2nd→3rd core items, each with `games`, `winRate`, `pickRate`, and `avgCompletionMinute`
+  - `situationalSlots[]` — 4th/5th/6th slots, each with the top item `options[]` (each option carries `games`/`winRate`/`pickRate`)
 - These sections degrade gracefully: champions/patches without ingested timeline build data return the existing build rows with the new fields null.
 
 `GET /api/lol/analytics/champions/{championId}/profile` returns the champion detail payload in one request:

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -6536,6 +6536,10 @@
           "winRate": {
             "type": "number",
             "format": "double"
+          },
+          "pickRate": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false
@@ -7024,6 +7028,10 @@
           "avgCompletionMinute": {
             "type": "number",
             "format": "double"
+          },
+          "pickRate": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false
@@ -7116,6 +7124,10 @@
             "format": "int32"
           },
           "winRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "pickRate": {
             "type": "number",
             "format": "double"
           }
@@ -8503,6 +8515,10 @@
           "winRate": {
             "type": "number",
             "format": "double"
+          },
+          "pickRate": {
+            "type": "number",
+            "format": "double"
           }
         },
         "additionalProperties": false
@@ -8523,6 +8539,10 @@
             "format": "int32"
           },
           "winRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "pickRate": {
             "type": "number",
             "format": "double"
           }
@@ -8746,6 +8766,10 @@
             "format": "int32"
           },
           "winRate": {
+            "type": "number",
+            "format": "double"
+          },
+          "pickRate": {
             "type": "number",
             "format": "double"
           }

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -4829,6 +4829,8 @@ export interface components {
             games?: number;
             /** Format: double */
             winRate?: number;
+            /** Format: double */
+            pickRate?: number;
         };
         ChampionBuildsResponse: {
             /** Format: int32 */
@@ -4994,6 +4996,8 @@ export interface components {
             winRate?: number;
             /** Format: double */
             avgCompletionMinute?: number;
+            /** Format: double */
+            pickRate?: number;
         };
         DataAgeMetadata: {
             /** Format: date-time */
@@ -5030,6 +5034,8 @@ export interface components {
             games?: number;
             /** Format: double */
             winRate?: number;
+            /** Format: double */
+            pickRate?: number;
         };
         LiveGameAnalysisDto: {
             /** Format: date-time */
@@ -5512,6 +5518,8 @@ export interface components {
             games?: number;
             /** Format: double */
             winRate?: number;
+            /** Format: double */
+            pickRate?: number;
         };
         StarterItemSetDto: {
             items?: number[] | null;
@@ -5519,6 +5527,8 @@ export interface components {
             games?: number;
             /** Format: double */
             winRate?: number;
+            /** Format: double */
+            pickRate?: number;
         };
         SummonerAcceptedResponse: {
             /** @description Refresh state message. "Refresh queued" when accepted now, "Refresh in process" when contention is detected. */
@@ -5600,6 +5610,8 @@ export interface components {
             games?: number;
             /** Format: double */
             winRate?: number;
+            /** Format: double */
+            pickRate?: number;
         };
         TeamAnalysisDto: {
             /** Format: int32 */


### PR DESCRIPTION
## Summary
A `/frontend-design` pass: comprehensive audit → 3 implemented milestones.

- **Confidence layer** — sample-size/uncertainty as a first-class visual: a `Confidence` primitive + `lib/confidence.ts`, `DataBar` CI whiskers, per-row low-sample badges on the tier list, a sticky sample strip, and an empirical-Bayes "observed → graded vs role average" hover.
- **Post-game insights** — deterministic, lobby-relative match Takeaways (`lib/matchInsights.ts`), a scoreboard Compact/Detailed density toggle, a profile Performance card (per-role split), and a rebuilt `LiveGameCard` scouting view (was a JSON dump).
- **Build pick-rate** — additive `pickRate` on the build DTOs (**no EF migration**; computed from existing aggregates), plus a client-side instant matchup sort (`MatchupsTable`).

## Validation
- Frontend: `tsc` 0 · `eslint --max-warnings=0` 0 · **143 vitest**
- Backend: `dotnet build` 0 errors · **196 Service.Core tests**
- Contract: `api:gen` regenerated (purely additive); `docs/API.md` updated

## Notes
- `pickRate` stays `0` (UI hides it) until the analytics worker recomputes build snapshots with this code — self-heals on the next refresh; verify post-deploy.
- Also fixes a pre-existing `tierlist.test.ts` typecheck break (stale `compositeScore`).
- Descoped: matchup lens (infeasible ~160× precompute), auto build labels (no data), sticky champion-detail filter (needs a Suspense-layout restructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
