### PR TITLE
Restore worker metrics wildcard binding

### DIFF
--- a/Transcendence.Service/Program.cs
+++ b/Transcendence.Service/Program.cs
@@ -205,8 +205,12 @@ if (builder.Configuration.GetValue("Telemetry:Enabled", true))
             .AddHttpClientInstrumentation()
             .AddPrometheusHttpListener(options =>
             {
-                options.Host = "+";
-                options.Port = metricsPort;
+                // The prerelease Host/Port replacement cannot express HttpListener's strong
+                // wildcard: UriBuilder rejects "+" and "0.0.0.0" is not a supported prefix.
+                // Keep the transitional property until the exporter provides a wildcard-safe API.
+#pragma warning disable CS0618 // UriPrefixes is required for wildcard container-network binding.
+                options.UriPrefixes = [$"http://+:{metricsPort}/"];
+#pragma warning restore CS0618
             }));
 }
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -33,8 +33,10 @@ production. They are tracked separately so the original 149-finding totals remai
   payload and processed-match ledger.
 - [x] Reconcile the local WebAPI service-boundary refactor with `main`; the deployed implementation
   is a strict superset, so no duplicate cherry-pick is required.
-- [x] Replace obsolete .NET/OpenTelemetry APIs, retired Riot platform constants, and Node 20 GitHub
-  Actions runtimes; document the immutable EF migration warning exception.
+- [x] Replace obsolete .NET APIs, retired Riot platform constants, and Node 20 GitHub Actions
+  runtimes; document the immutable EF migration warning exception. The prerelease OpenTelemetry
+  exporter's obsolete wildcard-prefix property remains narrowly suppressed because its replacement
+  cannot yet represent the worker's required container-network wildcard binding.
 - [x] Upgrade direct and transitive npm/NuGet dependencies until both package-manager vulnerability
   audits report zero advisories.
 


### PR DESCRIPTION
## Summary
- restore the OpenTelemetry HttpListener wildcard prefix required by the worker container network
- narrowly suppress the prerelease deprecation until the replacement API supports wildcard binding
- correct the post-audit roadmap note to document the compatibility exception

## Production incident
PR #136 migrated `http://+:{port}/` to `Host = "+"`, but OpenTelemetry 1.16.0-beta.1 passes `Host` through `UriBuilder`, which rejects `+`. The worker therefore crash-looped during startup while the web and API stayed healthy.

## Verification
- pinned .NET 10.0.302 worker build: 0 warnings, 0 errors
- production Docker worker image build: 0 warnings, 0 errors
- exact behavior matches the previously healthy production wildcard prefix

After merge, verify the worker container revision, health, metrics scrape, logs, Hangfire queues, and live endpoints.