### PR TITLE
fix(web): P1 wave-2 frontend UX + perf (prefetch, lazy palette, empty states, auth reveal, rank order)

### DIFF
--- a/apps/web/app/account/login/page.tsx
+++ b/apps/web/app/account/login/page.tsx
@@ -7,6 +7,9 @@ import { loginAction } from "@/app/account/actions";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
+import { PasswordInput } from "@/components/ui/PasswordInput";
+
+const GITHUB_REPO_URL = "https://github.com/luisgon-dev/Transcendence";
 
 export default function LoginPage() {
   const [state, formAction, pending] = useActionState(
@@ -78,16 +81,29 @@ export default function LoginPage() {
                   placeholder="name@example.com"
                 />
               </label>
-              <label className="grid gap-1.5">
-                <span className="field-label">Password</span>
-                <Input
+              <div className="grid gap-1.5">
+                <div className="flex items-baseline justify-between gap-3">
+                  <label htmlFor="password" className="field-label">
+                    Password
+                  </label>
+                  <Link
+                    href={`${GITHUB_REPO_URL}/issues`}
+                    target="_blank"
+                    rel="noreferrer"
+                    title="Password recovery is handled through our support tracker."
+                    className="type-meta rounded-sm font-semibold text-fg/62 transition hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/24 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+                  >
+                    Forgot password?
+                  </Link>
+                </div>
+                <PasswordInput
+                  id="password"
                   name="password"
-                  type="password"
                   autoComplete="current-password"
                   required
                   placeholder="Your password"
                 />
-              </label>
+              </div>
 
               {state.error ? (
                 <p className="field-error type-ui" aria-live="polite">

--- a/apps/web/app/account/register/page.tsx
+++ b/apps/web/app/account/register/page.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import Link from "next/link";
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
 
 import { registerAction } from "@/app/account/actions";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
+import { PasswordInput } from "@/components/ui/PasswordInput";
 
 export default function RegisterPage() {
   const [state, formAction, pending] = useActionState(
     registerAction,
     { error: null as string | null }
   );
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const mismatch = confirm.length > 0 && confirm !== password;
 
   return (
     <div className="auth-shell">
@@ -74,14 +78,38 @@ export default function RegisterPage() {
               </label>
               <label className="grid gap-1.5">
                 <span className="field-label">Password</span>
-                <Input
+                <PasswordInput
                   name="password"
-                  type="password"
                   autoComplete="new-password"
                   required
+                  minLength={12}
                   placeholder="At least 12 characters"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
                 />
                 <span className="field-note">Use at least 12 characters.</span>
+              </label>
+              <label className="grid gap-1.5">
+                <span className="field-label">Confirm password</span>
+                <PasswordInput
+                  name="confirmPassword"
+                  autoComplete="new-password"
+                  required
+                  placeholder="Re-enter your password"
+                  value={confirm}
+                  onChange={(event) => setConfirm(event.target.value)}
+                  aria-invalid={mismatch || undefined}
+                  aria-describedby={mismatch ? "confirm-password-error" : undefined}
+                />
+                {mismatch ? (
+                  <span
+                    id="confirm-password-error"
+                    className="field-error type-ui"
+                    aria-live="polite"
+                  >
+                    Passwords do not match.
+                  </span>
+                ) : null}
               </label>
 
               {state.error ? (
@@ -90,7 +118,7 @@ export default function RegisterPage() {
                 </p>
               ) : null}
 
-              <Button type="submit" disabled={pending} className="mt-1">
+              <Button type="submit" disabled={pending || mismatch} className="mt-1">
                 {pending ? "Creating account..." : "Create account"}
               </Button>
             </form>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -555,6 +555,10 @@ body::before {
   }
   .tierlist-row { transition: background-color 140ms var(--ease-out-quart); }
   .tierlist-row:hover { background: color-mix(in oklch, var(--t-fg), transparent 95%); }
+  /* Off-screen tier-list rows skip layout/paint; `auto` lets the engine cache the real
+     rendered height after first paint, so 52px is only a first-pass estimate. No JS
+     virtualization; degrades to a no-op where content-visibility is unsupported. */
+  .tierlist-cv { content-visibility: auto; contain-intrinsic-size: auto 52px; }
   .tierlist-tier-section { scroll-margin-top: 7rem; }
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Bricolage_Grotesque, Hanken_Grotesk, JetBrains_Mono } from "next/font/google";
 
 import "@/app/globals.css";
-import { GlobalCommandPalette } from "@/components/GlobalCommandPalette";
+import { GlobalCommandPaletteLoader } from "@/components/GlobalCommandPaletteLoader";
 import { SiteFooter } from "@/components/SiteFooter";
 import { SiteHeader } from "@/components/SiteHeader";
 
@@ -64,7 +64,7 @@ export default function RootLayout({
           {children}
         </main>
         <SiteFooter />
-        <GlobalCommandPalette />
+        <GlobalCommandPaletteLoader />
       </body>
     </html>
   );

--- a/apps/web/app/lol/champions/[championId]/page.tsx
+++ b/apps/web/app/lol/champions/[championId]/page.tsx
@@ -24,7 +24,7 @@ import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { formatGames } from "@/lib/format";
 import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
 import { normalizeAnalyticsPatch } from "@/lib/lolPatchFilters";
-import { resolveDefaultedRankTier, rankTierDisplayLabel } from "@/lib/ranks";
+import { resolveDefaultedRankTier, rankTierDisplayLabel, rankTierLadderOrdinal } from "@/lib/ranks";
 import { roleDisplayLabel } from "@/lib/roles";
 import {
   championIconUrl,
@@ -463,7 +463,7 @@ async function ChampionSections({
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2.5">
               {winrateRows
                 .slice()
-                .sort((a, b) => (b.games ?? 0) - (a.games ?? 0))
+                .sort((a, b) => rankTierLadderOrdinal(a.rankTier) - rankTierLadderOrdinal(b.rankTier))
                 .map((w) => (
                   <span
                     key={`${w.role ?? "ALL"}-${w.rankTier ?? "all"}`}

--- a/apps/web/app/lol/pro-builds/[championId]/page.tsx
+++ b/apps/web/app/lol/pro-builds/[championId]/page.tsx
@@ -335,6 +335,8 @@ export default async function ProBuildsChampionPage({
         </Card>
       ) : null}
 
+      {proBuildsRes.ok ? (
+        <>
       <div className="grid gap-6 md:grid-cols-2">
         <Card className="p-5">
           <h2 className="type-section">Top Players</h2>
@@ -485,6 +487,8 @@ export default async function ProBuildsChampionPage({
           </ul>
         )}
       </Card>
+        </>
+      ) : null}
 
       <Card className="border-primary/40 bg-primary/10 p-5">
         <h2 className="type-section text-primary">

--- a/apps/web/components/FavoriteButton.tsx
+++ b/apps/web/components/FavoriteButton.tsx
@@ -1,8 +1,26 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/Button";
+
+type FavoriteSummonerDto = {
+  id: string;
+  summonerPuuid: string;
+  platformRegion: string;
+  displayName?: string | null;
+  createdAtUtc: string;
+};
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  const json = (await res.json().catch(() => null)) as
+    | { message?: string; requestId?: string }
+    | null;
+  const message = json?.message ?? `${fallback} (${res.status}).`;
+  const rid = json?.requestId ? ` (Request ID: ${json.requestId})` : "";
+  return `${message}${rid}`;
+}
 
 export function FavoriteButton({
   region,
@@ -13,49 +31,112 @@ export function FavoriteButton({
   gameName: string;
   tagLine: string;
 }) {
+  const [favoriteId, setFavoriteId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [needsLogin, setNeedsLogin] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
 
-  async function add() {
+  // Seed the toggle from current state so it opens as "Added" when saved.
+  useEffect(() => {
+    let active = true;
+    const target = `${gameName}#${tagLine}`;
+    void (async () => {
+      try {
+        const res = await fetch("/api/trn/user/users/me/favorites", {
+          cache: "no-store"
+        });
+        if (!active || !res.ok) return; // 401/unauth stays silent until action
+        const items = (await res.json()) as FavoriteSummonerDto[];
+        const match = items.find(
+          (f) =>
+            f.displayName === target &&
+            f.platformRegion.toLowerCase() === region.toLowerCase()
+        );
+        if (active && match) setFavoriteId(match.id);
+      } catch {
+        // ignore — button falls back to "Add Favorite"
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [region, gameName, tagLine]);
+
+  async function toggle() {
+    if (busy) return;
     setBusy(true);
     setMsg(null);
+    setNeedsLogin(false);
     try {
+      if (favoriteId) {
+        const res = await fetch(
+          `/api/trn/user/users/me/favorites/${favoriteId}`,
+          { method: "DELETE" }
+        );
+        if (res.status === 401) {
+          setNeedsLogin(true);
+          return;
+        }
+        if (!res.ok && res.status !== 404) {
+          setMsg(await readError(res, "Failed to remove favorite"));
+          return;
+        }
+        setFavoriteId(null);
+        setMsg("Removed from favorites.");
+        return;
+      }
+
       const res = await fetch("/api/trn/user/users/me/favorites", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ region, gameName, tagLine })
       });
-
       if (res.status === 401) {
-        setMsg("Login required to save favorites.");
+        setNeedsLogin(true);
         return;
       }
-
       if (!res.ok) {
-        const json = (await res.json().catch(() => null)) as
-          | { message?: string; requestId?: string }
-          | null;
-        const msg =
-          json?.message ?? `Failed to add favorite (${res.status}).`;
-        const rid = json?.requestId ? ` (Request ID: ${json.requestId})` : "";
-        setMsg(`${msg}${rid}`);
+        setMsg(await readError(res, "Failed to add favorite"));
         return;
       }
-
+      const created = (await res.json()) as FavoriteSummonerDto;
+      setFavoriteId(created.id); // prevents duplicate POSTs
       setMsg("Saved to favorites.");
     } catch (e) {
-      setMsg(e instanceof Error ? e.message : "Failed to add favorite.");
+      setMsg(e instanceof Error ? e.message : "Something went wrong.");
     } finally {
       setBusy(false);
     }
   }
 
+  const added = favoriteId !== null;
+  const label = busy ? (added ? "Removing…" : "Saving…") : added ? "Added ✓" : "Add Favorite";
+
   return (
     <div className="flex items-center gap-3">
-      <Button variant="outline" size="sm" onClick={add} disabled={busy}>
-        {busy ? "Saving..." : "Add Favorite"}
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={toggle}
+        disabled={busy}
+        aria-pressed={added}
+        title={added ? "Remove from favorites" : "Add to favorites"}
+      >
+        {label}
       </Button>
-      {msg ? <span className="text-xs text-muted">{msg}</span> : null}
+      {needsLogin ? (
+        <span className="text-xs text-muted">
+          <Link
+            className="font-semibold text-primary hover:underline"
+            href="/account/login"
+          >
+            Sign in
+          </Link>{" "}
+          to save favorites.
+        </span>
+      ) : msg ? (
+        <span className="text-xs text-muted">{msg}</span>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/GlobalCommandPaletteLoader.tsx
+++ b/apps/web/components/GlobalCommandPaletteLoader.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// The command palette drags framer-motion + cmdk into whatever bundle imports
+// it. Loading it via next/dynamic with { ssr: false } keeps those libraries out
+// of the shared layout chunk so they are only fetched on the client, after
+// hydration. The open trigger is decoupled from render: the palette attaches a
+// window `keydown` (Cmd/Ctrl+K) listener and listens for the
+// `trn:open-command-palette` CustomEvent (dispatched by GlobalSearchLauncher),
+// both wired up in its own useEffect on mount — so lazy-mounting it here does
+// not break opening it.
+//
+// This wrapper is a Client Component on purpose: `ssr: false` is not allowed
+// with next/dynamic inside a Server Component (app/layout.tsx), so the dynamic
+// import lives here instead.
+const GlobalCommandPalette = dynamic(
+  () =>
+    import("@/components/GlobalCommandPalette").then(
+      (mod) => mod.GlobalCommandPalette
+    ),
+  { ssr: false }
+);
+
+export function GlobalCommandPaletteLoader() {
+  return <GlobalCommandPalette />;
+}

--- a/apps/web/components/SiteHeader.tsx
+++ b/apps/web/components/SiteHeader.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import { AccountNav } from "@/components/AccountNav";
 import { SiteHeaderClient } from "@/components/SiteHeaderClient";
 import { fetchLolAnalyticsStatus } from "@/lib/lolAnalyticsStatus";
@@ -12,7 +14,16 @@ export async function SiteHeader() {
 
   return (
     <SiteHeaderClient patch={patch}>
-      <AccountNav />
+      <Suspense
+        fallback={
+          <div
+            aria-hidden
+            className="h-11 w-20 rounded-full bg-surface-2/40"
+          />
+        }
+      >
+        <AccountNav />
+      </Suspense>
     </SiteHeaderClient>
   );
 }

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -28,7 +28,13 @@ import {
   type SpellStatic,
   type SummonerProfileResponse
 } from "@/components/lol-profile/shared";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/Button";
+import { buttonClassName } from "@/components/ui/buttonStyles";
 import { Card } from "@/components/ui/Card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { SearchIcon } from "@/components/ui/icons";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { computeNextPollDelayMs } from "@/lib/polling";
 import { formatQueueLabel } from "@/lib/queues";
@@ -439,9 +445,35 @@ export function SummonerProfileClient({
       />
 
       {!profile ? (
-        <Card className="profile-section-card p-5">
-          <Skeleton className="h-16 w-full" />
-        </Card>
+        polling && !error ? (
+          <Card className="profile-section-card p-5">
+            <Skeleton className="h-16 w-full" />
+          </Card>
+        ) : (
+          <EmptyState
+            icon={<SearchIcon className="h-6 w-6" />}
+            title={`We couldn’t find ${title}`}
+            description={
+              error?.message
+                ? `${error.message} Double-check the Riot ID and that ${region.toUpperCase()} is the right region, or queue an update to fetch fresh data.`
+                : `No profile in ${region.toUpperCase()} matched this Riot ID. Double-check the spelling and region, or queue an update to fetch fresh data.`
+            }
+            action={
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Button
+                  variant="primary"
+                  onClick={() => void queueRefresh()}
+                  disabled={busy}
+                >
+                  {busy ? "Updating…" : "Update now"}
+                </Button>
+                <Link href="/" className={buttonClassName({ variant: "outline" })}>
+                  New search
+                </Link>
+              </div>
+            }
+          />
+        )
       ) : (
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(280px,0.32fr)_minmax(0,1fr)] xl:items-start">
           {/* On mobile the sidebar (mastery / champion pool / duo / live-game) drops BELOW the match

--- a/apps/web/components/TierListTable.tsx
+++ b/apps/web/components/TierListTable.tsx
@@ -304,7 +304,7 @@ export function TierListTable({
       <tr
         key={`${entry.tier}-${entry.role}-${entry.championId}`}
         className={cn(
-          "tierlist-row border-b border-border/40 text-sm last:border-0",
+          "tierlist-row tierlist-cv border-b border-border/40 text-sm last:border-0",
           entry.isLowSample && "opacity-70"
         )}
       >
@@ -322,6 +322,7 @@ export function TierListTable({
           <div className="flex items-center gap-2">
             <Link
               href={`/lol/champions/${entry.championId}?${rowQuery}`}
+              prefetch={false}
               className="group flex min-w-0 items-center gap-2.5"
             >
               <Image
@@ -405,6 +406,7 @@ export function TierListTable({
         <td className="hidden px-3 py-2.5 text-right md:table-cell">
           <Link
             href={`/lol/champions/${entry.championId}?${rowQuery}#matchups`}
+            prefetch={false}
             className="type-ui font-medium text-fg/70 transition-colors hover:text-primary hover:underline"
           >
             Analyze

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -9,6 +9,8 @@ import { Card } from "@/components/ui/Card";
 import { Select } from "@/components/ui/Select";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { ChevronRightIcon } from "@/components/ui/icons";
+import { cn } from "@/lib/cn";
 import { MatchScoreboard } from "@/components/lol-profile/MatchScoreboard";
 import {
   formatDateTimeMs,
@@ -297,7 +299,13 @@ function MatchHistoryCard({
                 {matchKdaRatio(match).toFixed(2)} KDA
               </p>
             </div>
-            <span className="type-overline text-fg/65">
+            <span className="flex items-center justify-end gap-1.5 type-overline text-muted">
+              <ChevronRightIcon
+                className={cn(
+                  "size-3 shrink-0 transition-transform duration-150",
+                  expanded && "rotate-90"
+                )}
+              />
               {expanded ? "Collapse details" : "Expand details"}
             </span>
           </div>

--- a/apps/web/components/ui/PasswordInput.tsx
+++ b/apps/web/components/ui/PasswordInput.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import * as React from "react";
+
+import { Input, type InputProps } from "@/components/ui/Input";
+import { cn } from "@/lib/cn";
+
+function EyeIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M1.5 8s2.4-4.25 6.5-4.25S14.5 8 14.5 8s-2.4 4.25-6.5 4.25S1.5 8 1.5 8Z" />
+      <circle cx="8" cy="8" r="1.85" />
+    </svg>
+  );
+}
+
+function EyeOffIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M6.3 6.3a2.4 2.4 0 0 0 3.4 3.4" />
+      <path d="M4.1 4.2C2.6 5.2 1.5 8 1.5 8s2.4 4.25 6.5 4.25c1 0 1.9-.16 2.7-.44" />
+      <path d="M11.9 11.8C13.4 10.8 14.5 8 14.5 8s-2.4-4.25-6.5-4.25c-.5 0-.98.04-1.42.12" />
+      <path d="m2.5 2.5 11 11" />
+    </svg>
+  );
+}
+
+export type PasswordInputProps = Omit<InputProps, "type">;
+
+export const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
+  ({ className, ...props }, ref) => {
+    const [visible, setVisible] = React.useState(false);
+    return (
+      <span className="relative block w-full">
+        <Input
+          ref={ref}
+          type={visible ? "text" : "password"}
+          className={cn("pr-12", className)}
+          {...props}
+        />
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          aria-label={visible ? "Hide password" : "Show password"}
+          aria-pressed={visible}
+          className="absolute right-1.5 top-1/2 grid h-9 w-9 -translate-y-1/2 place-items-center rounded-control text-muted transition-colors hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        >
+          {visible ? (
+            <EyeOffIcon className="h-[18px] w-[18px]" />
+          ) : (
+            <EyeIcon className="h-[18px] w-[18px]" />
+          )}
+        </button>
+      </span>
+    );
+  }
+);
+PasswordInput.displayName = "PasswordInput";

--- a/apps/web/components/ui/icons.tsx
+++ b/apps/web/components/ui/icons.tsx
@@ -58,3 +58,20 @@ export function ArrowCornerIcon({ className }: { className?: string }) {
     </svg>
   );
 }
+
+export function ChevronRightIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4.5 3 7.5 6 4.5 9" />
+    </svg>
+  );
+}

--- a/apps/web/lib/ranks.ts
+++ b/apps/web/lib/ranks.ts
@@ -96,6 +96,17 @@ const TIER_LADDER_ORDER = [
   "CHALLENGER"
 ];
 
+/**
+ * Canonical ladder ordinal for a rank tier (Iron = 0 … Challenger = 9), matching
+ * TIER_LADDER_ORDER. Unknown/composite buckets (e.g. "ALL", "EMERALD_PLUS") sort
+ * last so real ladder tiers stay in ascending order.
+ */
+export function rankTierLadderOrdinal(tier: string | null | undefined): number {
+  if (!tier) return Number.MAX_SAFE_INTEGER;
+  const index = TIER_LADDER_ORDER.indexOf(tier.toUpperCase());
+  return index < 0 ? Number.MAX_SAFE_INTEGER : index;
+}
+
 const DIVISION_RANK: Record<string, number> = {
   IV: 0,
   III: 1,

--- a/apps/web/lib/session.ts
+++ b/apps/web/lib/session.ts
@@ -1,5 +1,7 @@
 import "server-only";
 
+import { cache } from "react";
+
 import type { components } from "@transcendence/api-client";
 
 import {
@@ -30,7 +32,7 @@ function isDynamicServerUsageError(error: unknown) {
   );
 }
 
-export async function getSessionMe(): Promise<SessionMe> {
+export const getSessionMe = cache(async (): Promise<SessionMe> => {
   try {
     const client = getTrnClient();
     const { accessToken, accessExpiresAtUtc } = await getAuthCookies();
@@ -97,4 +99,4 @@ export async function getSessionMe(): Promise<SessionMe> {
     logEvent("error", "getSessionMe failed unexpectedly", { error });
     return { authenticated: false };
   }
-}
+});

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -44,6 +44,9 @@ const nextConfig = {
         permanent: true
       }
     ];
+  },
+  experimental: {
+    optimizePackageImports: ["radix-ui", "framer-motion"]
   }
 };
 


### PR DESCRIPTION
Contained frontend UX/perf items from the audit P1 mediums — tier-list prefetch/content-visibility, lazy-loaded command palette + optimizePackageImports, profile empty-state + favorite toggle + expand caret, login/register password reveal + forgot-password + confirm, getSessionMe cache(), win-rate-by-rank ladder ordering, pro-builds error state. No contract change. web lint + build + **142 tests** green.

Deferred to a later pass: full tier-list JS virtualization and the profile server-streaming rewrite (larger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)