### PR TITLE
perf(analytics): P1 wave-2 backend correctness (SQL aggregation, caching, invalidation)

### DIFF
--- a/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
@@ -161,7 +161,9 @@ public class SummonerStatsService(
     private async Task<IReadOnlyList<ChampionStat>> ComputeChampionStatsAsync(Guid summonerId, int top,
         CancellationToken ct)
     {
-        var games = await db.MatchParticipants
+        // Aggregate server-side (GROUP BY ChampionId) so only the grouped rows leave the DB.
+        // Mirrors the ComputeOverviewAsync aggregate pattern (project → GroupBy → Select).
+        var rows = await db.MatchParticipants
             .AsNoTracking()
             .Where(mp => mp.SummonerId == summonerId)
             .InRankedSoloQueue()
@@ -177,36 +179,39 @@ public class SummonerStatsService(
                 Cs = mp.TotalMinionsKilled + mp.NeutralMinionsKilled,
                 MatchDuration = mp.Match.Duration
             })
-            .ToListAsync(ct);
-
-        var list = games
             .GroupBy(x => x.ChampionId)
-            .Select(g => new ChampionStat(
-                g.Key,
-                g.Count(),
-                g.Sum(x => x.Win ? 1 : 0),
-                g.Sum(x => x.Win ? 0 : 1),
-                g.Count() > 0 ? (double)g.Sum(x => x.Win ? 1 : 0) / g.Count() * 100.0 : 0.0,
-                g.Average(x => (double)x.Kills),
-                g.Average(x => (double)x.Deaths),
-                g.Average(x => (double)x.Assists),
-                0, // fill KDA after
-                g.Average(x => x.MatchDuration > 0
+            .Select(g => new
+            {
+                ChampionId = g.Key,
+                Games = g.Count(),
+                Wins = g.Sum(x => x.Win ? 1 : 0),
+                AvgKills = g.Average(x => (double)x.Kills),
+                AvgDeaths = g.Average(x => (double)x.Deaths),
+                AvgAssists = g.Average(x => (double)x.Assists),
+                AvgCsPerMin = g.Average(x => x.MatchDuration > 0
                     ? x.Cs / (x.MatchDuration / 60.0)
                     : 0.0),
-                g.Average(x => (double)x.VisionScore),
-                g.Average(x => (double)x.TotalDamageDealtToChampions)
-            ))
+                AvgVision = g.Average(x => (double)x.VisionScore),
+                AvgDamage = g.Average(x => (double)x.TotalDamageDealtToChampions)
+            })
             .OrderByDescending(x => x.Games)
             .Take(top)
-            .ToList();
+            .ToListAsync(ct);
 
-        // Compute KDA for each (post-projection)
-        return list
-            .Select(x => x with
-            {
-                KdaRatio = CalcKdaRatio(x.AvgKills, x.AvgDeaths, x.AvgAssists)
-            })
+        return rows
+            .Select(x => new ChampionStat(
+                x.ChampionId,
+                x.Games,
+                x.Wins,
+                x.Games - x.Wins,
+                x.Games > 0 ? (double)x.Wins / x.Games * 100.0 : 0.0,
+                x.AvgKills,
+                x.AvgDeaths,
+                x.AvgAssists,
+                CalcKdaRatio(x.AvgKills, x.AvgDeaths, x.AvgAssists),
+                x.AvgCsPerMin,
+                x.AvgVision,
+                x.AvgDamage))
             .ToList();
     }
 
@@ -574,19 +579,27 @@ public class SummonerStatsService(
 
     private async Task<IReadOnlyList<RoleStat>> ComputeRoleBreakdownAsync(Guid summonerId, CancellationToken ct)
     {
-        var rows = await db.MatchParticipants
+        // Aggregate raw TeamPosition server-side (GROUP BY TeamPosition); normalization/merge
+        // ("top" → "TOP", null → "UNKNOWN") happens in C# on the small grouped result set.
+        var rawRows = await db.MatchParticipants
             .AsNoTracking()
             .Where(mp => mp.SummonerId == summonerId)
             .InRankedSoloQueue()
-            .Select(mp => new { mp.TeamPosition, mp.Win })
+            .GroupBy(mp => mp.TeamPosition)
+            .Select(g => new
+            {
+                TeamPosition = g.Key,
+                Games = g.Count(),
+                Wins = g.Sum(x => x.Win ? 1 : 0)
+            })
             .ToListAsync(ct);
 
-        var list = rows
+        var list = rawRows
             .GroupBy(row => NormalizeTeamPosition(row.TeamPosition))
             .Select(g =>
             {
-                var games = g.Count();
-                var wins = g.Sum(x => x.Win ? 1 : 0);
+                var games = g.Sum(x => x.Games);
+                var wins = g.Sum(x => x.Wins);
                 return new RoleStat(
                     g.Key,
                     games,
@@ -1096,11 +1109,26 @@ public class SummonerStatsService(
         var cacheKey = $"{MatchTimelineCacheKeyPrefix}{matchId}";
         return await ExecuteStatsRequestAsync(
             "Failed to load match timeline.",
-            async token => await cache.GetOrCreateAsync(
-                cacheKey,
-                async cancel => await ComputeMatchTimelineAsync(matchId, cancel),
-                MatchDetailCacheOptions,
-                cancellationToken: token),
+            async token =>
+            {
+                var result = await cache.GetOrCreateAsync(
+                    cacheKey,
+                    async cancel => await ComputeMatchTimelineAsync(matchId, cancel),
+                    MatchDetailCacheOptions,
+                    cancellationToken: token);
+
+                // Do NOT persist an empty timeline under the long TTL: a match whose
+                // gold/XP snapshots have not been derived yet returns zero frames, and
+                // caching that for an hour would mask a freshly-ingested timeline with
+                // no invalidation path. Evict so the next request recomputes. Populated
+                // results stay cached; on a cache hit the entry is already non-empty
+                // (we never store empties), so this only fires on a miss that computed
+                // empty frames.
+                if (result is { Frames.Count: 0 })
+                    await cache.RemoveAsync(cacheKey, token);
+
+                return result;
+            },
             ct);
     }
 

--- a/Transcendence.Service.Core/Services/Analytics/ChampionTierScorer.cs
+++ b/Transcendence.Service.Core/Services/Analytics/ChampionTierScorer.cs
@@ -59,7 +59,53 @@ internal static class ChampionTierScorer
     /// <summary>The full scored output for one scope: every per-role row plus the primary-role overview.</summary>
     internal sealed record ScopeScore(
         IReadOnlyList<ScoredChampion> PerRole,
-        IReadOnlyList<ScoredChampion> Overview);
+        IReadOnlyList<ScoredChampion> Overview)
+    {
+        /// <summary>
+        /// Coarse confidence in this scope's tier spread, derived purely from the already-graded overview rows
+        /// (adds no state, changes no grade). It exists because the uncalibrated defaults (the S/A games floor
+        /// and the prior-fit floor) make a thin scope collapse toward the role baseline and grade almost
+        /// everything B — which looks identical to a genuinely balanced meta. This lets a caller tell the two
+        /// apart and render an "insufficient data" hint instead of a misleadingly uniform tier list.
+        /// </summary>
+        public ScopeConfidence Confidence => DeriveConfidence(Overview);
+    }
+
+    /// <summary>Whole-scope confidence signal (see <see cref="ScopeScore.Confidence"/>). Not a grade — a hint.</summary>
+    internal enum ScopeConfidence
+    {
+        /// <summary>At least one champion cleared the games floor and the scope shows a spread of tiers.</summary>
+        Resolved = 0,
+
+        /// <summary>Some champions cleared the floor, yet every graded champion landed on the same tier — the
+        /// list carries no separating signal (a possibly-balanced patch, but treat as low-information).</summary>
+        Flat = 1,
+
+        /// <summary>No champion in the scope reached the S/A games floor (or the scope is empty): every grade is
+        /// a pure shrinkage artifact, not a resolved edge. The strongest "not enough data" signal.</summary>
+        Insufficient = 2,
+    }
+
+    /// <summary>Derives <see cref="ScopeConfidence"/> from graded rows. Total: never throws.</summary>
+    private static ScopeConfidence DeriveConfidence(IReadOnlyList<ScoredChampion> rows)
+    {
+        if (rows.Count == 0)
+            return ScopeConfidence.Insufficient;
+
+        var anyAboveFloor = false;
+        var allOneTier = true;
+        var firstTier = rows[0].Tier;
+        foreach (var r in rows)
+        {
+            if (!r.IsLowSample) anyAboveFloor = true;
+            if (r.Tier != firstTier) allOneTier = false;
+        }
+
+        if (!anyAboveFloor)
+            return ScopeConfidence.Insufficient;
+
+        return allOneTier ? ScopeConfidence.Flat : ScopeConfidence.Resolved;
+    }
 
     /// <summary>
     /// The single shared entry point. Takes the per-<c>(champion, role)</c> games/wins for a whole scope

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -55,6 +55,10 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
     private readonly ChampionAnalyticsComputeOptions _computeOptions;
     private readonly MultiRegionIngestionOptions _multiRegionOptions;
 
+    // Short TTL for freshly-computed empty / zero-sample payloads so incoming games surface within
+    // minutes instead of inheriting the 24h analytics expiration (built per-instance from options).
+    private readonly HybridCacheEntryOptions _emptyResultCacheOptions;
+
     public ChampionAnalyticsService(
         TranscendenceContext context,
         HybridCache cache,
@@ -73,6 +77,13 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         _proService = proService;
         _computeOptions = computeOptions.Value;
         _multiRegionOptions = multiRegionOptions.Value;
+
+        var emptyTtl = TimeSpan.FromMinutes(Math.Max(1, _computeOptions.EmptyResultTtlMinutes));
+        _emptyResultCacheOptions = new HybridCacheEntryOptions
+        {
+            Expiration = emptyTtl,
+            LocalCacheExpiration = emptyTtl < TimeSpan.FromMinutes(2) ? emptyTtl : TimeSpan.FromMinutes(2)
+        };
     }
 
     /// <summary>
@@ -87,6 +98,41 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             ActivePatchCacheOptions,
             tags: new[] { AnalyticsCacheTag, CacheTags.ForPatch(patch) },
             cancellationToken: ct);
+
+    /// <summary>
+    /// Wraps <see cref="HybridCache.GetOrCreateAsync"/> so a freshly-computed empty / zero-sample
+    /// payload is re-cached under a short TTL (<see cref="_emptyResultCacheOptions"/>) instead of
+    /// inheriting the 24h analytics expiration. Newly-ingested games then surface within minutes
+    /// rather than waiting out the patch-tag invalidation. Non-empty results and plain cache hits are
+    /// returned untouched with the standard 24h TTL.
+    /// </summary>
+    private async Task<T> GetOrCreateWithEmptyTtlAsync<T>(
+        string key,
+        Func<CancellationToken, ValueTask<T>> factory,
+        Func<T, bool> isEmpty,
+        IEnumerable<string> tags,
+        CancellationToken ct)
+    {
+        var computed = false;
+        var value = await _cache.GetOrCreateAsync(
+            key,
+            async cancel =>
+            {
+                computed = true;
+                return await factory(cancel);
+            },
+            AnalyticsCacheOptions,
+            tags: tags,
+            cancellationToken: ct);
+
+        // Only shorten the TTL when WE just computed the value (a hit already carries the right TTL).
+        if (computed && isEmpty(value))
+        {
+            await _cache.SetAsync(key, value, _emptyResultCacheOptions, tags, ct);
+        }
+
+        return value;
+    }
 
     public async Task<ChampionWinRateSummary> GetWinRatesAsync(
         int championId,
@@ -119,12 +165,12 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
         // Serve from the precomputed aggregate tables (fast indexed scope roll-up; falls back to the raw
         // compute for any patch without aggregates yet). HybridCache stays the hot tier in front.
-        var winRates = await _cache.GetOrCreateAsync(
+        var winRates = await GetOrCreateWithEmptyTtlAsync(
             cacheKey,
             async cancel => await _winRateService.ComputeWinRatesFromStatsAsync(championId, normalizedFilter, currentPatch, cancel),
-            AnalyticsCacheOptions,
-            tags: new[] { AnalyticsCacheTag, $"champion:{championId}", CacheTags.ForPatch(currentPatch) },
-            cancellationToken: ct
+            static list => list.Sum(x => Math.Max(0, x.Games)) <= 0,
+            new[] { AnalyticsCacheTag, $"champion:{championId}", CacheTags.ForPatch(currentPatch) },
+            ct
         );
 
         var sampleSize = winRates.Sum(x => Math.Max(0, x.Games));
@@ -255,7 +301,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
 
         var selectedPatch = patchContext.Patch!;
 
-        var cacheKey = $"{BuildsCacheKeyPrefix}{championId}:{normalizedRole}:{normalizedTier}:{normalizedRegion}:{selectedPatch}";
+        var cacheKey = BuildBuildsKey(championId, normalizedRole, normalizedTier, normalizedRegion, selectedPatch);
         var tags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(selectedPatch), "builds" };
 
         var response = await _cache.GetOrCreateAsync(
@@ -300,7 +346,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
                 [],
                 BuildSampleMetadata(0, patchContext));
 
-        var cacheKey = $"{ProBuildsCacheKeyPrefix}{championId}:{normalizedRegion}:{normalizedRole}:{normalizedScope}:{resolvedPatch}";
+        var cacheKey = BuildProBuildsKey(championId, normalizedRegion, normalizedRole, normalizedScope, resolvedPatch);
         var tags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(resolvedPatch), "probuilds" };
 
         var response = await _cache.GetOrCreateAsync(
@@ -405,7 +451,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         }
 
         var selectedPatch = patchContext.Patch!;
-        var cacheKey = $"{MatchupsCacheKeyPrefix}{championId}:{normalizedRole}:{normalizedTier}:{normalizedRegion}:{selectedPatch}";
+        var cacheKey = BuildMatchupsKey(championId, normalizedRole, normalizedTier, normalizedRegion, selectedPatch);
         var tags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(selectedPatch), "matchups" };
 
         // Serve from the precomputed matchup aggregates (all-region scope; falls back to the raw self-join
@@ -492,13 +538,13 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         effectiveRole ??= "MIDDLE"; // mirror GetProfile's final fallback so the key always matches
 
         // ── Builds + matchups for the resolved lane (region=ALL, given tier) ──
-        var buildsKey = $"{BuildsCacheKeyPrefix}{championId}:{effectiveRole}:{normalizedTier}:{normalizedRegion}:{currentPatch}";
+        var buildsKey = BuildBuildsKey(championId, effectiveRole, normalizedTier, normalizedRegion, currentPatch);
         var buildsTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "builds" };
         var builds = await _buildService.ComputeBuildsFromStatsAsync(
             championId, effectiveRole, tierForCompute, normalizedRegion, currentPatch, ct);
         await _cache.SetAsync(buildsKey, builds, AnalyticsCacheOptions, buildsTags, ct);
 
-        var matchupsKey = $"{MatchupsCacheKeyPrefix}{championId}:{effectiveRole}:{normalizedTier}:{normalizedRegion}:{currentPatch}";
+        var matchupsKey = BuildMatchupsKey(championId, effectiveRole, normalizedTier, normalizedRegion, currentPatch);
         var matchupsTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "matchups" };
         var matchups = await _matchupService.ComputeMatchupsFromStatsAsync(
             championId, effectiveRole, tierForCompute, normalizedRegion, currentPatch, ct);
@@ -509,7 +555,7 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
         {
             var proScope = ChampionProComputeService.NormalizeProScope(null); // "all"
             const string proRegion = "ALL";
-            var proKey = $"{ProBuildsCacheKeyPrefix}{championId}:{proRegion}:{effectiveRole}:{proScope}:{currentPatch}";
+            var proKey = BuildProBuildsKey(championId, proRegion, effectiveRole, proScope, currentPatch);
             var proTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "probuilds" };
             var proBuilds = await _proService.ComputeProBuildsFromStatsAsync(
                 championId, proRegion, effectiveRole, proScope, currentPatch, ct);
@@ -577,6 +623,18 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             patchPhase != AnalyticsPatchPhase.Steady,
             patchPhase);
     }
