### PR TITLE
feat(web): collapse profile by-role by default + grammar & thin-sample polish

### DIFF
--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -8,6 +8,7 @@ import { ScoreboardTeamTable, type ScoreboardDensity } from "@/components/lol-pr
 import { GoldDiffChart } from "@/components/lol-profile/GoldDiffChart";
 import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { cn } from "@/lib/cn";
+import { plural } from "@/lib/format";
 import { deriveMatchTakeaways, type Takeaway, type TakeawayTone } from "@/lib/matchInsights";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl } from "@/lib/staticData";
@@ -139,14 +140,15 @@ function MatchTakeaways({ takeaways }: { takeaways: Takeaway[] }) {
 }
 
 function TeamObjectivesSummary({ team, side }: { team: MatchTeamObjectives | undefined; side: "blue" | "red" }) {
+  const obj = (n: number, noun: string) => `${n} ${plural(n, noun)}`;
   const items = team
     ? [
-        team.dragon.kills > 0 ? `${team.dragon.kills} Dragon` : null,
-        team.baron.kills > 0 ? `${team.baron.kills} Baron` : null,
-        team.riftHerald.kills > 0 ? `${team.riftHerald.kills} Herald` : null,
-        team.horde.kills > 0 ? `${team.horde.kills} Grubs` : null,
-        `${team.tower.kills} Towers`,
-        team.inhibitor.kills > 0 ? `${team.inhibitor.kills} Inhib` : null
+        team.dragon.kills > 0 ? obj(team.dragon.kills, "Dragon") : null,
+        team.baron.kills > 0 ? obj(team.baron.kills, "Baron") : null,
+        team.riftHerald.kills > 0 ? obj(team.riftHerald.kills, "Herald") : null,
+        team.horde.kills > 0 ? obj(team.horde.kills, "Grub") : null,
+        obj(team.tower.kills, "Tower"),
+        team.inhibitor.kills > 0 ? obj(team.inhibitor.kills, "Inhib") : null
       ].filter(Boolean)
     : [];
 

--- a/apps/web/components/lol-profile/PerformanceCard.tsx
+++ b/apps/web/components/lol-profile/PerformanceCard.tsx
@@ -3,7 +3,7 @@ import { DataBar } from "@/components/ui/DataBar";
 import { LaneIcon } from "@/components/ui/LaneIcon";
 import { Stat } from "@/components/ui/Stat";
 import { cn } from "@/lib/cn";
-import { formatGames } from "@/lib/format";
+import { formatGames, plural } from "@/lib/format";
 import { LANE_ROLES, roleDisplayLabel } from "@/lib/roles";
 
 import {
@@ -110,7 +110,7 @@ export function PerformanceCard({
         <div className="mt-4 grid gap-2">
           <div className="flex items-center justify-between gap-2">
             <p className="type-overline text-muted">Averages</p>
-            <p className="type-caption text-muted">Across {formatGames(overviewStats.totalMatches)} games</p>
+            <p className="type-caption text-muted">Across {formatGames(overviewStats.totalMatches)} {plural(overviewStats.totalMatches, "game")}</p>
           </div>
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
             <Stat label="CS / min" value={formatStat(overviewStats.avgCsPerMin, 1)} />
@@ -122,29 +122,48 @@ export function PerformanceCard({
       ) : null}
 
       {hasRoles ? (
-        <div className={cn("grid gap-2", hasAverages && "mt-5 border-t border-border pt-5")}>
-          <div className="flex items-center justify-between gap-2">
-            <p className="type-overline text-muted">By role</p>
-            <p className="type-caption text-muted">From last {formatGames(matches.length)} games</p>
-          </div>
-          {roleRows.map((row) => (
-            <div key={row.role} className="surface-subtle grid gap-2 rounded-control px-3 py-2.5">
-              <div className="flex items-center justify-between gap-3">
-                <div className="flex min-w-0 items-center gap-2">
-                  <LaneIcon role={row.role} className="h-4 w-4 shrink-0 text-muted" />
-                  <span className="truncate text-sm font-medium text-fg">{roleDisplayLabel(row.role)}</span>
+        // Collapsed by default so the match history sits higher on the page — the
+        // season averages above answer "how do you play" at a glance, and the
+        // per-role split is one click of depth away. Native <details> keeps it
+        // keyboard-accessible with no client state.
+        <details className={cn("group", hasAverages && "mt-5 border-t border-border/70 pt-5")}>
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded-control py-2 [&::-webkit-details-marker]:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45">
+            <span className="flex items-center gap-2">
+              <svg
+                viewBox="0 0 12 12"
+                aria-hidden="true"
+                className="size-3 shrink-0 text-muted transition-transform duration-150 group-open:rotate-90"
+              >
+                <path d="M4.5 3 7.5 6 4.5 9" stroke="currentColor" strokeWidth="1.4" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+              <span className="type-overline text-muted">By role</span>
+            </span>
+            <span className="type-caption text-muted">From last {formatGames(matches.length)} {plural(matches.length, "game")}</span>
+          </summary>
+          <div className="mt-3 grid gap-2">
+            {roleRows.map((row) => (
+              <div key={row.role} className="surface-subtle grid gap-2 rounded-control px-3 py-2.5">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <LaneIcon role={row.role} className="h-4 w-4 shrink-0 text-muted" />
+                    <span className="truncate text-sm font-medium text-fg">{roleDisplayLabel(row.role)}</span>
+                  </div>
+                  {/* A single-game (usually off-role) row lands at 0%/100%, where the
+                      Wald CI whisker collapses and the bar would read as a confident
+                      verdict. Below 2 games we render a muted "—" instead — matching
+                      the played-with guard and the "never present small-n as fact" rule. */}
+                  <DataBar value={row.games >= 2 ? row.winRate : null} games={row.games} />
                 </div>
-                <DataBar value={row.winRate} games={row.games} />
+                <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
+                  <span className="min-w-0 truncate">
+                    {formatGames(row.games)} {plural(row.games, "game")}{row.topChampion ? ` · ${row.topChampion}` : ""}
+                  </span>
+                  <span className="shrink-0 tabular-nums">{row.avgKda.toFixed(2)} KDA</span>
+                </div>
               </div>
-              <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
-                <span className="min-w-0 truncate">
-                  {formatGames(row.games)} games{row.topChampion ? ` · ${row.topChampion}` : ""}
-                </span>
-                <span className="shrink-0 tabular-nums">{row.avgKda.toFixed(2)} KDA</span>
-              </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        </details>
       ) : null}
     </Card>
   );

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -7,7 +7,7 @@ import { Card } from "@/components/ui/Card";
 import { DataBar } from "@/components/ui/DataBar";
 import { Sparkline } from "@/components/ui/Sparkline";
 import { championIconUrl } from "@/lib/staticData";
-import { formatPercent, winRateColorClass } from "@/lib/format";
+import { formatPercent, plural, winRateColorClass } from "@/lib/format";
 import { rankEmblemUrl, rankTierDisplayLabel, rankToLadderPoints } from "@/lib/ranks";
 import { encodeRiotIdPath } from "@/lib/riotid";
 
@@ -210,7 +210,7 @@ export function ProfileSidebar({
                   <DataBar value={championStat.winRate} games={championStat.games} />
                 </div>
                 <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
-                  <span>{championStat.games} games tracked</span>
+                  <span>{championStat.games} {plural(championStat.games, "game")} tracked</span>
                   <span>{championStat.kdaRatio.toFixed(2)} KDA</span>
                 </div>
               </Link>
@@ -243,7 +243,7 @@ export function ProfileSidebar({
                     {wr != null ? <DataBar value={wr} games={mate.sameTeamGames} /> : null}
                   </div>
                   <div className="flex items-center justify-between gap-2 text-xs text-fg/64">
-                    <span>{mate.gamesTogether} games together</span>
+                    <span>{mate.gamesTogether} {plural(mate.gamesTogether, "game")} together</span>
                     {mate.sameTeamGames > 0 ? <span>{mate.sameTeamGames} as duo</span> : null}
                   </div>
                 </Link>

--- a/apps/web/lib/format.ts
+++ b/apps/web/lib/format.ts
@@ -63,6 +63,12 @@ export function formatGames(count: number | null | undefined): string {
   return Math.floor(count).toLocaleString();
 }
 
+// Count-agreeing noun: plural(1, "game") → "game", plural(3, "game") → "games".
+// Pair with the caller's own number formatting, e.g. `{formatGames(n)} {plural(n, "game")}`.
+export function plural(count: number | null | undefined, noun: string): string {
+  return count === 1 ? noun : `${noun}s`;
+}
+
 export function formatRelativeTime(timestamp: number | null | undefined): string {
   if (timestamp == null || !Number.isFinite(timestamp)) return "";
   const now = Date.now();


### PR DESCRIPTION
### By-role collapse
Match history now sits higher on the profile. The "By role" performance breakdown is a native `<details>` disclosure, **collapsed by default** — the season averages above answer "how do you play" at a glance, and the per-role split is one click of depth away. Reuses the existing champions-page chevron pattern (`group-open:rotate`); keyboard- and touch-accessible with no client state.

### Second impeccable pass (adversarial audit)
A fresh 4-lens audit, told what the first pass fixed so it hunted new issues. Confirmed fixes:

- **Pluralization** — new `format.ts` `plural()` helper fixes grammar across the page: `"1 game"` (was "1 games"), `"1 game tracked"` / `"1 game together"`, and the match objectives strip (`"3 Dragons"`, `"1 Tower"` — were "3 Dragon" / "1 Towers" / "1 Grubs").
- **Thin-sample honesty** — a single-game (usually off-role) row rendered a bold, fully-saturated `0.0%`/`100%` win-rate bar whose 95% CI whisker collapses at the extremes, so the least-certain reading looked the most confident. Below 2 games it now shows a muted `—`, matching the existing played-with guard and the "never present small-n noise as fact" principle.
- **Touch + token consistency** — the collapse summary gains `py-2` for a 24px tap target; its focus ring `/40`→`/45` and the section divider `border-border`→`border-border/70` align the two new outliers to the page's standard.

### Verification
`tsc --noEmit` clean, `pnpm lint` clean (0 warnings), **136 web tests pass**; screenshots confirm the collapse (default + expanded), the `—` guard, and the objectives grammar in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
