### PR TITLE
fix(web): drop banned match-card side-stripe; polish landing skeleton, lead widow, panel headers

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -291,6 +291,7 @@ body::before {
     font-size: 1.0625rem;
     line-height: 1.7;
     color: color-mix(in oklch, var(--t-fg), transparent 22%);
+    text-wrap: pretty;
   }
   .type-ui {
     font-size: 0.9375rem;
@@ -459,20 +460,25 @@ body::before {
     padding: 0.95rem 1rem;
   }
 
-  /* Match cards — flat surface + win/loss accent edge (no radial glow) */
+  /* Match cards — flat surface with a faint win/loss wash (no side-stripe, no
+     radial glow). Win/loss is carried by the VICTORY/DEFEAT badge + the 1px
+     border tint; this full-surface wash is the scannable at-a-glance
+     reinforcement the old left edge used to provide. */
   .match-card-shell {
     position: relative;
     overflow: hidden;
     border-radius: var(--radius-card);
     transition: transform 160ms var(--ease-out-quart), border-color 160ms var(--ease-out-quart), box-shadow 160ms var(--ease-out-quart);
   }
+  /* Interpolate in oklab (rectangular), not oklch: mixing a saturated accent
+     into a near-achromatic surface in cylindrical oklch lets the surface's
+     powerless hue drag the result toward slate on some engines, collapsing the
+     win/loss tints into the same gray. oklab keeps the green/red deterministic. */
   .match-card-shell--win {
-    border-left: 3px solid color-mix(in oklch, var(--t-win), transparent 25%);
-    background: var(--t-surface);
+    background: color-mix(in oklab, var(--t-win) 5%, var(--t-surface));
   }
   .match-card-shell--loss {
-    border-left: 3px solid color-mix(in oklch, var(--t-loss), transparent 25%);
-    background: var(--t-surface);
+    background: color-mix(in oklab, var(--t-loss) 5%, var(--t-surface));
   }
   .match-card-shell:hover {
     transform: translateY(-1px);

--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -9,11 +9,18 @@ export default function Loading() {
   return (
     <div className="grid gap-8">
       <section className="page-hero p-6 sm:p-8 md:p-10">
-        <div className="grid max-w-3xl gap-3">
-          <Skeleton className="h-10 w-11/12 rounded-lg" />
-          <Skeleton className="h-10 w-2/3 rounded-lg" />
+        {/* Three lines of display type: bar heights track the clamp()-sized
+            headline (h-10→14) and the lead runs two lines, so the real hero
+            (~476px on desktop) streams in without shoving the panels down. */}
+        <div className="grid max-w-3xl gap-3 sm:gap-3.5 md:gap-4">
+          <Skeleton className="h-10 w-full rounded-lg sm:h-12 md:h-14" />
+          <Skeleton className="h-10 w-11/12 rounded-lg sm:h-12 md:h-14" />
+          <Skeleton className="h-10 w-2/5 rounded-lg sm:h-12 md:h-14" />
         </div>
-        <Skeleton className="mt-6 h-4 w-3/4 max-w-2xl rounded-md" />
+        <div className="mt-5 grid max-w-2xl gap-2">
+          <Skeleton className="h-4 w-full rounded-md" />
+          <Skeleton className="h-4 w-1/3 rounded-md" />
+        </div>
         <div className="mt-8 grid gap-3">
           <Skeleton className="h-14 w-full max-w-2xl rounded-control" />
           <Skeleton className="h-3.5 w-64 rounded-md" />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -138,7 +138,7 @@ export default async function LandingPage() {
       >
         {hasPicks ? (
           <div className="page-panel grid gap-4 p-5 sm:p-6">
-            <div className="flex items-center justify-between gap-3">
+            <div className="flex min-h-7 items-center justify-between gap-3">
               <span className="inline-flex flex-wrap items-center gap-2">
                 <span className="type-kicker text-muted">Top picks · Emerald+</span>
                 {patch ? <Badge>Patch {patch}</Badge> : null}
@@ -184,7 +184,7 @@ export default async function LandingPage() {
         ) : null}
 
         <div className="page-panel grid content-start gap-4 p-5 sm:p-6">
-          <p className="type-kicker text-muted">Explore</p>
+          <p className="type-kicker flex min-h-7 items-center text-muted">Explore</p>
           <div className="grid">
             {EXPLORE.map((dest, index) => (
               <Link

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -126,10 +126,6 @@ function MatchHistoryCard({
         match.win ? "match-card-shell--win border-success/28" : "match-card-shell--loss border-danger/28"
       } rounded-panel border`}
     >
-      <span
-        className={`absolute inset-y-0 left-0 w-1.5 ${match.win ? "bg-success/75" : "bg-danger/75"}`}
-        aria-hidden="true"
-      />
       <button
         className="relative z-10 w-full px-4 py-4 text-left focus-visible:outline-none md:px-5 md:py-5"
         onClick={() => void onToggleExpanded(match.matchId)}


### PR DESCRIPTION
## What

A frontend polish pass on the landing page, plus removal of a design-system violation it surfaced on the profile match cards.

### Landing (`app/page.tsx`, `app/loading.tsx`, `globals.css`)
- **Cut a ~150px first-paint layout jump.** The `loading.tsx` hero skeleton was ~325px tall while the real hero is ~476px (3-line `type-display` + 2-line lead + search), so the panels lurched down when data streamed in. Reworked the skeleton to 3 responsive headline bars (`h-10 → h-14`) + a 2-line lead; it now measures ~456px, cutting the jump to ~20px.
- **Fixed a typographic widow.** The hero subtitle wrapped "games." alone on its second line. Added `text-wrap: pretty` to the shared `.type-lead` class (a root-cause fix that improves lead text app-wide); it now reads "…continuously from / ranked games."
- **Aligned the two panel-header kickers.** "Top picks" sat 7px below "Explore" because the left header carries a badge/link that vertically centered its kicker. Gave both header zones `min-h-7 items-center` so the kickers share a baseline and the panels read as a matched pair.

### Profile match cards (`MatchHistorySection.tsx`, `globals.css`)
- **Removed a banned side-stripe.** Each match card had a 6px win/loss bar pinned to its left edge (plus dead CSS `border-left: 3px` that Tailwind's `border` utility already overrode) — the exact side-stripe pattern DESIGN.md's anti-references forbid. Replaced the flat surface with a faint 5% win/loss background wash, the op.gg-style compliant way to keep at-a-glance scannability. Win/loss is still carried by the VICTORY/DEFEAT badge + the 1px tinted border, so the encoding stays color-blind-safe and no information is lost.
- **Interpolated the wash in oklab, not oklch.** Mixing a saturated accent into a near-achromatic surface in cylindrical oklch lets the surface's powerless hue drag the result toward slate on some engines, collapsing win and loss into the same gray. oklab (the rectangular form of the same space) keeps the green/red deterministic everywhere. Verified against real painted pixels: light win `(242,247,245)` / loss `(252,244,243)`, dark win `(23,31,36)` / loss `(30,27,34)` — clearly differentiated in both themes.

## Verification
- Rendered against the live backend in both light and dark themes: landing (loaded + loading skeleton) and the sample profile match history (12W/8L). Confirmed the stripe is gone, the wash is subtle and stat text stays legible, and the two landing kickers now share a baseline (text-center Y equal).
- `pnpm lint` (`--max-warnings=0`) and `pnpm build` both pass.
- Adversarial multi-lens review (correctness / DS-compliance / a11y-contrast / consistency) of the diff; its one finding (color-mix hue) was verified against ground-truth pixels and hardened via the oklab switch above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
