### PR TITLE
fix(worker): tolerate unmodelled Riot queueType in ranked ingestion

### DIFF
--- a/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
@@ -105,6 +105,13 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<ISummonerService, SummonerService>();
         services.AddScoped<IRankService, RankService>();
+        // Tolerant League-V4 entries fallback (enum-free) for when Riot returns a queueType Camille's
+        // latest nightly doesn't model. Binds the Riot key on the typed client; used only on that failure.
+        services.AddHttpClient<IRankFallbackClient, RankFallbackClient>(client =>
+        {
+            client.DefaultRequestHeaders.Add("X-Riot-Token", riotApiKey);
+            client.Timeout = TimeSpan.FromSeconds(15);
+        });
         services.AddScoped<IChampionMasteryService, ChampionMasteryService>();
         services.AddScoped<IMatchService, MatchService>();
         services.AddScoped<IStaticDataService, StaticDataService>();

--- a/Transcendence.Service.Core/Services/Jobs/AddOrUpdateHighEloProfiles.cs
+++ b/Transcendence.Service.Core/Services/Jobs/AddOrUpdateHighEloProfiles.cs
@@ -102,12 +102,23 @@ public class AddOrUpdateHighEloProfiles(
 
             foreach (var summonerPuuid in summonerPuuids)
             {
-                var summoner =
-                    await summonerService.GetSummonerByPuuidAsync(summonerPuuid, platform, stoppingToken);
-                await summonerRepository.AddOrUpdateSummonerAsync(summoner, stoppingToken);
-                await UpsertTrackedHighValueSummonerAsync(summoner, platform, stoppingToken);
-                pendingChanges++;
-                rosterUpdates++;
+                try
+                {
+                    var summoner =
+                        await summonerService.GetSummonerByPuuidAsync(summonerPuuid, platform, stoppingToken);
+                    await summonerRepository.AddOrUpdateSummonerAsync(summoner, stoppingToken);
+                    await UpsertTrackedHighValueSummonerAsync(summoner, platform, stoppingToken);
+                    pendingChanges++;
+                    rosterUpdates++;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    // Isolate per summoner: a single account that fails to enrich (e.g. a Riot payload the
+                    // client can't parse, or a dead riot-id) must not abort the whole platform's refresh.
+                    logger.LogWarning(ex,
+                        "High-elo profile refresh skipped summoner {Puuid} on {Platform}.", summonerPuuid, platform);
+                    continue;
+                }
 
                 if (pendingChanges < saveBatchSize)
                     continue;

--- a/Transcendence.Service.Core/Services/RiotApi/Implementations/RankFallbackClient.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/Implementations/RankFallbackClient.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Camille.Enums;
+using Microsoft.Extensions.Logging;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Service.Core.Services.RiotApi.Interfaces;
+
+namespace Transcendence.Service.Core.Services.RiotApi.Implementations;
+
+/// <summary>
+/// Raw, enum-free League-V4 entries fetch used only when Camille's typed deserialization throws on an
+/// unmodelled <c>queueType</c>. Routes through the same per-region <see cref="IRiotRateGate"/> as the
+/// other bespoke Riot clients so the (rare) fallback still respects the key's budget; the <c>X-Riot-Token</c>
+/// header is bound on the typed <see cref="HttpClient"/> in DI. Platform endpoints live on the
+/// per-platform host, e.g. <c>https://na1.api.riotgames.com</c>.
+/// </summary>
+public sealed class RankFallbackClient(
+    HttpClient httpClient,
+    IRiotRateGate rateGate,
+    ILogger<RankFallbackClient> logger) : IRankFallbackClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<List<Rank>> GetLeagueEntriesTolerantAsync(
+        string summonerPuuid, PlatformRoute platformRoute, CancellationToken cancellationToken = default)
+    {
+        // Pace under the per-region budget; an exhausted gate degrades to "no rank this cycle" (picked up
+        // on the next refresh) rather than risking a 429 on the shared key.
+        if (!await rateGate.AcquireAsync(platformRoute.ToString(), cancellationToken))
+            return [];
+
+        var host = $"https://{platformRoute.ToString().ToLowerInvariant()}.api.riotgames.com";
+        var url = $"{host}/lol/league/v4/entries/by-puuid/{Uri.EscapeDataString(summonerPuuid)}";
+
+        using var response = await httpClient.GetAsync(url, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return []; // account has no ranked entries
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning(
+                "Tolerant league-entries fallback returned {Status} for {Puuid} on {Platform}.",
+                (int)response.StatusCode, summonerPuuid, platformRoute);
+            return [];
+        }
+
+        var entries = await response.Content
+            .ReadFromJsonAsync<List<LeagueEntryRaw>>(JsonOptions, cancellationToken) ?? [];
+
+        return entries.Select(e => new Rank
+        {
+            QueueType = e.QueueType ?? string.Empty,
+            Tier = e.Tier ?? string.Empty,
+            RankNumber = e.Rank ?? string.Empty,
+            LeaguePoints = e.LeaguePoints,
+            Wins = e.Wins,
+            Losses = e.Losses
+        }).ToList();
+    }
+
+    // Mirrors the shape RankService needs; queueType/tier/rank stay strings so no value can fail to bind.
+    private sealed record LeagueEntryRaw(
+        string? QueueType, string? Tier, string? Rank, int LeaguePoints, int Wins, int Losses);
+}

--- a/Transcendence.Service.Core/Services/RiotApi/Implementations/RankService.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/Implementations/RankService.cs
@@ -1,27 +1,46 @@
+using System.Text.Json;
 using Camille.Enums;
 using Camille.RiotGames;
+using Microsoft.Extensions.Logging;
 using Transcendence.Data.Models.LoL.Account;
 using Transcendence.Service.Core.Services.RiotApi;
 using Transcendence.Service.Core.Services.RiotApi.Interfaces;
 
 namespace Transcendence.Service.Core.Services.RiotApi.Implementations;
 
-public class RankService(LeagueRiotApiContext riotApiContext) : IRankService
+public class RankService(
+    LeagueRiotApiContext riotApiContext,
+    IRankFallbackClient fallbackClient,
+    ILogger<RankService> logger) : IRankService
 {
     public async Task<List<Rank>> GetRankedDataAsync(string summonerPuuid, PlatformRoute platformRoute,
         CancellationToken cancellationToken = default)
     {
-        var entries = await riotApiContext.Api.LeagueV4()
-            .GetLeagueEntriesByPUUIDAsync(platformRoute, summonerPuuid, cancellationToken);
-        // Normalize and return Rank models without binding to a Summoner; caller will attach
-        return entries.Select(e => new Rank
+        try
         {
-            QueueType = e.QueueType.ToString(),
-            Tier = e.Tier.ToString() ?? string.Empty,
-            RankNumber = e.Rank.ToString() ?? string.Empty,
-            LeaguePoints = e.LeaguePoints,
-            Wins = e.Wins,
-            Losses = e.Losses
-        }).ToList();
+            var entries = await riotApiContext.Api.LeagueV4()
+                .GetLeagueEntriesByPUUIDAsync(platformRoute, summonerPuuid, cancellationToken);
+            // Normalize and return Rank models without binding to a Summoner; caller will attach
+            return entries.Select(e => new Rank
+            {
+                QueueType = e.QueueType.ToString(),
+                Tier = e.Tier.ToString() ?? string.Empty,
+                RankNumber = e.Rank.ToString() ?? string.Empty,
+                LeaguePoints = e.LeaguePoints,
+                Wins = e.Wins,
+                Losses = e.Losses
+            }).ToList();
+        }
+        catch (JsonException ex)
+        {
+            // Riot returned a queueType Camille's QueueType enum doesn't model (Camille is already on its
+            // latest nightly), so its typed deserialization throws for the whole array. Re-fetch tolerantly
+            // (queueType as a string) so the account keeps its Solo/Flex rank instead of being dropped —
+            // and one such account no longer fails the entire high-elo batch.
+            logger.LogWarning(ex,
+                "Camille could not deserialize league entries for {Puuid} on {Platform} (unmodelled queueType); using tolerant fallback.",
+                summonerPuuid, platformRoute);
+            return await fallbackClient.GetLeagueEntriesTolerantAsync(summonerPuuid, platformRoute, cancellationToken);
+        }
     }
 }

