### PR TITLE
fix(web): polish summoner profile — data scope, a11y, confidence, copy

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -487,7 +487,7 @@ body::before {
   }
   .match-card-shell:focus-within {
     border-color: color-mix(in oklch, var(--t-primary), transparent 45%);
-    box-shadow: 0 0 0 1px color-mix(in oklch, var(--t-primary), transparent 60%);
+    box-shadow: 0 0 0 2px color-mix(in oklch, var(--t-primary), transparent 30%);
   }
   .match-detail-shell {
     position: relative; border-radius: var(--radius-card);

--- a/apps/web/app/lol/summoners/[region]/[riotId]/loading.tsx
+++ b/apps/web/app/lol/summoners/[region]/[riotId]/loading.tsx
@@ -1,24 +1,66 @@
 import { Card } from "@/components/ui/Card";
 import { Skeleton } from "@/components/ui/Skeleton";
 
+// Mirrors the shipped profile shell (SummonerProfileUnified): a compact Toolbar
+// hero over an xl sidebar + main split. Matching the real structure keeps the
+// layout from jumping when the server fetch resolves. Flat placeholders, no
+// shimmer, per the design system.
 export default function Loading() {
   return (
-    <div className="grid gap-6">
-      <Card className="p-5">
-        <Skeleton className="h-6 w-48" />
-        <Skeleton className="mt-3 h-4 w-80" />
-      </Card>
-      <div className="grid gap-6 md:grid-cols-2">
-        <Card className="p-5">
-          <Skeleton className="h-5 w-40" />
-          <Skeleton className="mt-4 h-24 w-full" />
-        </Card>
-        <Card className="p-5">
-          <Skeleton className="h-5 w-40" />
-          <Skeleton className="mt-4 h-24 w-full" />
-        </Card>
+    <div className="grid grid-cols-1 gap-8">
+      {/* Hero — the Toolbar primitive: identity + actions, then a recent-form row */}
+      <div className="toolbar flex flex-col gap-3 px-4 py-3.5 sm:px-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-12 w-12 rounded-xl" />
+            <div className="grid gap-2">
+              <Skeleton className="h-6 w-44" />
+              <Skeleton className="h-3.5 w-56" />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-9 w-28 rounded-control" />
+            <Skeleton className="h-9 w-28 rounded-control" />
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 border-t border-border/70 pt-3">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <Skeleton key={i} className="h-2.5 w-7 rounded-full" />
+          ))}
+        </div>
+      </div>
+
+      {/* Sidebar + main, matching the xl:grid-cols split of the live page */}
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(280px,0.32fr)_minmax(0,1fr)] xl:items-start">
+        <div className="grid content-start gap-5">
+          <Card className="profile-section-card p-5">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="mt-3 h-24 w-full" />
+          </Card>
+          <Card className="profile-section-card p-5">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="mt-3 h-40 w-full" />
+          </Card>
+        </div>
+        <div className="grid gap-6">
+          <Card className="profile-section-card p-5">
+            <Skeleton className="h-3 w-28" />
+            <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          </Card>
+          <Card className="profile-section-card rounded-panel p-5 md:p-6">
+            <Skeleton className="h-6 w-40" />
+            <div className="mt-5 flex flex-col gap-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-24 w-full rounded-panel" />
+              ))}
+            </div>
+          </Card>
+        </div>
       </div>
     </div>
   );
 }
-