+
+    // Shared cache-key builders — the reader path (GetBuildsAsync/GetProBuildsAsync/GetMatchupsAsync)
+    // and the warm writer (RefreshDefaultProfileCacheAsync) MUST produce byte-identical keys or the
+    // warmed entry never gets hit. Keep these as the single source of truth (mirrors BuildCacheKey).
+    private static string BuildBuildsKey(int championId, string role, string tier, string region, string patch)
+        => $"{BuildsCacheKeyPrefix}{championId}:{role}:{tier}:{region}:{patch}";
+
+    private static string BuildMatchupsKey(int championId, string role, string tier, string region, string patch)
+        => $"{MatchupsCacheKeyPrefix}{championId}:{role}:{tier}:{region}:{patch}";
+
+    private static string BuildProBuildsKey(int championId, string region, string role, string scope, string patch)
+        => $"{ProBuildsCacheKeyPrefix}{championId}:{region}:{role}:{scope}:{patch}";
 
     private static string BuildCacheKey(int championId, ChampionAnalyticsFilter filter, string patch)
     {

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionWinRateComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionWinRateComputeService.cs
@@ -281,11 +281,11 @@ public sealed class ChampionWinRateComputeService : IChampionWinRateComputeServi
         if (totalParticipants == 0)
             return [];
 
-        var scopeMatchIds = await query
-            .Select(x => x.MatchId)
-            .Distinct()
-            .ToListAsync(ct);
-        var totalMatchesInScope = scopeMatchIds.Count;
+        // Keep the scope's distinct match-id set as an IQueryable subquery so the ban rollup stays
+        // entirely in SQL (a COUNT subquery + a Contains-subquery), never materialising the (large)
+        // id set into app memory. Derived from `query` so the role filter above stays in scope.
+        var scopeMatchIds = query.Select(x => x.MatchId).Distinct();
+        var totalMatchesInScope = await scopeMatchIds.CountAsync(ct);
         var banCountsByChampion = totalMatchesInScope == 0
             ? new Dictionary<int, int>()
             : await _context.MatchBans

--- a/Transcendence.Service.Core/Services/Analytics/Models/ChampionAnalyticsComputeOptions.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/ChampionAnalyticsComputeOptions.cs
@@ -17,4 +17,12 @@ public class ChampionAnalyticsComputeOptions
     /// most-recent-first, which matches the "recent pro/high-MMR builds" surface.
     /// </summary>
     public int ProBuildMaxParticipantRows { get; set; } = 1500;
+
+    /// <summary>
+    /// Cache lifetime (minutes) applied to a freshly-computed empty / zero-sample analytics payload
+    /// instead of the 24h analytics TTL. Keeps "no data yet" answers cheap to serve while letting
+    /// newly-ingested games surface within minutes rather than waiting out the 24h patch-tag
+    /// invalidation. Kept small (single-digit-to-low-double-digit minutes).
+    /// </summary>
+    public int EmptyResultTtlMinutes { get; set; } = 10;
 }

