### PR TITLE
fix(ops): prometheus targets use portable container names

### DIFF
--- a/config/monitoring/prometheus.yml
+++ b/config/monitoring/prometheus.yml
@@ -1,6 +1,8 @@
 # Prometheus scrape config for the Transcendence stack.
-# Targets use compose service names, resolved over the `transcendence-net` Docker network — so this
-# same file works locally (repo compose) and in prod (Portainer stack), which share those names.
+# Targets use the app *container names* (`transcendence-webapi`/`transcendence-service`), which are
+# network aliases in BOTH environments — locally (repo compose sets container_name) and in prod (the
+# Portainer app stack). Compose *service* names (webapi/service) only alias locally, so the container
+# names are the portable form. All resolve over the shared `transcendence-net` Docker network.
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
@@ -14,10 +16,10 @@ scrape_configs:
   - job_name: transcendence-webapi
     metrics_path: /metrics
     static_configs:
-      - targets: ["webapi:8080"]
+      - targets: ["transcendence-webapi:8080"]
 
   # The worker has no HTTP server, so it exposes /metrics via a standalone Prometheus HttpListener.
   - job_name: transcendence-worker
     metrics_path: /metrics
     static_configs:
-      - targets: ["service:9464"]
+      - targets: ["transcendence-service:9464"]


### PR DESCRIPTION
## Why

Follow-up to #126. While syncing the consolidated `config/monitoring/` to prod, I found the committed `prometheus.yml` had **drifted** from prod: it targeted compose **service** names (`webapi:8080`, `service:9464`), while prod targets the app **container** names (`transcendence-webapi`, `transcendence-service`).

Compose service names only alias on the **local** app network; in the prod Portainer stack they don't resolve, which is why prod was hand-edited. Syncing the repo version as-is would have left **prod scraping nothing** → the new `WebAPI down` / `Worker down` alerts would fire falsely.

## Fix

Target the app **container names**, which are network aliases in **both** environments (`container_name` is set in the app compose locally, and in the Portainer stack in prod). One file now works everywhere — the point of the consolidation.

- `webapi:8080` → `transcendence-webapi:8080`
- `service:9464` → `transcendence-service:9464`
- Job names unchanged → alert rules unaffected.

Verified: the repo target lines now match prod's live `prometheus.yml` byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)