--- a/Transcendence.Service.Core/Services/RiotApi/Interfaces/IRankFallbackClient.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/Interfaces/IRankFallbackClient.cs
@@ -1,0 +1,17 @@
+using Camille.Enums;
+using Transcendence.Data.Models.LoL.Account;
+
+namespace Transcendence.Service.Core.Services.RiotApi.Interfaces;
+
+/// <summary>
+/// Tolerant fallback for League-V4 ranked entries. Camille deserializes each entry's <c>queueType</c>
+/// into its <c>Camille.Enums.QueueType</c> enum and throws on any value it does not model — and Riot can
+/// introduce queue types faster than Camille's (already-latest) nightly ships them, which fails the whole
+/// array. This path re-fetches the same endpoint and parses <c>queueType</c> as a plain string, so an
+/// account keeps its Solo/Flex rank instead of being dropped when it also carries an unknown-queue entry.
+/// </summary>
+public interface IRankFallbackClient
+{
+    Task<List<Rank>> GetLeagueEntriesTolerantAsync(
+        string summonerPuuid, PlatformRoute platformRoute, CancellationToken cancellationToken = default);
+}

--- a/tests/Transcendence.Service.Core.Tests/RankFallbackClientTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/RankFallbackClientTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using Camille.Enums;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Transcendence.Service.Core.Services.RiotApi;
+using Transcendence.Service.Core.Services.RiotApi.Implementations;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// The tolerant League-V4 fallback exists precisely so a <c>queueType</c> Camille's enum doesn't model
+/// no longer throws (and no longer drops the whole account's rank). These tests drive it through a stub
+/// <see cref="HttpMessageHandler"/> so the real parse/map path runs without the network.
+/// </summary>
+public class RankFallbackClientTests
+{
+    private static RankFallbackClient BuildClient(HttpStatusCode status, string? body, bool gateOpen = true)
+    {
+        var handler = new StubHandler(status, body);
+        var http = new HttpClient(handler);
+        var gate = new Mock<IRiotRateGate>();
+        gate.Setup(g => g.AcquireAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gateOpen);
+        return new RankFallbackClient(http, gate.Object, NullLogger<RankFallbackClient>.Instance);
+    }
+
+    [Fact]
+    public async Task PreservesUnknownQueueTypeAsStringInsteadOfThrowing()
+    {
+        // Second entry carries a queueType Camille's QueueType enum does not model — the Camille typed
+        // path would throw on the whole array here; the fallback keeps every entry as strings.
+        const string body = """
+        [
+          {"queueType":"RANKED_SOLO_5x5","tier":"CHALLENGER","rank":"I","leaguePoints":1200,"wins":300,"losses":200},
+          {"queueType":"RANKED_SOME_NEW_QUEUE_2026","tier":"GOLD","rank":"II","leaguePoints":50,"wins":10,"losses":5}
+        ]
+        """;
+        var client = BuildClient(HttpStatusCode.OK, body);
+
+        var ranks = await client.GetLeagueEntriesTolerantAsync("PUUID-1", PlatformRoute.NA1);
+
+        ranks.Should().HaveCount(2);
+        ranks[0].QueueType.Should().Be("RANKED_SOLO_5x5");
+        ranks[0].Tier.Should().Be("CHALLENGER");
+        ranks[0].LeaguePoints.Should().Be(1200);
+        ranks[1].QueueType.Should().Be("RANKED_SOME_NEW_QUEUE_2026"); // preserved, not rejected
+        ranks[1].Wins.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyOnNotFound()
+    {
+        var client = BuildClient(HttpStatusCode.NotFound, null);
+
+        var ranks = await client.GetLeagueEntriesTolerantAsync("PUUID-none", PlatformRoute.NA1);
+
+        ranks.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyWhenRateGateExhausted()
+    {
+        // Gate closed -> no call made -> degrade to no-rank this cycle (not an exception).
+        var client = BuildClient(HttpStatusCode.OK, "[]", gateOpen: false);
+
+        var ranks = await client.GetLeagueEntriesTolerantAsync("PUUID-1", PlatformRoute.NA1);
+
+        ranks.Should().BeEmpty();
+    }
+
+    private sealed class StubHandler(HttpStatusCode status, string? body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(status);
+            if (body is not null)
+                response.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+            return Task.FromResult(response);
+        }
+    }
+}


### PR DESCRIPTION
## Why (found during the 2026-07-19 incident triage)

The worker was repeatedly failing a Hangfire job with:
```
System.Text.Json.JsonException: The JSON value could not be converted to Camille.Enums.QueueType. Path: $[1].queueType
  at Camille.Core.JsonHandler.Deserialize[T]
  at RankService.GetRankedDataAsync (RankService.cs:14)
  at AddOrUpdateHighEloProfiles.ExecuteForPlatformAsync (:105)
```
`RankService` used Camille's typed `LeagueV4().GetLeagueEntriesByPUUIDAsync`, which binds each entry's `queueType` to `Camille.Enums.QueueType` and **throws on any value it doesn't model**. Riot adds queue types faster than Camille ships them — and **we're already on Camille's latest nightly** (`3.0.0-nightly-2025-06-24`, verified newest of 122 on NuGet), so there's no package bump to apply. One unmodelled entry failed the **whole array** → `GetSummonerByPuuidAsync` threw → and because the batch loop had **no per-summoner isolation**, the entire platform's high-elo refresh aborted and crash-looped on that one account.

## Fix (two layers)

1. **`RankService`** keeps Camille as the happy path but, on `JsonException`, falls back to a new **`IRankFallbackClient`** that re-fetches `/lol/league/v4/entries/by-puuid` and parses `queueType`/`tier`/`rank` as **plain strings** (no enum) through a rate-gated typed `HttpClient`. The account keeps its Solo/Flex rank instead of being dropped — for any current *or future* unknown queue. (We only ever used `e.QueueType.ToString()`, so the string is all we need.)
2. **`AddOrUpdateHighEloProfiles`** wraps the per-summoner loop body in `try/catch` (skip + log, excluding cancellation) so one unenrichable account never aborts the whole platform refresh — general hardening.

## Notes
- No API / contract / env change (reuses `RiotApi:League:ApiKey`; the fallback is worker-only, registered in `AddTranscendenceLeagueRiot`).
- The fallback is gated by the existing per-region `IRiotRateGate` (like `RiotMatchIdsClient`); on exhaustion it degrades to no-rank-this-cycle rather than risking a 429.

## Validation
- New `RankFallbackClientTests`: unknown `queueType` **preserved as string** (no throw), 404 → empty, rate-gate-exhausted → empty.
- Service.Core **202/202** green; full solution builds clean (only the pre-existing `init`-migration name warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)