--- a/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/RefreshPrecomputedAnalyticsJob.cs
@@ -19,6 +19,7 @@ namespace Transcendence.Service.Core.Services.Jobs;
 public class RefreshPrecomputedAnalyticsJob(
     TranscendenceContext db,
     IPrecomputedAnalyticsRefresher refresher,
+    IChampionAnalyticsService analyticsService,
     ILogger<RefreshPrecomputedAnalyticsJob> logger)
 {
     [Queue(HangfireQueues.AnalyticsWarm)]
@@ -42,6 +43,12 @@ public class RefreshPrecomputedAnalyticsJob(
         var matchupRows = await refresher.RefreshMatchupsAsync(patch, ct);
         var buildRows = await refresher.RefreshBuildsAsync(patch, ct);
         var proRows = await refresher.RefreshProSurfacesAsync(patch, ct);
+
+        // Now that the precomputed atoms for this patch are committed, drop the patch-scoped
+        // analytics read-cache so the served data and the "updated N ago" freshness label advance
+        // together. Scoped to the current patch tag only (CacheTags.ForPatch) so other patches, the
+        // pro roster, and playrate entries stay warm.
+        await analyticsService.InvalidateAnalyticsCacheForPatchAsync(patch, ct);
 
         logger.LogInformation(
             "Precompute refresh patch {Patch} completed in {ElapsedMs}ms: {RoleTier} role-tier, {ScopeMatch} scope-match, {Ban} ban, {Matchup} matchup, {Build} build, {Pro} pro rows.",

--- a/Transcendence.WebAPI/Controllers/SummonersController.cs
+++ b/Transcendence.WebAPI/Controllers/SummonersController.cs
@@ -100,7 +100,7 @@ public class SummonersController(
 
         var platformRegion = platform.ToString();
         var summoner = await summonerRepository.FindByRiotIdAsync(platformRegion, name, tag,
-            q => q.Include(s => s.Ranks).Include(s => s.HistoricalRanks).AsSplitQuery(), ct);
+            q => q.AsNoTracking().Include(s => s.Ranks), ct);
         if (summoner != null)
         {
             // Map to response DTO with data age metadata


### PR DESCRIPTION
Backend-correctness batch from the audit P1 mediums — server-side aggregation, empty-cache TTLs, shared cache key-builders (reader+writer), atom-refresh cache invalidation, profile no-tracking read, tiering low-confidence signal. No contract change. Backend **236 tests** + build + api:check green. Details in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)