--- a/apps/web/app/lol/summoners/[region]/[riotId]/page.tsx
+++ b/apps/web/app/lol/summoners/[region]/[riotId]/page.tsx
@@ -80,7 +80,7 @@ export default async function SummonerProfilePage({
     return (
       <BackendErrorCard
         title="Summoner"
-        message="Invalid player link. Use /summoners/{region}/{gameName}-{tagLine}."
+        message="This player link isn't valid. Search for the player by name from the home page instead."
         requestId={pageRequestId}
         detail={
           verbosity === "verbose"

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -181,21 +181,6 @@ export function SummonerProfileClient({
     return (history?.items ?? []).slice(0, 10).map((match) => match.win);
   }, [history?.items]);
 
-  const quickStats = useMemo(() => {
-    const matches = history?.items ?? [];
-    if (matches.length === 0) return null;
-
-    const total = matches.length;
-    const wins = matches.filter((match) => match.win).length;
-    const avgKda = matches.reduce((sum, match) => sum + matchKdaRatio(match), 0) / total;
-
-    return {
-      total,
-      winRate: wins / total,
-      avgKda
-    };
-  }, [history?.items]);
-
   useEffect(() => {
     if (!history || !expandedMatchId) return;
     if (visibleMatches.some((match) => match.matchId === expandedMatchId)) return;
@@ -285,7 +270,7 @@ export function SummonerProfileClient({
     if (pollAttempts >= MAX_POLL_ATTEMPTS) {
       setPolling(false);
       setAccepted({
-        message: "This update is taking longer than expected — it'll keep processing in the background. Tap Update Now to check again."
+        message: "This update is taking longer than expected — it'll keep processing in the background. Use Update Now to check again."
       });
       return;
     }
@@ -445,7 +430,6 @@ export function SummonerProfileClient({
         championStatic={championStatic}
         dataAge={dataAge}
         rankedEntries={rankedEntries}
-        quickStats={quickStats}
         recentForm={recentForm}
         accepted={accepted}
         error={error}

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -123,7 +123,7 @@ function MatchHistoryCard({
   return (
     <div
       className={`match-card-shell ${
-        match.win ? "match-card-shell--win border-success/28" : "match-card-shell--loss border-danger/28"
+        match.win ? "match-card-shell--win border-win/28" : "match-card-shell--loss border-loss/28"
       } rounded-panel border`}
     >
       <button
@@ -139,7 +139,7 @@ function MatchHistoryCard({
             <div className="flex flex-wrap items-center gap-2">
               <span
                 className={`type-overline rounded-full px-2.5 py-1 ${
-                  match.win ? "bg-success/15 text-success" : "bg-danger/15 text-danger"
+                  match.win ? "bg-win/15 text-win" : "bg-loss/15 text-loss"
                 }`}
               >
                 {match.win ? "VICTORY" : "DEFEAT"}
@@ -291,7 +291,7 @@ function MatchHistoryCard({
           <div className="grid gap-2 xl:justify-items-end">
             <div className="surface-subtle rounded-card px-4 py-3 text-right">
               <p className="text-xl font-semibold leading-tight tracking-tight text-fg">
-                <span>{match.kills}</span>/<span className="text-danger/90">{match.deaths}</span>/<span>{match.assists}</span>
+                <span>{match.kills}</span>/<span className="text-loss/90">{match.deaths}</span>/<span>{match.assists}</span>
               </p>
               <p className="mt-1 text-xs font-medium text-fg/82">
                 {matchKdaRatio(match).toFixed(2)} KDA
@@ -322,7 +322,7 @@ function MatchHistoryCard({
             <div className="mt-4 border-t border-border/55 px-4 pt-4 md:px-5">
               {detailBusy ? <Skeleton className="h-12 w-full" /> : null}
               {!detailBusy && !detail ? (
-                <p className="text-sm text-fg/75">Detailed rows are unavailable for this match.</p>
+                <p className="text-sm text-fg/75">Detailed stats are unavailable for this match.</p>
               ) : null}
               {detail ? (
                 <MatchScoreboard
@@ -485,12 +485,11 @@ export function MatchHistorySection({
         </div>
 
         <p className="mt-3 text-xs text-muted">
-          Match history:{" "}
           <Link
             href={`/lol/summoners/${region}/${encodeRiotIdPath({ gameName, tagLine })}/matches`}
-            className="text-primary hover:underline"
+            className="rounded-control text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
           >
-            /lol/summoners/.../matches
+            View full match history →
           </Link>
         </p>
       </Card>

--- a/apps/web/components/lol-profile/PerformanceCard.tsx
+++ b/apps/web/components/lol-profile/PerformanceCard.tsx
@@ -4,7 +4,7 @@ import { LaneIcon } from "@/components/ui/LaneIcon";
 import { Stat } from "@/components/ui/Stat";
 import { cn } from "@/lib/cn";
 import { formatGames } from "@/lib/format";
-import { roleDisplayLabel } from "@/lib/roles";
+import { LANE_ROLES, roleDisplayLabel } from "@/lib/roles";
 
 import {
   matchKdaRatio,
@@ -70,10 +70,12 @@ export function PerformanceCard({
     buckets.set(role, bucket);
   }
 
-  // Drop UNKNOWN entirely — an "Unknown" role row teaches nothing. If every match
-  // is unknown the per-role section simply renders nothing.
+  // Keep only the five real lanes. normalizeRoleKey maps every valid position into
+  // LANE_ROLES (SUPPORT→UTILITY), so this drops both "UNKNOWN" and the non-standard
+  // teamPosition tokens that special modes (e.g. Arena) carry — those render as a
+  // meaningless "Unknown" row and teach nothing about how the player lanes.
   const roleRows: RoleRow[] = [...buckets.entries()]
-    .filter(([role]) => role !== "UNKNOWN")
+    .filter(([role]) => (LANE_ROLES as readonly string[]).includes(role))
     .map(([role, bucket]) => {
       let topChampionId = -1;
       let topCount = -1;
@@ -105,11 +107,17 @@ export function PerformanceCard({
       </div>
 
       {hasAverages ? (
-        <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <Stat label="CS / min" value={formatStat(overviewStats.avgCsPerMin, 1)} />
-          <Stat label="Vision" value={formatStat(overviewStats.avgVisionScore, 1)} />
-          <Stat label="KDA" value={formatStat(overviewStats.kdaRatio, 2)} />
-          <Stat label="Dmg / game" value={formatCompactNumber(overviewStats.avgDamageToChamps)} />
+        <div className="mt-4 grid gap-2">
+          <div className="flex items-center justify-between gap-2">
+            <p className="type-overline text-muted">Averages</p>
+            <p className="type-caption text-muted">Across {formatGames(overviewStats.totalMatches)} games</p>
+          </div>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <Stat label="CS / min" value={formatStat(overviewStats.avgCsPerMin, 1)} />
+            <Stat label="Vision" value={formatStat(overviewStats.avgVisionScore, 1)} />
+            <Stat label="KDA" value={formatStat(overviewStats.kdaRatio, 2)} />
+            <Stat label="Dmg / game" value={formatCompactNumber(overviewStats.avgDamageToChamps)} />
+          </div>
         </div>
       ) : null}
 

--- a/apps/web/components/lol-profile/ProfileHeroCard.tsx
+++ b/apps/web/components/lol-profile/ProfileHeroCard.tsx
@@ -17,12 +17,6 @@ import {
 } from "@/components/lol-profile/shared";
 import { rankTierDisplayLabel } from "@/lib/ranks";
 
-type QuickStats = {
-  total: number;
-  winRate: number;
-  avgKda: number;
-};
-
 type RankedEntry = {
   label: string;
   rank: RankInfo;
@@ -41,7 +35,6 @@ export function ProfileHeroCard({
   championStatic,
   dataAge,
   rankedEntries,
-  quickStats,
   recentForm,
   accepted,
   error,
@@ -56,7 +49,6 @@ export function ProfileHeroCard({
   championStatic: ChampionStatic | null;
   dataAge: string;
   rankedEntries: RankedEntry[];
-  quickStats: QuickStats | null;
   recentForm: boolean[];
   accepted: AcceptedResponse | null;
   error: ApiErrorResponse | null;
@@ -67,6 +59,13 @@ export function ProfileHeroCard({
   const rankText = primaryRank
     ? `${rankTierDisplayLabel(primaryRank.tier)} ${primaryRank.division}`
     : "Unranked";
+
+  // Win rate is derived from — and labelled against — the same recent-form window
+  // as the pips below, so it never reads as (and never contradicts) the ranked win
+  // rate broken out in the sidebar.
+  const recentWins = recentForm.filter(Boolean).length;
+  const recentWr =
+    recentForm.length > 0 ? formatPercent(recentWins / recentForm.length) : null;
 
   return (
     <div className="flex flex-col gap-3">
@@ -96,7 +95,6 @@ export function ProfileHeroCard({
               {rankText}
               {primaryRank ? ` · ${primaryRank.leaguePoints} LP` : ""}
             </span>
-            {quickStats ? <span className="text-fg/80">{formatPercent(quickStats.winRate)} WR</span> : null}
           </>
         }
         actions={
@@ -111,18 +109,31 @@ export function ProfileHeroCard({
           recentForm.length > 0 ? (
             <>
               <span className="type-overline text-muted">Recent form</span>
-              <div className="flex flex-wrap items-center gap-1" aria-label="Recent match outcomes (latest first)">
+              {/* Wins render solid, losses render outlined: a fill/shape cue that
+                  survives red/green color blindness, with color as a redundant
+                  signal. The whole strip is one labelled image for screen readers;
+                  the individual pips are decorative (aria-hidden). */}
+              <div
+                className="flex flex-wrap items-center gap-1"
+                role="img"
+                aria-label={`Recent form, latest first: ${recentForm
+                  .map((win) => (win ? "Win" : "Loss"))
+                  .join(", ")}`}
+              >
                 {recentForm.map((win, idx) => (
                   <span
                     key={`${win ? "w" : "l"}-${idx}`}
-                    className={`h-2.5 w-7 rounded-full ${win ? "bg-success/75" : "bg-danger/70"}`}
-                    aria-label={win ? "Win" : "Loss"}
+                    aria-hidden="true"
+                    className={`h-2.5 w-7 rounded-full ${
+                      win ? "bg-win/80" : "border border-loss/70 bg-loss/25"
+                    }`}
                     title={win ? "Win" : "Loss"}
                   />
                 ))}
               </div>
               <span className="type-caption ml-auto text-muted">
-                Last {recentForm.length} · {dataAge}
+                Last {recentForm.length}
+                {recentWr ? ` · ${recentWr} WR` : ""} · {dataAge}
               </span>
             </>
           ) : undefined

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -153,7 +153,7 @@ export function ProfileSidebar({
                 <Link
                   key={m.championId}
                   href={`/lol/champions/${m.championId}`}
-                  className="surface-subtle group flex items-center gap-3 rounded-control px-3 py-2.5 transition hover:border-border-strong hover:bg-surface-2/60"
+                  className="surface-subtle group flex items-center gap-3 rounded-control px-3 py-2.5 transition hover:border-border-strong hover:bg-surface-2/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
                 >
                   {champion && championStatic ? (
                     <Image
@@ -198,7 +198,7 @@ export function ProfileSidebar({
               <Link
                 key={championStat.championId}
                 href={`/lol/champions/${championStat.championId}`}
-                className="surface-subtle group grid gap-2 rounded-control px-3 py-3 transition hover:border-border-strong hover:bg-surface-2/60"
+                className="surface-subtle group grid gap-2 rounded-control px-3 py-3 transition hover:border-border-strong hover:bg-surface-2/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
               >
                 <div className="flex items-center justify-between gap-3">
                   <div>
@@ -207,7 +207,7 @@ export function ProfileSidebar({
                       {champion?.name ?? championStat.championName}
                     </p>
                   </div>
-                  <DataBar value={championStat.winRate} />
+                  <DataBar value={championStat.winRate} games={championStat.games} />
                 </div>
                 <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
                   <span>{championStat.games} games tracked</span>
@@ -233,14 +233,14 @@ export function ProfileSidebar({
                 <Link
                   key={mate.summonerId}
                   href={`/lol/summoners/${region}/${encodeRiotIdPath({ gameName: mate.gameName, tagLine: mate.tagLine })}`}
-                  className="surface-subtle group grid gap-1.5 rounded-control px-3 py-2.5 transition hover:border-border-strong hover:bg-surface-2/60"
+                  className="surface-subtle group grid gap-1.5 rounded-control px-3 py-2.5 transition hover:border-border-strong hover:bg-surface-2/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
                 >
                   <div className="flex items-center justify-between gap-3">
                     <p className="min-w-0 truncate text-sm font-medium text-fg group-hover:text-primary">
                       {mate.gameName}
                       <span className="text-muted">#{mate.tagLine}</span>
                     </p>
-                    {wr != null ? <DataBar value={wr} /> : null}
+                    {wr != null ? <DataBar value={wr} games={mate.sameTeamGames} /> : null}
                   </div>
                   <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
                     <span>{mate.gamesTogether} games together</span>

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -185,7 +185,7 @@ function ScoreboardRow({
             {canLink ? (
               <Link
                 href={`/lol/summoners/${region}/${encodeRiotIdPath({ gameName: participant.gameName as string, tagLine: participant.tagLine as string })}`}
-                className="block truncate text-sm font-medium text-fg/95 transition-colors hover:text-primary hover:underline"
+                className="block truncate rounded text-sm font-medium text-fg/95 transition-colors hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
               >
                 {displayName}
               </Link>
@@ -226,13 +226,17 @@ function ScoreboardRow({
               </div>
             }
           >
-            <div className="ml-auto mt-1 h-1.5 w-16 overflow-hidden rounded-full bg-surface-2/70">
-              <div className="flex h-full" style={{ width: `${damageFillPct}%` }}>
+            <button
+              type="button"
+              aria-label={`Damage ${totalDmg.toLocaleString()}: ${physDmg.toLocaleString()} physical, ${magicDmg.toLocaleString()} magic, ${trueDmg.toLocaleString()} true`}
+              className="ml-auto mt-1 block h-1.5 w-16 overflow-hidden rounded-full bg-surface-2/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45"
+            >
+              <span className="flex h-full" style={{ width: `${damageFillPct}%` }}>
                 <span className="h-full" style={{ width: `${(physDmg / splitSum) * 100}%`, backgroundColor: "var(--color-loss)" }} />
                 <span className="h-full" style={{ width: `${(magicDmg / splitSum) * 100}%`, backgroundColor: "var(--color-team-blue)" }} />
                 <span className="h-full" style={{ width: `${(trueDmg / splitSum) * 100}%`, backgroundColor: "var(--color-fg)" }} />
-              </div>
-            </div>
+              </span>
+            </button>
           </Tooltip>
         ) : null}
       </Td>

--- a/apps/web/lib/queues.ts
+++ b/apps/web/lib/queues.ts
@@ -9,6 +9,7 @@ const QUEUE_ID_LABELS: Record<number, string> = {
   900: "ARURF",
   1700: "Arena",
   1710: "Arena",
+  1750: "Arena",
   1810: "Arena",
   1820: "Arena",
   1830: "Arena",


### PR DESCRIPTION
Craft/polish pass on the summoner profile page, driven by a 4-lens audit (copy/clarity, IA + data-integrity, a11y, tokens/visual) with each finding adversarially verified before implementing. The page was already in good shape; these are low-risk, high-value fixes. Verified in light + dark + mobile against live data.

### Data integrity & trust
- **Drop the junk "Unknown" role row** in "By role" — Arena/special-mode matches carry a non-lane `teamPosition` that slipped the old `!== "UNKNOWN"` filter and rendered as a meaningless "Unknown" row; now filters to real lanes (`LANE_ROLES`).
- **Fix the misleading hero WR** — it was unlabeled and computed over loaded history (all queues, ≤20 games), so it read as the ranked WR but contradicted the sidebar (60% vs 54.4%). Relocated into the recent-form caption, scoped to the same window (`Last 10 · 70.0% WR`). Removes the now-dead `quickStats` memo/prop.
- **Confidence whiskers** — sidebar champion-pool and played-with `DataBar`s now pass `games`, so thin samples (e.g. 100% over 6 duo games) render a 95% CI whisker instead of reading as certain.
- **Scope caption** on the "How you play" averages so the all-time figures don't blur with the `From last 20 games` by-role block.

### Accessibility
- Recent-form pips get a **non-hue cue** (solid win / outlined loss) + a single `role="img"` label (per-pip aria was on non-announced spans).
- **Focus-visible rings** on sidebar / scoreboard / footer links — a global `*:focus-visible { outline: none }` had left every custom `<Link>` with no keyboard indicator.
- Damage-split bar is now a focusable `<button>` (its breakdown was keyboard-unreachable in a tooltip); match-card focus ring bumped 1px → 2px.

### Copy & tokens
- Footer route-path link `/lol/summoners/.../matches` → **"View full match history"**; friendlier invalid-link error; `Tap` → `Use`; `rows` → `stats`; map queue `1750` → **Arena**.
- Match-outcome colors moved from `success`/`danger` to the `win`/`loss` **data tokens** (zero-pixel; `--t-win` ≡ `--t-success`).
- `loading.tsx` rewritten to mirror the real Toolbar + sidebar/main shell (no more layout jump on data arrival).

### Verification
- `tsc --noEmit` clean, `pnpm lint` clean (0 warnings), **136 web tests pass**.

### Follow-ups (out of scope, not in this PR)
- Queue **710** is still unmapped (renders "Queue 710"); needs backend queue-enum confirmation before labeling.
- Backend `profileAge.ageDescription` has a pluralization bug ("1 hours ago") — server-side string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
