### PR TITLE
Fix leaderboard filters and curate Pro Solo Q roster

### DIFF
--- a/Transcendence.Data/Models/LoL/Account/ProPlayerDiscoveryCandidate.cs
+++ b/Transcendence.Data/Models/LoL/Account/ProPlayerDiscoveryCandidate.cs
@@ -1,0 +1,17 @@
+namespace Transcendence.Data.Models.LoL.Account;
+
+public class ProPlayerDiscoveryCandidate
+{
+    public Guid Id { get; set; }
+    public string Source { get; set; } = string.Empty;
+    public string ExternalId { get; set; } = string.Empty;
+    public string ProName { get; set; } = string.Empty;
+    public string? TeamName { get; set; }
+    public string? Role { get; set; }
+    public string? SoloQueueIds { get; set; }
+    public string Status { get; set; } = "pending";
+    public Guid? ApprovedTrackedProSummonerId { get; set; }
+    public DateTime FirstSeenAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime LastSeenAtUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? ReviewedAtUtc { get; set; }
+}

--- a/Transcendence.Data/Models/LoL/Account/TrackedProSummoner.cs
+++ b/Transcendence.Data/Models/LoL/Account/TrackedProSummoner.cs
@@ -12,6 +12,13 @@ public class TrackedProSummoner
     public bool IsPro { get; set; } = true;
     public bool IsHighEloOtp { get; set; }
     public bool IsActive { get; set; } = true;
+    public string Source { get; set; } = "manual";
+    public string? SourceExternalId { get; set; }
+    public DateTime? LastVerifiedAtUtc { get; set; }
+    public int? OtpChampionId { get; set; }
+    public int? OtpGames { get; set; }
+    public int? OtpSampleSize { get; set; }
+    public DateTime? OtpEvaluatedAtUtc { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAtUtc { get; set; } = DateTime.UtcNow;
 }

--- a/Transcendence.Data/Repositories/Implementations/LeaderboardRepository.cs
+++ b/Transcendence.Data/Repositories/Implementations/LeaderboardRepository.cs
@@ -99,7 +99,7 @@ public sealed class LeaderboardRepository(TranscendenceContext db) : ILeaderboar
                 participant.Match.MatchDate <= endMs &&
                 (participant.Match.QueueId == queueId ||
                  (participant.Match.QueueId == 0 && participant.Match.QueueType == queueId.ToString())) &&
-                participant.Summoner.PlatformRegion == platformRegion &&
+                participant.Match.PlatformRegion == platformRegion &&
                 participant.Summoner.GameName != null &&
                 participant.Summoner.TagLine != null);
 

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -18,6 +18,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<HistoricalRank> HistoricalRanks { get; set; }
     public DbSet<ChampionMastery> ChampionMasteries { get; set; }
     public DbSet<TrackedProSummoner> TrackedProSummoners { get; set; }
+    public DbSet<ProPlayerDiscoveryCandidate> ProPlayerDiscoveryCandidates { get; set; }
     public DbSet<SummonerIngestionCursor> SummonerIngestionCursors { get; set; }
     public DbSet<RankedSeason> RankedSeasons { get; set; }
     public DbSet<SummonerFullHistoryBackfill> SummonerFullHistoryBackfills { get; set; }
@@ -157,6 +158,9 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             .HasIndex(x => x.QueueFamily);
         modelBuilder.Entity<Match>()
             .HasIndex(x => new { x.PlatformRegion, x.Status, x.Patch });
+        modelBuilder.Entity<Match>()
+            .HasIndex(x => new { x.PlatformRegion, x.Status, x.QueueId, x.MatchDate })
+            .HasDatabaseName("IX_Matches_Leaderboard");
 
         // Summoner lookups by Puuid
         modelBuilder.Entity<Summoner>()
@@ -586,9 +590,26 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             entity.HasKey(x => x.Id);
             entity.Property(x => x.Puuid).IsRequired();
             entity.Property(x => x.PlatformRegion).IsRequired();
+            entity.Property(x => x.Source).HasMaxLength(64).IsRequired().HasDefaultValue("manual");
+            entity.Property(x => x.SourceExternalId).HasMaxLength(256);
             entity.HasIndex(x => new { x.Puuid, x.PlatformRegion }).IsUnique();
             entity.HasIndex(x => x.IsActive);
             entity.HasIndex(x => x.UpdatedAtUtc);
+            entity.HasIndex(x => new { x.Source, x.SourceExternalId });
+        });
+
+        modelBuilder.Entity<ProPlayerDiscoveryCandidate>(entity =>
+        {
+            entity.HasKey(x => x.Id);
+            entity.Property(x => x.Source).HasMaxLength(64).IsRequired();
+            entity.Property(x => x.ExternalId).HasMaxLength(256).IsRequired();
+            entity.Property(x => x.ProName).HasMaxLength(128).IsRequired();
+            entity.Property(x => x.TeamName).HasMaxLength(128);
+            entity.Property(x => x.Role).HasMaxLength(64);
+            entity.Property(x => x.SoloQueueIds).HasMaxLength(2048);
+            entity.Property(x => x.Status).HasMaxLength(32).IsRequired();
+            entity.HasIndex(x => new { x.Source, x.ExternalId }).IsUnique();
+            entity.HasIndex(x => new { x.Status, x.LastSeenAtUtc });
         });
 
         modelBuilder.Entity<SummonerIngestionCursor>(entity =>

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -158,10 +158,6 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             .HasIndex(x => x.QueueFamily);
         modelBuilder.Entity<Match>()
             .HasIndex(x => new { x.PlatformRegion, x.Status, x.Patch });
-        modelBuilder.Entity<Match>()
-            .HasIndex(x => new { x.PlatformRegion, x.Status, x.QueueId, x.MatchDate })
-            .HasDatabaseName("IX_Matches_Leaderboard");
-
         // Summoner lookups by Puuid
         modelBuilder.Entity<Summoner>()
             .Property(s => s.Puuid)

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionAnalyticsService.cs
@@ -699,10 +699,10 @@ public class ChampionAnalyticsService : IChampionAnalyticsService
             championId, effectiveRole, tierForCompute, normalizedRegion, currentPatch, ct);
         await _cache.SetAsync(matchupsKey, matchups, AnalyticsCacheOptions, matchupsTags, ct);
 
-        // ── Pro-builds default (most-played lane, region=ALL, scope=all) ──
+        // ── Pro-builds default (most-played lane, region=ALL, scope=pro) ──
         if (includeProBuilds)
         {
-            var proScope = ChampionProComputeService.NormalizeProScope(null); // "all"
+            var proScope = ChampionProComputeService.NormalizeProScope(null); // "pro"
             const string proRegion = "ALL";
             var proKey = BuildProBuildsKey(championId, proRegion, effectiveRole, proScope, currentPatch);
             var proTags = new[] { AnalyticsCacheTag, CacheTags.ForPatch(currentPatch), "probuilds" };

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionProComputeService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/ChampionProComputeService.cs
@@ -359,11 +359,11 @@ public sealed class ChampionProComputeService : IChampionProComputeService
     }
 
     internal static string NormalizeProScope(string? scope) =>
-        (scope ?? "all").Trim().ToLowerInvariant() switch
+        (scope ?? "pro").Trim().ToLowerInvariant() switch
         {
-            "pro" => "pro",
+            "all" => "all",
             "highelo" => "highelo",
-            _ => "all"
+            _ => "pro"
         };
 
     public async Task<ChampionProBuildsResponse> ComputeProBuildsFromStatsAsync(

--- a/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Interfaces/IChampionAnalyticsService.cs
@@ -89,7 +89,7 @@ public interface IChampionAnalyticsService
 
     /// <summary>
     /// Gets champions ranked by pro / high-elo pick frequency, with caching.
-    /// Scope: "pro" | "highelo" | "all" (default all). Cached for 24 hours.
+    /// Scope: "pro" | "highelo" | "all" (default pro). Cached for 24 hours.
     /// </summary>
     Task<ProChampionPlayrateResponse> GetProChampionPlayrateAsync(
         string? region,

--- a/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
+++ b/Transcendence.Service.Core/Services/Extensions/ServiceCollectionExtensions.cs
@@ -127,6 +127,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<RefreshLockLifecycleJob>();
         services.AddScoped<BackfillMatchPlatformRegionJob>();
         services.AddScoped<IngestionHealthAlertJob>();
+        services.AddHttpClient<ProRosterDiscoveryJob>(client =>
+        {
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("Transcendence/1.0 (pro-roster-discovery)");
+            client.Timeout = TimeSpan.FromSeconds(30);
+        });
         services.AddScoped<IIngestionPriorityScoringPolicy, IngestionPriorityScoringPolicy>();
         services.AddSingleton<IQueueDepthProbe, HangfireQueueDepthProbe>();
 

--- a/Transcendence.Service.Core/Services/Jobs/AddOrUpdateHighEloProfiles.cs
+++ b/Transcendence.Service.Core/Services/Jobs/AddOrUpdateHighEloProfiles.cs
@@ -100,6 +100,22 @@ public class AddOrUpdateHighEloProfiles(
                 platform,
                 summonerPuuids.Count);
 
+            // Older versions treated every Master+ account as an OTP. Clear those unverified,
+            // auto-created rows before rebuilding the roster from match evidence below.
+            await context.TrackedProSummoners
+                .Where(x =>
+                    x.PlatformRegion == platform.ToString() &&
+                    !x.IsPro &&
+                    x.IsHighEloOtp &&
+                    x.OtpEvaluatedAtUtc == null &&
+                    x.ProName == null &&
+                    x.TeamName == null)
+                .ExecuteUpdateAsync(setters => setters
+                    .SetProperty(x => x.IsHighEloOtp, false)
+                    .SetProperty(x => x.IsActive, false)
+                    .SetProperty(x => x.Source, "riot-high-elo")
+                    .SetProperty(x => x.UpdatedAtUtc, DateTime.UtcNow), stoppingToken);
+
             foreach (var summonerPuuid in summonerPuuids)
             {
                 try
@@ -107,9 +123,10 @@ public class AddOrUpdateHighEloProfiles(
                     var summoner =
                         await summonerService.GetSummonerByPuuidAsync(summonerPuuid, platform, stoppingToken);
                     await summonerRepository.AddOrUpdateSummonerAsync(summoner, stoppingToken);
-                    await UpsertTrackedHighValueSummonerAsync(summoner, platform, stoppingToken);
+                    var isOtp = await ReconcileTrackedOtpAsync(summoner, platform, stoppingToken);
                     pendingChanges++;
-                    rosterUpdates++;
+                    if (isOtp)
+                        rosterUpdates++;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -149,16 +166,30 @@ public class AddOrUpdateHighEloProfiles(
         }
     }
 
-    private async Task UpsertTrackedHighValueSummonerAsync(
+    private async Task<bool> ReconcileTrackedOtpAsync(
         Data.Models.LoL.Account.Summoner summoner,
         PlatformRoute platform,
         CancellationToken stoppingToken)
     {
         if (string.IsNullOrWhiteSpace(summoner.Puuid))
-            return;
+            return false;
 
         var nowUtc = DateTime.UtcNow;
         var platformRegion = platform.ToString();
+        var championIds = await context.MatchParticipants
+            .AsNoTracking()
+            .Where(participant =>
+                participant.Puuid == summoner.Puuid &&
+                participant.Match.PlatformRegion == platformRegion &&
+                participant.Match.Status == Data.Models.LoL.Match.FetchStatus.Success &&
+                (participant.Match.QueueId == QueueCatalog.RankedSoloDuoQueueId ||
+                 (participant.Match.QueueId == 0 &&
+                  participant.Match.QueueType == QueueCatalog.RankedSoloDuoQueueId.ToString())))
+            .OrderByDescending(participant => participant.Match.MatchDate)
+            .Take(50)
+            .Select(participant => participant.ChampionId)
+            .ToListAsync(stoppingToken);
+        var qualification = EvaluateOtp(championIds);
         var existing = await context.TrackedProSummoners
             .FirstOrDefaultAsync(
                 x => x.Puuid == summoner.Puuid && x.PlatformRegion == platformRegion,
@@ -166,6 +197,9 @@ public class AddOrUpdateHighEloProfiles(
 
         if (existing == null)
         {
+            if (!qualification.IsQualified)
+                return false;
+
             context.TrackedProSummoners.Add(new TrackedProSummoner
             {
                 Id = Guid.NewGuid(),
@@ -174,20 +208,62 @@ public class AddOrUpdateHighEloProfiles(
                 GameName = summoner.GameName,
                 TagLine = summoner.TagLine,
                 IsPro = false,
-                // These are auto-discovered Challenger/GM/Master players — flag them so the
-                // "high-elo" / "all" pro-analytics scopes can include them (IsPro stays curated).
                 IsHighEloOtp = true,
                 IsActive = true,
+                Source = "riot-high-elo",
+                LastVerifiedAtUtc = nowUtc,
+                OtpChampionId = qualification.ChampionId,
+                OtpGames = qualification.ChampionGames,
+                OtpSampleSize = qualification.SampleSize,
+                OtpEvaluatedAtUtc = nowUtc,
                 UpdatedAtUtc = nowUtc,
                 CreatedAtUtc = nowUtc
             });
-            return;
+            return true;
         }
 
         existing.GameName = summoner.GameName;
         existing.TagLine = summoner.TagLine;
-        existing.IsHighEloOtp = true;
-        existing.IsActive = true;
+        existing.IsHighEloOtp = qualification.IsQualified;
+        if (qualification.IsQualified)
+            existing.IsActive = true;
+        else if (!existing.IsPro && existing.Source == "riot-high-elo")
+            existing.IsActive = false;
+        if (!existing.IsPro)
+            existing.Source = "riot-high-elo";
+        existing.LastVerifiedAtUtc = nowUtc;
+        existing.OtpChampionId = qualification.ChampionId;
+        existing.OtpGames = qualification.ChampionGames;
+        existing.OtpSampleSize = qualification.SampleSize;
+        existing.OtpEvaluatedAtUtc = nowUtc;
         existing.UpdatedAtUtc = nowUtc;
+        return qualification.IsQualified;
     }
+
+    public static OtpQualification EvaluateOtp(IReadOnlyCollection<int> championIds)
+    {
+        const int sampleSize = 50;
+        const int requiredChampionGames = 30;
+        if (championIds.Count < sampleSize)
+            return new OtpQualification(false, null, 0, championIds.Count);
+
+        var topChampion = championIds
+            .Take(sampleSize)
+            .GroupBy(championId => championId)
+            .Select(group => new { ChampionId = group.Key, Games = group.Count() })
+            .OrderByDescending(row => row.Games)
+            .ThenBy(row => row.ChampionId)
+            .First();
+        return new OtpQualification(
+            topChampion.Games >= requiredChampionGames,
+            topChampion.ChampionId,
+            topChampion.Games,
+            sampleSize);
+    }
+
+    public sealed record OtpQualification(
+        bool IsQualified,
+        int? ChampionId,
+        int ChampionGames,
+        int SampleSize);
 }

--- a/Transcendence.Service.Core/Services/Jobs/Configuration/ProRosterDiscoveryOptions.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Configuration/ProRosterDiscoveryOptions.cs
@@ -1,0 +1,9 @@
+namespace Transcendence.Service.Core.Services.Jobs.Configuration;
+
+public sealed class ProRosterDiscoveryOptions
+{
+    public string Endpoint { get; set; } = "https://lol.fandom.com/api.php";
+    public int PageSize { get; set; } = 500;
+    public int MaxPages { get; set; } = 4;
+    public int PageDelaySeconds { get; set; } = 65;
+}

--- a/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerJobScheduleOptions.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerJobScheduleOptions.cs
@@ -33,6 +33,8 @@ public class WorkerJobScheduleOptions
     public bool EnableRuneSelectionIntegrityBackfill { get; set; } = true;
     public bool EnableHighEloProfileRefresh { get; set; } = true;
     public string HighEloProfileRefreshCron { get; set; } = "0 */12 * * *";
+    public bool EnableProRosterDiscovery { get; set; } = true;
+    public string ProRosterDiscoveryCron { get; set; } = "15 3 * * *";
     public bool EnableRefreshLockLifecycleCleanup { get; set; } = true;
     public int RefreshLockLifecycleForensicsWindowMinutes { get; set; } = 30;
     public int RefreshLockLifecycleCleanupBatchSize { get; set; } = 250;

--- a/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerRecurringJobPolicy.cs
+++ b/Transcendence.Service.Core/Services/Jobs/Configuration/WorkerRecurringJobPolicy.cs
@@ -37,6 +37,7 @@ public sealed class WorkerRecurringJobPolicy(
     public const string RuneSelectionIntegrityBackfillJobId = "rune-selection-integrity-backfill";
     public const string PollLiveGamesJobId = "poll-live-games";
     public const string HighEloProfileRefreshJobId = "high-elo-profile-refresh";
+    public const string ProRosterDiscoveryJobId = "pro-roster-discovery";
     public const string RefreshLockLifecycleCleanupJobId = "refresh-lock-lifecycle-cleanup";
     public const string IngestionHealthAlertJobId = "ingestion-health-alert";
     public const string RefreshPrecomputedAnalyticsJobId = "refresh-precomputed-analytics";
@@ -63,6 +64,7 @@ public sealed class WorkerRecurringJobPolicy(
         RuneSelectionIntegrityBackfillJobId,
         PollLiveGamesJobId,
         HighEloProfileRefreshJobId,
+        ProRosterDiscoveryJobId,
         RefreshLockLifecycleCleanupJobId,
         IngestionHealthAlertJobId,
         RefreshPrecomputedAnalyticsJobId,
@@ -160,6 +162,12 @@ public sealed class WorkerRecurringJobPolicy(
                 schedule.HighEloProfileRefreshCron,
                 schedule.EnableHighEloProfileRefresh,
                 ConfigureHighEloProfileRefresh),
+            CreateDescriptor(
+                ProRosterDiscoveryJobId,
+                "Jobs:Schedule:ProRosterDiscoveryCron",
+                schedule.ProRosterDiscoveryCron,
+                schedule.EnableProRosterDiscovery,
+                ConfigureProRosterDiscovery),
             CreateDescriptor(
                 PollLiveGamesJobId,
                 "Jobs:Schedule:LiveGamePollingCron",
@@ -326,6 +334,15 @@ public sealed class WorkerRecurringJobPolicy(
         recurringJobManager.AddOrUpdate<AddOrUpdateHighEloProfiles>(
             HighEloProfileRefreshJobId,
             job => job.Execute(CancellationToken.None),
+            cronExpression,
+            new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+
+    private static void ConfigureProRosterDiscovery(
+        IRecurringJobManager recurringJobManager,
+        string cronExpression) =>
+        recurringJobManager.AddOrUpdate<ProRosterDiscoveryJob>(
+            ProRosterDiscoveryJobId,
+            job => job.ExecuteAsync(CancellationToken.None),
             cronExpression,
             new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
 

--- a/Transcendence.Service.Core/Services/Jobs/ProRosterDiscoveryJob.cs
+++ b/Transcendence.Service.Core/Services/Jobs/ProRosterDiscoveryJob.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using Hangfire;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Transcendence.Data;
+using Transcendence.Data.Models.LoL.Account;
+using Transcendence.Service.Core.Services.Jobs.Configuration;
+
+namespace Transcendence.Service.Core.Services.Jobs;
+
+public sealed class ProRosterDiscoveryJob(
+    HttpClient httpClient,
+    TranscendenceContext db,
+    IOptions<ProRosterDiscoveryOptions> options,
+    ILogger<ProRosterDiscoveryJob> logger)
+{
+    [Queue("maintenance")]
+    public async Task ExecuteAsync(CancellationToken ct)
+    {
+        var settings = options.Value;
+        var pageSize = Math.Clamp(settings.PageSize, 1, 500);
+        var maxPages = Math.Clamp(settings.MaxPages, 1, 20);
+        var pageDelay = TimeSpan.FromSeconds(Math.Clamp(settings.PageDelaySeconds, 0, 300));
+        var discovered = new Dictionary<string, DiscoveredProPlayer>(StringComparer.OrdinalIgnoreCase);
+
+        for (var page = 0; page < maxPages; page++)
+        {
+            IReadOnlyList<DiscoveredProPlayer> players;
+            try
+            {
+                var requestUri = BuildRequestUri(settings.Endpoint, pageSize, page * pageSize);
+                using var response = await httpClient.GetAsync(requestUri, ct);
+                response.EnsureSuccessStatusCode();
+                var payload = await response.Content.ReadAsStringAsync(ct);
+                players = ParsePlayers(payload);
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                // Leaguepedia is a discovery aid, not a production dependency. Keep any pages
+                // already read and let the next daily run retry without failing worker health.
+                logger.LogWarning(
+                    exception,
+                    "Pro roster discovery source page {Page} was unavailable; preserving partial and existing candidates.",
+                    page + 1);
+                break;
+            }
+
+            foreach (var player in players)
+                discovered[player.ExternalId] = player;
+            if (players.Count < pageSize)
+                break;
+            if (page + 1 < maxPages && pageDelay > TimeSpan.Zero)
+                await Task.Delay(pageDelay, ct);
+        }
+
+        if (discovered.Count == 0)
+        {
+            logger.LogInformation("Pro roster discovery completed with no source rows.");
+            return;
+        }
+
+        var externalIds = discovered.Keys.ToList();
+        var existing = await db.ProPlayerDiscoveryCandidates
+            .Where(candidate => candidate.Source == "leaguepedia" && externalIds.Contains(candidate.ExternalId))
+            .ToDictionaryAsync(candidate => candidate.ExternalId, StringComparer.OrdinalIgnoreCase, ct);
+        var nowUtc = DateTime.UtcNow;
+        var created = 0;
+
+        foreach (var player in discovered.Values)
+        {
+            if (!existing.TryGetValue(player.ExternalId, out var candidate))
+            {
+                db.ProPlayerDiscoveryCandidates.Add(new ProPlayerDiscoveryCandidate
+                {
+                    Id = Guid.NewGuid(),
+                    Source = "leaguepedia",
+                    ExternalId = player.ExternalId,
+                    ProName = player.ProName,
+                    TeamName = player.TeamName,
+                    Role = player.Role,
+                    SoloQueueIds = player.SoloQueueIds,
+                    Status = "pending",
+                    FirstSeenAtUtc = nowUtc,
+                    LastSeenAtUtc = nowUtc
+                });
+                created++;
+                continue;
+            }
+
+            candidate.ProName = player.ProName;
+            candidate.TeamName = player.TeamName;
+            candidate.Role = player.Role;
+            candidate.SoloQueueIds = player.SoloQueueIds;
+            candidate.LastSeenAtUtc = nowUtc;
+        }
+
+        await db.SaveChangesAsync(ct);
+        logger.LogInformation(
+            "Pro roster discovery staged {Created} new candidates and refreshed {Updated} existing candidates.",
+            created,
+            discovered.Count - created);
+    }
+
+    public static IReadOnlyList<DiscoveredProPlayer> ParsePlayers(string payload)
+    {
+        using var document = JsonDocument.Parse(payload);
+        if (document.RootElement.TryGetProperty("error", out var error))
+            throw new InvalidOperationException($"Leaguepedia returned an error: {error}");
+        if (!document.RootElement.TryGetProperty("cargoquery", out var rows) ||
+            rows.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var players = new List<DiscoveredProPlayer>();
+        foreach (var row in rows.EnumerateArray())
+        {
+            if (!row.TryGetProperty("title", out var title) || title.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var externalId = ReadString(title, "ID");
+            var proName = externalId;
+            var soloQueueIds = ReadString(title, "SoloqueueIds");
+            if (string.IsNullOrWhiteSpace(externalId) ||
+                string.IsNullOrWhiteSpace(proName) ||
+                string.IsNullOrWhiteSpace(soloQueueIds))
+                continue;
+
+            players.Add(new DiscoveredProPlayer(
+                externalId.Trim(),
+                proName.Trim(),
+                NormalizeOptional(ReadString(title, "Team")),
+                NormalizeOptional(ReadString(title, "Role")),
+                soloQueueIds.Trim()));
+        }
+
+        return players;
+    }
+
+    private static string BuildRequestUri(string endpoint, int limit, int offset)
+    {
+        var fields = "P.ID=ID,P.OverviewPage=OverviewPage,P.PlayerName=PlayerName,P.Team=Team,P.Role=Role,P.SoloqueueIds=SoloqueueIds";
+        var where = "P.IsRetired=0 AND P.Team IS NOT NULL AND P.SoloqueueIds IS NOT NULL";
+        var query = string.Join("&",
+            "action=cargoquery",
+            "format=json",
+            $"tables={Uri.EscapeDataString("Players=P")}",
+            $"fields={Uri.EscapeDataString(fields)}",
+            $"where={Uri.EscapeDataString(where)}",
+            $"limit={limit}",
+            $"offset={offset}");
+        return $"{endpoint.TrimEnd('?')}{(endpoint.Contains('?') ? '&' : '?')}{query}";
+    }
+
+    private static string? ReadString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out var value))
+            return null;
+        return value.ValueKind == JsonValueKind.String ? value.GetString() : value.ToString();
+    }
+
+    private static string? NormalizeOptional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    public sealed record DiscoveredProPlayer(
+        string ExternalId,
+        string ProName,
+        string? TeamName,
+        string? Role,
+        string SoloQueueIds);
+}

--- a/Transcendence.Service.Core/Services/ProSummoners/Implementations/TrackedProSummonerService.cs
+++ b/Transcendence.Service.Core/Services/ProSummoners/Implementations/TrackedProSummonerService.cs
@@ -30,6 +30,13 @@ public sealed class TrackedProSummonerService(TranscendenceContext db) : ITracke
                 x.IsPro,
                 x.IsHighEloOtp,
                 x.IsActive,
+                x.Source,
+                x.SourceExternalId,
+                x.LastVerifiedAtUtc,
+                x.OtpChampionId,
+                x.OtpGames,
+                x.OtpSampleSize,
+                x.OtpEvaluatedAtUtc,
                 x.CreatedAtUtc,
                 x.UpdatedAtUtc))
             .ToListAsync(ct);
@@ -51,6 +58,13 @@ public sealed class TrackedProSummonerService(TranscendenceContext db) : ITracke
                 x.IsPro,
                 x.IsHighEloOtp,
                 x.IsActive,
+                x.Source,
+                x.SourceExternalId,
+                x.LastVerifiedAtUtc,
+                x.OtpChampionId,
+                x.OtpGames,
+                x.OtpSampleSize,
+                x.OtpEvaluatedAtUtc,
                 x.CreatedAtUtc,
                 x.UpdatedAtUtc))
             .FirstOrDefaultAsync(ct);
@@ -116,6 +130,8 @@ public sealed class TrackedProSummonerService(TranscendenceContext db) : ITracke
             IsPro = request.IsPro,
             IsHighEloOtp = request.IsHighEloOtp,
             IsActive = request.IsActive,
+            Source = "manual",
+            LastVerifiedAtUtc = now,
             CreatedAtUtc = now,
             UpdatedAtUtc = now
         };
@@ -146,6 +162,7 @@ public sealed class TrackedProSummonerService(TranscendenceContext db) : ITracke
         entity.IsPro = request.IsPro;
         entity.IsHighEloOtp = request.IsHighEloOtp;
         entity.IsActive = request.IsActive;
+        entity.LastVerifiedAtUtc = DateTime.UtcNow;
         entity.UpdatedAtUtc = DateTime.UtcNow;
 
         await db.SaveChangesAsync(ct);
@@ -163,6 +180,81 @@ public sealed class TrackedProSummonerService(TranscendenceContext db) : ITracke
         return true;
     }
 
+    public async Task<IReadOnlyList<ProPlayerDiscoveryCandidateDto>> ListCandidatesAsync(
+        string status,
+        CancellationToken ct = default)
+    {
+        var normalizedStatus = NormalizeCandidateStatus(status);
+        return await db.ProPlayerDiscoveryCandidates
+            .AsNoTracking()
+            .Where(x => x.Status == normalizedStatus)
+            .OrderByDescending(x => x.LastSeenAtUtc)
+            .ThenBy(x => x.ProName)
+            .Take(500)
+            .Select(x => new ProPlayerDiscoveryCandidateDto(
+                x.Id,
+                x.Source,
+                x.ExternalId,
+                x.ProName,
+                x.TeamName,
+                x.Role,
+                x.SoloQueueIds,
+                x.Status,
+                x.ApprovedTrackedProSummonerId,
+                x.FirstSeenAtUtc,
+                x.LastSeenAtUtc,
+                x.ReviewedAtUtc))
+            .ToListAsync(ct);
+    }
+
+    public async Task<TrackedProCreateResult> ApproveCandidateAsync(
+        Guid id,
+        ApproveProPlayerCandidateRequest request,
+        CancellationToken ct = default)
+    {
+        var candidate = await db.ProPlayerDiscoveryCandidates.FirstOrDefaultAsync(x => x.Id == id, ct);
+        if (candidate is null)
+            return TrackedProCreateResult.Invalid("Discovery candidate was not found.");
+        if (candidate.Status == "approved")
+            return TrackedProCreateResult.Invalid("Discovery candidate is already approved.");
+
+        var outcome = await CreateAsync(new UpsertTrackedProSummonerRequest(
+            request.GameName,
+            request.TagLine,
+            request.PlatformRegion,
+            request.Puuid,
+            candidate.ProName,
+            candidate.TeamName,
+            IsPro: true,
+            IsHighEloOtp: false,
+            IsActive: true), ct);
+        if (!outcome.IsSuccess)
+            return outcome;
+
+        var created = await db.TrackedProSummoners
+            .FirstAsync(x => x.Id == outcome.Value!.Id, ct);
+        created.Source = candidate.Source;
+        created.SourceExternalId = candidate.ExternalId;
+        created.LastVerifiedAtUtc = DateTime.UtcNow;
+        candidate.Status = "approved";
+        candidate.ApprovedTrackedProSummonerId = created.Id;
+        candidate.ReviewedAtUtc = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+        return TrackedProCreateResult.Success(ToDto(created));
+    }
+
+    public async Task<bool> RejectCandidateAsync(Guid id, CancellationToken ct = default)
+    {
+        var candidate = await db.ProPlayerDiscoveryCandidates.FirstOrDefaultAsync(x => x.Id == id, ct);
+        if (candidate is null)
+            return false;
+
+        candidate.Status = "rejected";
+        candidate.ReviewedAtUtc = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
     private static TrackedProSummonerDto ToDto(TrackedProSummoner entity) => new(
         entity.Id,
         entity.Puuid,
@@ -174,9 +266,24 @@ public sealed class TrackedProSummonerService(TranscendenceContext db) : ITracke
         entity.IsPro,
         entity.IsHighEloOtp,
         entity.IsActive,
+        entity.Source,
+        entity.SourceExternalId,
+        entity.LastVerifiedAtUtc,
+        entity.OtpChampionId,
+        entity.OtpGames,
+        entity.OtpSampleSize,
+        entity.OtpEvaluatedAtUtc,
         entity.CreatedAtUtc,
         entity.UpdatedAtUtc);
 
     private static string? NormalizeOptional(string? value) =>
         string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string NormalizeCandidateStatus(string? status) =>
+        status?.Trim().ToLowerInvariant() switch
+        {
+            "approved" => "approved",
+            "rejected" => "rejected",
+            _ => "pending"
+        };
 }

--- a/Transcendence.Service.Core/Services/ProSummoners/Interfaces/ITrackedProSummonerService.cs
+++ b/Transcendence.Service.Core/Services/ProSummoners/Interfaces/ITrackedProSummonerService.cs
@@ -18,6 +18,17 @@ public interface ITrackedProSummonerService
         CancellationToken ct = default);
 
     Task<bool> DeleteAsync(Guid id, CancellationToken ct = default);
+
+    Task<IReadOnlyList<ProPlayerDiscoveryCandidateDto>> ListCandidatesAsync(
+        string status,
+        CancellationToken ct = default);
+
+    Task<TrackedProCreateResult> ApproveCandidateAsync(
+        Guid id,
+        ApproveProPlayerCandidateRequest request,
+        CancellationToken ct = default);
+
+    Task<bool> RejectCandidateAsync(Guid id, CancellationToken ct = default);
 }
 
 public sealed record TrackedProCreateResult(TrackedProSummonerDto? Value, string? ValidationError)

--- a/Transcendence.Service.Core/Services/ProSummoners/Models/TrackedProSummonerContracts.cs
+++ b/Transcendence.Service.Core/Services/ProSummoners/Models/TrackedProSummonerContracts.cs
@@ -27,6 +27,35 @@ public record TrackedProSummonerDto(
     bool IsPro,
     bool IsHighEloOtp,
     bool IsActive,
+    string Source,
+    string? SourceExternalId,
+    DateTime? LastVerifiedAtUtc,
+    int? OtpChampionId,
+    int? OtpGames,
+    int? OtpSampleSize,
+    DateTime? OtpEvaluatedAtUtc,
     DateTime CreatedAtUtc,
     DateTime UpdatedAtUtc
+);
+
+public record ProPlayerDiscoveryCandidateDto(
+    Guid Id,
+    string Source,
+    string ExternalId,
+    string ProName,
+    string? TeamName,
+    string? Role,
+    string? SoloQueueIds,
+    string Status,
+    Guid? ApprovedTrackedProSummonerId,
+    DateTime FirstSeenAtUtc,
+    DateTime LastSeenAtUtc,
+    DateTime? ReviewedAtUtc
+);
+
+public record ApproveProPlayerCandidateRequest(
+    [property: Required] string GameName,
+    [property: Required] string TagLine,
+    [property: Required] string PlatformRegion,
+    string? Puuid = null
 );

--- a/Transcendence.Service/Migrations/20260724034851_ImproveLeaderboardsAndProRosterDiscovery.Designer.cs
+++ b/Transcendence.Service/Migrations/20260724034851_ImproveLeaderboardsAndProRosterDiscovery.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260724034851_ImproveLeaderboardsAndProRosterDiscovery")]
+    partial class ImproveLeaderboardsAndProRosterDiscovery
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260724034851_ImproveLeaderboardsAndProRosterDiscovery.cs
+++ b/Transcendence.Service/Migrations/20260724034851_ImproveLeaderboardsAndProRosterDiscovery.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class ImproveLeaderboardsAndProRosterDiscovery : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastVerifiedAtUtc",
+                table: "TrackedProSummoners",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OtpChampionId",
+                table: "TrackedProSummoners",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "OtpEvaluatedAtUtc",
+                table: "TrackedProSummoners",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OtpGames",
+                table: "TrackedProSummoners",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OtpSampleSize",
+                table: "TrackedProSummoners",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Source",
+                table: "TrackedProSummoners",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "manual");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SourceExternalId",
+                table: "TrackedProSummoners",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ProPlayerDiscoveryCandidates",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Source = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ExternalId = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ProName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    TeamName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    Role = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    SoloQueueIds = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ApprovedTrackedProSummonerId = table.Column<Guid>(type: "uuid", nullable: true),
+                    FirstSeenAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ReviewedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProPlayerDiscoveryCandidates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TrackedProSummoners_Source_SourceExternalId",
+                table: "TrackedProSummoners",
+                columns: new[] { "Source", "SourceExternalId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Matches_Leaderboard",
+                table: "Matches",
+                columns: new[] { "PlatformRegion", "Status", "QueueId", "MatchDate" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProPlayerDiscoveryCandidates_Source_ExternalId",
+                table: "ProPlayerDiscoveryCandidates",
+                columns: new[] { "Source", "ExternalId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProPlayerDiscoveryCandidates_Status_LastSeenAtUtc",
+                table: "ProPlayerDiscoveryCandidates",
+                columns: new[] { "Status", "LastSeenAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProPlayerDiscoveryCandidates");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TrackedProSummoners_Source_SourceExternalId",
+                table: "TrackedProSummoners");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Matches_Leaderboard",
+                table: "Matches");
+
+            migrationBuilder.DropColumn(
+                name: "LastVerifiedAtUtc",
+                table: "TrackedProSummoners");
+
+            migrationBuilder.DropColumn(
+                name: "OtpChampionId",
+                table: "TrackedProSummoners");
+
+            migrationBuilder.DropColumn(
+                name: "OtpEvaluatedAtUtc",
+                table: "TrackedProSummoners");
+
+            migrationBuilder.DropColumn(
+                name: "OtpGames",
+                table: "TrackedProSummoners");
+
+            migrationBuilder.DropColumn(
+                name: "OtpSampleSize",
+                table: "TrackedProSummoners");
+
+            migrationBuilder.DropColumn(
+                name: "Source",
+                table: "TrackedProSummoners");
+
+            migrationBuilder.DropColumn(
+                name: "SourceExternalId",
+                table: "TrackedProSummoners");
+        }
+    }
+}

--- a/Transcendence.Service/Migrations/20260724042007_ImproveLeaderboardsAndProRosterDiscovery.Designer.cs
+++ b/Transcendence.Service/Migrations/20260724042007_ImproveLeaderboardsAndProRosterDiscovery.Designer.cs
@@ -13,7 +13,7 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    [Migration("20260724034851_ImproveLeaderboardsAndProRosterDiscovery")]
+    [Migration("20260724042007_ImproveLeaderboardsAndProRosterDiscovery")]
     partial class ImproveLeaderboardsAndProRosterDiscovery
     {
         /// <inheritdoc />
@@ -1795,9 +1795,6 @@ namespace Transcendence.Service.Migrations
                     b.HasIndex("QueueType");
 
                     b.HasIndex("PlatformRegion", "Status", "Patch");
-
-                    b.HasIndex("PlatformRegion", "Status", "QueueId", "MatchDate")
-                        .HasDatabaseName("IX_Matches_Leaderboard");
 
                     b.ToTable("Matches");
                 });

--- a/Transcendence.Service/Migrations/20260724042007_ImproveLeaderboardsAndProRosterDiscovery.cs
+++ b/Transcendence.Service/Migrations/20260724042007_ImproveLeaderboardsAndProRosterDiscovery.cs
@@ -84,11 +84,6 @@ namespace Transcendence.Service.Migrations
                 columns: new[] { "Source", "SourceExternalId" });
 
             migrationBuilder.CreateIndex(
-                name: "IX_Matches_Leaderboard",
-                table: "Matches",
-                columns: new[] { "PlatformRegion", "Status", "QueueId", "MatchDate" });
-
-            migrationBuilder.CreateIndex(
                 name: "IX_ProPlayerDiscoveryCandidates_Source_ExternalId",
                 table: "ProPlayerDiscoveryCandidates",
                 columns: new[] { "Source", "ExternalId" },
@@ -109,10 +104,6 @@ namespace Transcendence.Service.Migrations
             migrationBuilder.DropIndex(
                 name: "IX_TrackedProSummoners_Source_SourceExternalId",
                 table: "TrackedProSummoners");
-
-            migrationBuilder.DropIndex(
-                name: "IX_Matches_Leaderboard",
-                table: "Matches");
 
             migrationBuilder.DropColumn(
                 name: "LastVerifiedAtUtc",

--- a/Transcendence.Service/Migrations/ProjectSyndraContextModelSnapshot.cs
+++ b/Transcendence.Service/Migrations/ProjectSyndraContextModelSnapshot.cs
@@ -1793,9 +1793,6 @@ namespace Transcendence.Service.Migrations
 
                     b.HasIndex("PlatformRegion", "Status", "Patch");
 
-                    b.HasIndex("PlatformRegion", "Status", "QueueId", "MatchDate")
-                        .HasDatabaseName("IX_Matches_Leaderboard");
-
                     b.ToTable("Matches");
                 });
 

--- a/Transcendence.Service/Program.cs
+++ b/Transcendence.Service/Program.cs
@@ -161,6 +161,7 @@ builder.Services.Configure<RuneSelectionIntegrityBackfillJobOptions>(
     builder.Configuration.GetSection("Jobs:RuneSelectionIntegrityBackfill"));
 builder.Services.Configure<SummonerBootstrapOptions>(builder.Configuration.GetSection("Jobs:SummonerBootstrap"));
 builder.Services.Configure<MultiRegionIngestionOptions>(builder.Configuration.GetSection("Jobs:MultiRegionIngestion"));
+builder.Services.Configure<ProRosterDiscoveryOptions>(builder.Configuration.GetSection("Jobs:ProRosterDiscovery"));
 builder.Services.Configure<ChampionAnalyticsComputeOptions>(builder.Configuration.GetSection("Analytics:Compute"));
 builder.Services.Configure<TieringOptions>(builder.Configuration.GetSection("Analytics:Tiering"));
 builder.Services.Configure<PrecomputedAnalyticsOptions>(

--- a/Transcendence.Service/appsettings.json
+++ b/Transcendence.Service/appsettings.json
@@ -41,6 +41,8 @@
       "EnableRuneSelectionIntegrityBackfill": true,
       "EnableHighEloProfileRefresh": true,
       "HighEloProfileRefreshCron": "0 */12 * * *",
+      "EnableProRosterDiscovery": true,
+      "ProRosterDiscoveryCron": "15 3 * * *",
       "EnableRefreshLockLifecycleCleanup": true,
       "RefreshLockLifecycleForensicsWindowMinutes": 30,
       "RefreshLockLifecycleCleanupBatchSize": 250,
@@ -48,6 +50,12 @@
       "CleanupOnStartup": false,
       "RunPatchDetectionOnStartup": true,
       "PurgeBacklogOnPatchRolloverOnStartup": false
+    },
+    "ProRosterDiscovery": {
+      "Endpoint": "https://lol.fandom.com/api.php",
+      "PageSize": 500,
+      "MaxPages": 4,
+      "PageDelaySeconds": 65
     },
     "SchedulingProfiles": {
       "Profiles": {

--- a/Transcendence.WebAPI/Controllers/ProAnalyticsController.cs
+++ b/Transcendence.WebAPI/Controllers/ProAnalyticsController.cs
@@ -19,7 +19,7 @@ public class ProAnalyticsController(IChampionAnalyticsService analyticsService) 
     /// Champions ranked by how often tracked pros / high-elo players pick them.
     /// </summary>
     /// <param name="region">Optional region filter (e.g., NA, EUW, KR). Defaults to ALL.</param>
-    /// <param name="scope">Roster scope: "pro", "highelo", or "all". Defaults to all.</param>
+    /// <param name="scope">Roster scope: "pro", "highelo", or "all". Defaults to pro.</param>
     /// <param name="patch">Optional patch version. Defaults to the active analytics patch.</param>
     /// <param name="ct">Cancellation token</param>
     [HttpGet("champions")]

--- a/Transcendence.WebAPI/Controllers/ProSummonersController.cs
+++ b/Transcendence.WebAPI/Controllers/ProSummonersController.cs
@@ -92,6 +92,53 @@ public class ProSummonersController(
         return NoContent();
     }
 
+    [HttpGet("candidates")]
+    [ProducesResponseType(typeof(List<ProPlayerDiscoveryCandidateDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> ListCandidates(
+        [FromQuery] string status = "pending",
+        CancellationToken ct = default)
+    {
+        return Ok(await trackedProSummonerService.ListCandidatesAsync(status, ct));
+    }
+
+    [HttpPost("candidates/{id:guid}/approve")]
+    [EnableRateLimiting("admin-write")]
+    [ProducesResponseType(typeof(TrackedProSummonerDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ApproveCandidate(
+        [FromRoute] Guid id,
+        [FromBody] ApproveProPlayerCandidateRequest request,
+        CancellationToken ct = default)
+    {
+        var outcome = await trackedProSummonerService.ApproveCandidateAsync(id, request, ct);
+        if (!outcome.IsSuccess)
+            return BadRequest(outcome.ValidationError);
+
+        var approved = outcome.Value!;
+        await WriteAuditAsync("pro-summoners.candidate.approve", id.ToString(), new
+        {
+            approved.Id,
+            approved.Puuid,
+            approved.PlatformRegion,
+            approved.ProName,
+            approved.TeamName,
+            approved.Source
+        }, ct);
+        return Ok(approved);
+    }
+
+    [HttpPost("candidates/{id:guid}/reject")]
+    [EnableRateLimiting("admin-write")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RejectCandidate([FromRoute] Guid id, CancellationToken ct = default)
+    {
+        if (!await trackedProSummonerService.RejectCandidateAsync(id, ct))
+            return NotFound();
+        await WriteAuditAsync("pro-summoners.candidate.reject", id.ToString(), null, ct);
+        return NoContent();
+    }
+
     [HttpPost("{id:guid}/refresh")]
     [EnableRateLimiting("admin-write")]
     [ProducesResponseType(

--- a/Transcendence.WebAPI/Program.cs
+++ b/Transcendence.WebAPI/Program.cs
@@ -31,6 +31,7 @@ using Transcendence.WebAPI.Security;
 
 var builder = WebApplication.CreateBuilder(args);
 ConfigureSharedBackendConfiguration(builder.Configuration, builder.Environment);
+var isOpenApiExport = ParseBool(builder.Configuration["OpenApi:ExportOnly"], false);
 builder.Logging.AddOperationalFileLogger(builder.Configuration, defaultServiceName: "webapi");
 var requireJwtKeyInDevelopment = ParseBool(builder.Configuration["Auth:Jwt:RequireKeyInDevelopment"], false);
 var bootstrapApiKey = builder.Configuration["Auth:BootstrapApiKey"];
@@ -281,13 +282,17 @@ builder.Services.AddAuthorization(options =>
             .RequireRole(SystemRoles.Admin));
 });
 
-// Configure Hangfire client (no server) for enqueueing jobs
-builder.Services.AddHangfire(config =>
-    config.SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
-        .UseSimpleAssemblyNameTypeSerializer()
-        .UseRecommendedSerializerSettings()
-        .UsePostgreSqlStorage(options =>
-            options.UseNpgsqlConnection(builder.Configuration.GetConnectionString("MainDatabase"))));
+// Configure Hangfire client (no server) for enqueueing jobs. Swagger export does not
+// resolve controllers or enqueue work, so avoid initializing PostgreSQL-backed job storage.
+if (!isOpenApiExport)
+{
+    builder.Services.AddHangfire(config =>
+        config.SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
+            .UseSimpleAssemblyNameTypeSerializer()
+            .UseRecommendedSerializerSettings()
+            .UsePostgreSqlStorage(options =>
+                options.UseNpgsqlConnection(builder.Configuration.GetConnectionString("MainDatabase"))));
+}
 
 // Behind nginx + the Next.js BFF (which forwards X-Forwarded-For verbatim), honor the forwarded
 // headers so RemoteIpAddress is the real client rather than the proxy — this is what restores
@@ -340,8 +345,9 @@ app.MapHealthChecks("/health/live", new HealthCheckOptions { Predicate = _ => fa
 // Readiness: dependencies (PostgreSQL, Redis) reachable — gates traffic / deploy readiness.
 app.MapHealthChecks("/health/ready", new HealthCheckOptions { Predicate = check => check.Tags.Contains("ready") });
 
-using (var scope = app.Services.CreateScope())
+if (!isOpenApiExport)
 {
+    using var scope = app.Services.CreateScope();
     var bootstrap = scope.ServiceProvider.GetRequiredService<IAdminBootstrapService>();
     var bootstrapLogger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>()
         .CreateLogger("AdminBootstrap");

--- a/apps/web/app/admin/actions.ts
+++ b/apps/web/app/admin/actions.ts
@@ -144,6 +144,39 @@ export async function refreshProSummonerAction(formData: FormData) {
     () => revalidatePath("/admin/pro-summoners"));
 }
 
+export async function approveProCandidateAction(formData: FormData) {
+  const id = String(formData.get("id") ?? "").trim();
+  const gameName = String(formData.get("gameName") ?? "").trim();
+  const tagLine = String(formData.get("tagLine") ?? "").trim();
+  const platformRegion = String(formData.get("platformRegion") ?? "").trim();
+  if (!id || !gameName || !tagLine || !platformRegion) {
+    return { error: "Riot game name, tag line, and region are required." };
+  }
+
+  try {
+    await adminPost(`/api/admin/pro-summoners/candidates/${encodeURIComponent(id)}/approve`, {
+      gameName,
+      tagLine,
+      platformRegion,
+      puuid: String(formData.get("puuid") ?? "").trim() || null
+    });
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "Failed to approve candidate." };
+  }
+
+  revalidatePath("/admin/pro-summoners");
+  return { error: null };
+}
+
+export async function rejectProCandidateAction(formData: FormData) {
+  return simpleAdminAction(
+    formData,
+    "id",
+    (id) => `/api/admin/pro-summoners/candidates/${id}/reject`,
+    () => revalidatePath("/admin/pro-summoners")
+  );
+}
+
 export type BulkImportResult = {
   created: number;
   errors: string[];

--- a/apps/web/app/admin/pro-summoners/ProSummonersPanel.tsx
+++ b/apps/web/app/admin/pro-summoners/ProSummonersPanel.tsx
@@ -3,15 +3,17 @@
 import { useRef, useState, useTransition } from "react";
 
 import {
+  approveProCandidateAction,
   bulkCreateProSummonersAction,
   createProSummonerAction,
   deleteProSummonerAction,
+  rejectProCandidateAction,
   refreshProSummonerAction,
   type BulkImportResult
 } from "@/app/admin/actions";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
-import type { ProSummoner } from "@/lib/adminTypes";
+import type { ProPlayerDiscoveryCandidate, ProSummoner } from "@/lib/adminTypes";
 
 const PLATFORM_REGIONS = [
   "NA1",
@@ -27,7 +29,13 @@ const PLATFORM_REGIONS = [
   "RU"
 ] as const;
 
-export function ProSummonersPanel({ rows }: { rows: ProSummoner[] }) {
+export function ProSummonersPanel({
+  rows,
+  candidates
+}: {
+  rows: ProSummoner[];
+  candidates: ProPlayerDiscoveryCandidate[];
+}) {
   const [showAddForm, setShowAddForm] = useState(false);
   const [showCsvImport, setShowCsvImport] = useState(false);
 
@@ -52,6 +60,7 @@ export function ProSummonersPanel({ rows }: { rows: ProSummoner[] }) {
 
       {showAddForm && <AddSummonerForm />}
       {showCsvImport && <CsvImportForm />}
+      <DiscoveryCandidates candidates={candidates} />
 
       <div className="page-panel p-4">
         <h2 className="text-lg font-semibold">
@@ -77,6 +86,91 @@ export function ProSummonersPanel({ rows }: { rows: ProSummoner[] }) {
         </div>
       </div>
     </section>
+  );
+}
+
+function DiscoveryCandidates({ candidates }: { candidates: ProPlayerDiscoveryCandidate[] }) {
+  return (
+    <div className="page-panel p-4">
+      <div>
+        <h2 className="text-lg font-semibold">Pro account candidates ({candidates.length})</h2>
+        <p className="mt-1 text-sm text-fg/60">
+          Leaguepedia names are staged here. Confirm the current Riot ID before adding an account.
+        </p>
+      </div>
+      {candidates.length === 0 ? (
+        <p className="mt-4 text-sm text-fg/65">No candidates need review.</p>
+      ) : (
+        <div className="mt-4 grid gap-3">
+          {candidates.map((candidate) => (
+            <CandidateRow key={candidate.id} candidate={candidate} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CandidateRow({ candidate }: { candidate: ProPlayerDiscoveryCandidate }) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-surface-2/25 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="font-semibold">{candidate.proName}</p>
+          <p className="text-xs text-fg/60">
+            {[candidate.teamName, candidate.role].filter(Boolean).join(" · ") || "No current team"}
+          </p>
+          <p className="mt-1 whitespace-pre-wrap text-xs text-fg/75">
+            Source accounts: {candidate.soloQueueIds || "None listed"}
+          </p>
+        </div>
+        <form
+          action={(formData) => {
+            startTransition(async () => {
+              await rejectProCandidateAction(formData);
+            });
+          }}
+        >
+          <input type="hidden" name="id" value={candidate.id} />
+          <Button type="submit" size="sm" variant="ghost" disabled={pending}>
+            Reject
+          </Button>
+        </form>
+      </div>
+      <form
+        action={(formData) => {
+          setError(null);
+          startTransition(async () => {
+            const result = await approveProCandidateAction(formData);
+            setError(result?.error ?? null);
+          });
+        }}
+        className="mt-3 grid gap-2 sm:grid-cols-[1fr_8rem_8rem_1fr_auto]"
+      >
+        <input type="hidden" name="id" value={candidate.id} />
+        <Input name="gameName" placeholder="Riot game name" required />
+        <Input name="tagLine" placeholder="Tag" required />
+        <select
+          name="platformRegion"
+          required
+          aria-label={`Region for ${candidate.proName}`}
+          className="control-select h-11 w-full bg-surface/50 px-3 text-sm text-fg focus:border-primary/70 focus:ring-2 focus:ring-primary/25"
+        >
+          <option value="">Region</option>
+          {PLATFORM_REGIONS.map((region) => (
+            <option key={region} value={region}>{region}</option>
+          ))}
+        </select>
+        <Input name="puuid" placeholder="PUUID (optional)" />
+        <Button type="submit" size="sm" disabled={pending}>
+          {pending ? "Adding..." : "Approve"}
+        </Button>
+      </form>
+      {error ? <p className="mt-2 text-xs text-danger">{error}</p> : null}
+    </div>
   );
 }
 
@@ -216,7 +310,14 @@ function SummonerRow({ row }: { row: ProSummoner }) {
       </td>
       <td className="py-2">{row.platformRegion}</td>
       <td className="py-2">
-        {[row.proName, row.teamName].filter(Boolean).join(" / ") || "-"}
+        <p>{[row.proName, row.teamName].filter(Boolean).join(" / ") || "-"}</p>
+        <p className="text-xs text-fg/55">
+          {row.isPro ? "Pro" : "One-trick"}
+          {row.isHighEloOtp && row.otpGames && row.otpSampleSize
+            ? ` · ${row.otpGames}/${row.otpSampleSize} games`
+            : ""}
+          {` · ${row.source}`}
+        </p>
       </td>
       <td className="py-2">{new Date(row.updatedAtUtc).toLocaleString()}</td>
       <td className="py-2">

--- a/apps/web/app/admin/pro-summoners/page.tsx
+++ b/apps/web/app/admin/pro-summoners/page.tsx
@@ -1,10 +1,13 @@
 import { adminGet } from "@/lib/adminBackend";
-import type { ProSummoner } from "@/lib/adminTypes";
+import type { ProPlayerDiscoveryCandidate, ProSummoner } from "@/lib/adminTypes";
 
 import { ProSummonersPanel } from "./ProSummonersPanel";
 
 export default async function AdminProSummonersPage() {
-  const rows = await adminGet<ProSummoner[]>("/api/admin/pro-summoners?isActive=true");
+  const [rows, candidates] = await Promise.all([
+    adminGet<ProSummoner[]>("/api/admin/pro-summoners?isActive=true"),
+    adminGet<ProPlayerDiscoveryCandidate[]>("/api/admin/pro-summoners/candidates?status=pending")
+  ]);
 
-  return <ProSummonersPanel rows={rows} />;
+  return <ProSummonersPanel rows={rows} candidates={candidates} />;
 }

--- a/apps/web/app/lol/champions/page.tsx
+++ b/apps/web/app/lol/champions/page.tsx
@@ -104,9 +104,9 @@ export default async function ChampionsPage({
   return (
     <div className="grid gap-4">
       <Toolbar
-        eyebrow="League Directory"
+        eyebrow="Champions"
         title="Champions"
-        meta={<span>Builds, win rates, and matchups for every champion</span>}
+        meta={<span>Builds, win rates, and matchups</span>}
         filters={<AnalyticsRegionFilter options={regionOptions} activeRegion={activeRegion} />}
       />
       <AnalyticsSampleBanner

--- a/apps/web/app/lol/leaderboards/loading.tsx
+++ b/apps/web/app/lol/leaderboards/loading.tsx
@@ -1,0 +1,21 @@
+import { Card } from "@/components/ui/Card";
+
+export default function LeaderboardsLoading() {
+  return (
+    <div className="grid gap-4" aria-label="Loading leaderboard">
+      <div className="h-28 animate-pulse rounded-2xl border border-border/60 bg-surface" />
+      <Card className="overflow-hidden p-0">
+        <div className="grid divide-y divide-border/30">
+          {Array.from({ length: 8 }, (_, index) => (
+            <div key={index} className="flex h-[61px] animate-pulse items-center gap-4 px-4">
+              <span className="h-3 w-8 rounded bg-surface-2" />
+              <span className="size-9 rounded-lg bg-surface-2" />
+              <span className="h-3 w-36 rounded bg-surface-2" />
+              <span className="ml-auto h-3 w-24 rounded bg-surface-2" />
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/lol/leaderboards/page.tsx
+++ b/apps/web/app/lol/leaderboards/page.tsx
@@ -71,7 +71,7 @@ export default async function LeaderboardsPage({
   if (!response.ok || !response.body) {
     return (
       <div className="grid gap-4">
-        <Toolbar eyebrow="Ranked Competition" title="Leaderboards" filters={filterBar} />
+        <Toolbar eyebrow="Ranked" title="Leaderboards" filters={filterBar} />
         <BackendErrorCard
           title="Leaderboard unavailable"
           message="We couldn't load this ranked board right now."
@@ -88,7 +88,7 @@ export default async function LeaderboardsPage({
   return (
     <div className="grid gap-4">
       <Toolbar
-        eyebrow="Ranked Competition"
+        eyebrow="Ranked"
         title="Leaderboards"
         meta={
           <>

--- a/apps/web/app/lol/live/page.tsx
+++ b/apps/web/app/lol/live/page.tsx
@@ -5,7 +5,7 @@ import { socialImageUrl } from "@/lib/seo";
 
 const title = "Live Game Scout";
 const description =
-  "Scout an active League match with ranks, recent form, streaks, champion pools, spells, and runes.";
+  "View ranks, recent form, champion pools, spells, and runes for an active League match.";
 const image = socialImageUrl(title, "Live matchup", "Ranks, streaks, champion pools, spells, and runes");
 
 export const metadata: Metadata = {

--- a/apps/web/app/lol/multi-search/page.tsx
+++ b/apps/web/app/lol/multi-search/page.tsx
@@ -4,7 +4,7 @@ import { MultiSearchClient } from "@/components/MultiSearchClient";
 import { socialImageUrl } from "@/lib/seo";
 
 const title = "Champ Select Multi-Search";
-const description = "Paste up to five Riot IDs to compare ranks, main roles, tracked form, champion pools, and autofill risk.";
+const description = "Compare ranks, roles, recent form, and champion pools for up to five Riot IDs.";
 const image = socialImageUrl(title, "Team scout", "Ranks, role coverage, champion pools, and autofill signals");
 
 export const metadata: Metadata = {

--- a/apps/web/app/lol/pro-builds/[championId]/page.tsx
+++ b/apps/web/app/lol/pro-builds/[championId]/page.tsx
@@ -6,6 +6,7 @@ import { BackendErrorCard } from "@/components/BackendErrorCard";
 import { AnalyticsSampleBanner } from "@/components/AnalyticsSampleBanner";
 import { AnalyticsPatchFilter } from "@/components/AnalyticsPatchFilter";
 import { AnalyticsRegionFilter } from "@/components/AnalyticsRegionFilter";
+import { ProScopeToggle } from "@/components/ProScopeToggle";
 import { RoleFilterTabs } from "@/components/RoleFilterTabs";
 import { RuneSetupDisplay } from "@/components/RuneSetupDisplay";
 import { WinRateText } from "@/components/WinRateText";
@@ -39,16 +40,10 @@ import {
 type ChampionWinRateSummary = components["schemas"]["ChampionWinRateSummary"];
 type ChampionProBuildsResponse = components["schemas"]["ChampionProBuildsResponse"];
 
-const SCOPE_OPTIONS: readonly { value: ProBuildScope; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "pro", label: "Pros" },
-  { value: "highelo", label: "High-Elo" }
-];
-
 const SCOPE_LABEL: Record<ProBuildScope, string> = {
-  all: "Pro & High-Elo",
+  all: "Pros and One-Tricks",
   pro: "Pros",
-  highelo: "High-Elo"
+  highelo: "One-Tricks"
 };
 
 function proFeedErrorMessage(result: BackendJsonResult<ChampionProBuildsResponse>) {
@@ -248,7 +243,7 @@ export default async function ProBuildsChampionPage({
   const alternativeBuilds = usableCommonBuilds.slice(1);
   const roleExtraParams: Record<string, string> = {};
   if (regionFilter !== "ALL") roleExtraParams.region = regionFilter;
-  if (scopeFilter !== "all") roleExtraParams.scope = scopeFilter;
+  if (scopeFilter !== "pro") roleExtraParams.scope = scopeFilter;
   if (patchFilter) roleExtraParams.patch = patchFilter;
 
   const effectivePatch =
@@ -258,6 +253,7 @@ export default async function ProBuildsChampionPage({
   // off that so the most-played lane lights up and navigation preserves it.
   const effectiveRole = normalizeProBuildRole(proBuilds?.role ?? roleFilter);
   const effectiveScope = normalizeProBuildScope(proBuilds?.scope ?? scopeFilter);
+  const includeOneTricks = scopeFilter !== "pro";
   const sampleNotice = pickMostSevereAnalyticsSample(
     (proBuilds as { sample?: unknown } | null)?.sample as AnalyticsSampleLike,
     (winrates as { sample?: unknown } | null)?.sample as AnalyticsSampleLike
@@ -279,8 +275,7 @@ export default async function ProBuildsChampionPage({
               Pro Solo Queue Builds
             </h1>
             <p className="type-ui mt-2 text-fg/75">
-              Ranked solo-queue builds from tracked pros and high-MMR specialists for {championName}.
-              Not tournament match data.
+              Ranked Solo/Duo builds from tracked professional accounts for {championName}.
             </p>
           </div>
         </div>
@@ -308,24 +303,15 @@ export default async function ProBuildsChampionPage({
             extraParams={roleExtraParams}
           />
           <AnalyticsRegionFilter options={regionOptions} activeRegion={activeRegion} variant="select" />
-          <div role="group" aria-label="Pro pool scope" className="flex flex-wrap gap-x-3 gap-y-3 sm:gap-x-4 sm:gap-y-2">
-            {SCOPE_OPTIONS.map((option) => (
-              <Link
-                key={option.value}
-                href={buildProBuildPageHref(championId, {
-                  role: effectiveRole,
-                  region: regionFilter,
-                  scope: option.value,
-                  patch: patchFilter
-                })}
-                className="control-tab type-ui min-h-11 px-3.5 py-2"
-                data-active={option.value === scopeFilter}
-                aria-current={option.value === scopeFilter ? "page" : undefined}
-              >
-                {option.label}
-              </Link>
-            ))}
-          </div>
+          <ProScopeToggle
+            checked={includeOneTricks}
+            href={buildProBuildPageHref(championId, {
+              role: effectiveRole,
+              region: regionFilter,
+              scope: includeOneTricks ? "pro" : "all",
+              patch: patchFilter
+            })}
+          />
           <AnalyticsPatchFilter patches={patchOptions} activePatch={patchFilter} />
           {patchFilter ? (
             <Link

--- a/apps/web/app/lol/pro-builds/page.tsx
+++ b/apps/web/app/lol/pro-builds/page.tsx
@@ -6,6 +6,7 @@ import type { components } from "@transcendence/api-client";
 import { AnalyticsSampleBanner } from "@/components/AnalyticsSampleBanner";
 import { AnalyticsRegionFilter } from "@/components/AnalyticsRegionFilter";
 import { BackendErrorCard } from "@/components/BackendErrorCard";
+import { ProScopeToggle } from "@/components/ProScopeToggle";
 import { Card } from "@/components/ui/Card";
 import { DataBar } from "@/components/ui/DataBar";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -26,16 +27,10 @@ type ProMatchBuildDto = components["schemas"]["ProMatchBuildDto"];
 type ProChampionPlayrateResponse = components["schemas"]["ProChampionPlayrateResponse"];
 type ProRosterResponse = components["schemas"]["ProRosterResponse"];
 
-const SCOPE_OPTIONS = [
-  { value: "all", label: "All" },
-  { value: "pro", label: "Pros" },
-  { value: "highelo", label: "High-Elo" }
-] as const;
-
 const SCOPE_TITLE: Record<ProBuildScope, string> = {
-  all: "Pro & High-Elo",
+  all: "Pro and One-Trick",
   pro: "Pro",
-  highelo: "High-Elo"
+  highelo: "One-Trick"
 };
 
 const SCOPE_NOUN: Record<ProBuildScope, string> = {
@@ -56,7 +51,7 @@ function buildProHomeHref({
   query: string | null;
 }) {
   const params = new URLSearchParams();
-  if (scope && scope !== "all") params.set("scope", scope);
+  if (scope && scope !== "pro") params.set("scope", scope);
   if (region && region !== "ALL") params.set("region", region);
   if (query) params.set("q", query);
   const qs = params.toString();
@@ -127,6 +122,7 @@ export default async function ProBuildsIndexPage({
   );
   const championQuery = normalizeChampionQuery(resolvedSearchParams?.q);
   const scope = normalizeProBuildScope(resolvedSearchParams?.scope);
+  const includeOneTricks = scope !== "pro";
   const tierListQuery = new URLSearchParams();
   if (activeRegion !== "ALL") tierListQuery.set("region", activeRegion);
 
@@ -211,7 +207,7 @@ export default async function ProBuildsIndexPage({
   return (
     <div className="grid gap-4">
       <Toolbar
-        eyebrow="League · Ranked Solo Queue"
+        eyebrow="Ranked Solo Queue"
         title="Pro Solo Queue Builds"
         meta={
           <>
@@ -233,10 +229,8 @@ export default async function ProBuildsIndexPage({
       />
 
       <Card className="bg-surface-2/50 px-5 py-4">
-        <p className="type-overline text-muted">Coverage note</p>
-        <p className="type-ui mt-1 text-fg/80">
-          This surface follows tracked professional players and high-elo specialists in ranked solo
-          queue. It does not represent tournament drafts, esports schedules, or official match results.
+        <p className="type-ui text-fg/80">
+          Ranked Solo/Duo matches from tracked professional accounts. Tournament matches are not included.
         </p>
       </Card>
 
@@ -248,19 +242,14 @@ export default async function ProBuildsIndexPage({
               Champions most picked by tracked {SCOPE_NOUN[scope]} this patch.
             </p>
           </div>
-          <div role="group" aria-label="Pro pool scope" className="flex items-center gap-2 text-xs">
-            {SCOPE_OPTIONS.map((option) => (
-              <Link
-                key={option.value}
-                href={buildProHomeHref({ scope: option.value, region: activeRegion, query: championQuery })}
-                className="control-tab type-ui px-3 py-2"
-                data-active={option.value === scope}
-                aria-current={option.value === scope ? "page" : undefined}
-              >
-                {option.label}
-              </Link>
-            ))}
-          </div>
+          <ProScopeToggle
+            checked={includeOneTricks}
+            href={buildProHomeHref({
+              scope: includeOneTricks ? "pro" : "all",
+              region: activeRegion,
+              query: championQuery
+            })}
+          />
         </div>
 
         {playrateChampions.length === 0 ? (
@@ -334,7 +323,7 @@ export default async function ProBuildsIndexPage({
           <div className="flex items-center justify-between gap-3">
             <div>
               <h2 className="type-section">Tracked Pros</h2>
-              <p className="type-ui mt-1 text-muted">Pro players we follow — open any profile.</p>
+              <p className="type-ui mt-1 text-muted">Open a tracked pro profile.</p>
             </div>
             <span className="type-tabular tabular-nums text-muted">{rosterPlayers.length} players</span>
           </div>
@@ -373,7 +362,7 @@ export default async function ProBuildsIndexPage({
         <h2 className="type-section">Search Champions</h2>
         <form action="/lol/pro-builds" method="get" className="mt-3 flex flex-wrap items-center gap-2">
           {activeRegion !== "ALL" ? <input type="hidden" name="region" value={activeRegion} /> : null}
-          {scope !== "all" ? <input type="hidden" name="scope" value={scope} /> : null}
+          {scope !== "pro" ? <input type="hidden" name="scope" value={scope} /> : null}
           <input
             type="text"
             name="q"

--- a/apps/web/app/lol/tierlist/page.tsx
+++ b/apps/web/app/lol/tierlist/page.tsx
@@ -200,7 +200,7 @@ export default async function TierListPage({
           meta row while docked, so the separate freshness strip below no longer needs to stick. */}
       <Toolbar
         className="tierlist-toolbar-dock z-30"
-        eyebrow="League Analytics"
+        eyebrow="Current patch"
         title="Tier List"
         meta={
           <>

--- a/apps/web/components/GlobalCommandPalette.test.tsx
+++ b/apps/web/components/GlobalCommandPalette.test.tsx
@@ -33,12 +33,23 @@ describe("GlobalCommandPalette", () => {
             version: "16.14.1",
             champions: {
               "103": { id: "Ahri", name: "Ahri" },
-              "86": { id: "Garen", name: "Garen" }
+              "86": { id: "Garen", name: "Garen" },
+              "145": { id: "Kaisa", name: "Kai'Sa" }
             }
           });
         }
 
-        return jsonResponse({ items: [] });
+        return jsonResponse({
+          items: [
+            {
+              platformRegion: "NA1",
+              region: "na",
+              gameName: "KaisaMain",
+              tagLine: "NA1",
+              profileIconId: 29
+            }
+          ]
+        });
       })
     );
   });
@@ -73,9 +84,42 @@ describe("GlobalCommandPalette", () => {
 
     const input = await screen.findByRole("combobox", { name: "Global search input" });
     await user.type(input, "Kronic#NA1");
-    expect(await screen.findByText("Kronic#NA1 in NA")).toBeTruthy();
+    expect(await screen.findByRole("option", { name: /Kronic#NA1/i })).toBeTruthy();
 
     await user.keyboard("{Enter}");
     await waitFor(() => expect(router.push).toHaveBeenCalledWith("/lol/summoners/na/Kronic-NA1"));
+  });
+
+  it("normalizes punctuationless champion names and selects the champion before players", async () => {
+    const user = userEvent.setup();
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+
+    const input = await screen.findByRole("combobox", { name: "Global search input" });
+    await user.type(input, "kaisa");
+
+    const championLabel = await screen.findByText("Kai'Sa");
+    const champion = championLabel.closest('[role="option"]');
+    expect(champion).not.toBeNull();
+    await waitFor(() => expect(champion.getAttribute("data-selected")).toBe("true"));
+
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/lol/champions/145"));
+  });
+
+  it("keeps multi-search available as command navigation", async () => {
+    const user = userEvent.setup();
+    render(<GlobalCommandPalette />);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+
+    const input = await screen.findByRole("combobox", { name: "Global search input" });
+    await user.type(input, "multi search");
+    await screen.findByRole("option", { name: /Multi-Search/i });
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Multi-Search/i }).getAttribute("data-selected")).toBe("true")
+    );
+
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(router.push).toHaveBeenCalledWith("/lol/multi-search"));
   });
 });

--- a/apps/web/components/GlobalCommandPalette.tsx
+++ b/apps/web/components/GlobalCommandPalette.tsx
@@ -1,23 +1,18 @@
 "use client";
 
 import { Command } from "cmdk";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { Dialog, VisuallyHidden } from "radix-ui";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import { ArrowCornerIcon, SearchIcon, SparkIcon } from "@/components/ui/icons";
+import { SearchIcon } from "@/components/ui/icons";
 import { Select } from "@/components/ui/Select";
-import {
-  getGlobalSearchOpenDetail,
-  GLOBAL_SEARCH_OPEN_EVENT,
-  type GlobalSearchOpenOrigin
-} from "@/lib/globalSearch";
+import { GLOBAL_SEARCH_OPEN_EVENT } from "@/lib/globalSearch";
 import { buildLolPublicSummonerSearchPath } from "@/lib/lolPublicApi";
 import { LOL_REGION_OPTIONS } from "@/lib/lolRegions";
-import { DEFAULT_TIERLIST_RANK_TIER, rankTierDisplayLabel } from "@/lib/ranks";
 import { encodeRiotIdPath, parseRiotIdInput } from "@/lib/riotid";
+import { searchMatchScore } from "@/lib/searchNormalization";
 import { championIconUrl } from "@/lib/staticData";
 
 type ChampionSearchItem = {
@@ -43,135 +38,60 @@ type SummonerSearchResponse = {
   items: SummonerSearchItem[];
 };
 
-const TIER_LINKS = [
+type NavigationItem = {
+  label: string;
+  detail: string;
+  href: string;
+  keywords: string;
+};
+
+const NAVIGATION_ITEMS: readonly NavigationItem[] = [
   {
-    label: `Tier List · All Roles (${rankTierDisplayLabel(DEFAULT_TIERLIST_RANK_TIER)})`,
-    href: "/lol/tierlist"
+    label: "Tier List",
+    detail: "Champion rankings",
+    href: "/lol/tierlist",
+    keywords: "tiers rankings"
   },
   {
-    label: `Tier List · Top (${rankTierDisplayLabel(DEFAULT_TIERLIST_RANK_TIER)})`,
-    href: "/lol/tierlist?role=TOP"
+    label: "Leaderboards",
+    detail: "Regional and champion rankings",
+    href: "/lol/leaderboards",
+    keywords: "rank ladder"
   },
   {
-    label: `Tier List · Jungle (${rankTierDisplayLabel(DEFAULT_TIERLIST_RANK_TIER)})`,
-    href: "/lol/tierlist?role=JUNGLE"
+    label: "Champions",
+    detail: "Champion list",
+    href: "/lol/champions",
+    keywords: "champion analytics"
   },
   {
-    label: `Tier List · Middle (${rankTierDisplayLabel(DEFAULT_TIERLIST_RANK_TIER)})`,
-    href: "/lol/tierlist?role=MIDDLE"
+    label: "Build Atlas",
+    detail: "Items and runes",
+    href: "/lol/items",
+    keywords: "items runes builds"
   },
   {
-    label: `Tier List · Bottom (${rankTierDisplayLabel(DEFAULT_TIERLIST_RANK_TIER)})`,
-    href: "/lol/tierlist?role=BOTTOM"
+    label: "Live Game",
+    detail: "Current match lookup",
+    href: "/lol/live",
+    keywords: "spectator current match"
   },
   {
-    label: `Tier List · Support (${rankTierDisplayLabel(DEFAULT_TIERLIST_RANK_TIER)})`,
-    href: "/lol/tierlist?role=UTILITY"
+    label: "Pro Solo Q",
+    detail: "Professional solo queue builds",
+    href: "/lol/pro-builds",
+    keywords: "pros pro builds"
   },
-  { label: "Tier List · All Ranks", href: "/lol/tierlist?rankTier=all" },
-  { label: "Tier List · Challenger", href: "/lol/tierlist?rankTier=CHALLENGER" },
-  { label: "Champions", href: "/lol/champions" },
-  { label: "Item Analytics · Pick rates and champion fit", href: "/lol/items" },
-  { label: "Rune Analytics · Pick rates and champion fit", href: "/lol/runes" },
-  { label: "Leaderboards · Regional and champion", href: "/lol/leaderboards" },
-  { label: "Pro Solo Queue Builds", href: "/lol/pro-builds" },
-  { label: "Multi-Search · Champ Select Scout", href: "/lol/multi-search" }
-] as const;
+  {
+    label: "Multi-Search",
+    detail: "Search several players",
+    href: "/lol/multi-search",
+    keywords: "multi search scout team"
+  }
+];
 
 const RESULT_ITEM_CLASS =
-  "group flex min-h-[52px] cursor-pointer items-center gap-3 rounded-card border border-transparent px-3 py-2.5 text-left text-fg/90 transition duration-150 data-[selected=true]:translate-x-1 data-[selected=true]:border-primary/25 data-[selected=true]:bg-primary/10 data-[selected=true]:shadow-card";
-
-const PANEL_ENTRY_EASE = [0.16, 1, 0.3, 1] as const;
-
-const resultsContainerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.045,
-      delayChildren: 0.08
-    }
-  },
-  exit: {
-    opacity: 0,
-    transition: {
-      duration: 0.12
-    }
-  }
-};
-
-const resultsSectionVariants = {
-  hidden: { opacity: 0, y: 14 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.26,
-      ease: PANEL_ENTRY_EASE
-    }
-  }
-};
-
-function capturePanelOpening(
-  origin: GlobalSearchOpenOrigin | null,
-  prefersReducedMotion: boolean
-) {
-  const viewportWidth = window.innerWidth;
-  const panelWidth = Math.max(320, Math.min(880, viewportWidth - 24));
-  const topOffset = Math.max(72, Math.round(window.innerHeight * 0.09));
-
-  if (prefersReducedMotion) {
-    return {
-      topOffset,
-      enterState: {
-        opacity: 0,
-        x: 0,
-        y: -10,
-        scaleX: 1,
-        scaleY: 1,
-        borderRadius: 24
-      }
-    };
-  }
-
-  if (!origin) {
-    return {
-      topOffset,
-      enterState: {
-        opacity: 0,
-        x: 0,
-        y: -18,
-        scaleX: 0.985,
-        scaleY: 0.97,
-        borderRadius: 24
-      }
-    };
-  }
-
-  return {
-    topOffset,
-    enterState: {
-      opacity: 0.76,
-      x: origin.centerX - viewportWidth / 2,
-      y: origin.centerY - topOffset,
-      scaleX: Math.min(1, Math.max(0.18, origin.width / panelWidth)),
-      scaleY: Math.min(1, Math.max(0.15, origin.height / 280)),
-      borderRadius: Math.max(18, Math.round(origin.height / 2))
-    }
-  };
-}
-
-const DEFAULT_PANEL_OPENING = {
-  topOffset: 96,
-  enterState: {
-    opacity: 0,
-    x: 0,
-    y: -18,
-    scaleX: 0.985,
-    scaleY: 0.97,
-    borderRadius: 24
-  }
-};
+  "group flex min-h-12 cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-left text-fg/82 outline-none transition-colors data-[selected=true]:bg-primary/12 data-[selected=true]:text-fg";
 
 function isEditableTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) return false;
@@ -184,11 +104,9 @@ function useDebouncedValue<T>(value: T, delayMs: number) {
   const [debounced, setDebounced] = useState(value);
 
   useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      setDebounced(value);
-    }, delayMs);
+    const timeoutId = window.setTimeout(() => setDebounced(value), delayMs);
     return () => window.clearTimeout(timeoutId);
-  }, [value, delayMs]);
+  }, [delayMs, value]);
 
   return debounced;
 }
@@ -197,70 +115,36 @@ function profileIconSrc(version: string, profileIconId: number) {
   return `https://ddragon.leagueoflegends.com/cdn/${version}/img/profileicon/${profileIconId}.png`;
 }
 
-function splitQuickLinkLabel(label: string) {
-  const [title, detail] = label.split("·").map((part) => part.trim());
-  return {
-    title: title || label,
-    detail: detail || null
-  };
+function resultValue(kind: string, id: string | number) {
+  return `${kind}:${id}`;
 }
 
-function SearchSection({
-  title,
-  countLabel,
-  children,
-  className
+function ResultGroup({
+  heading,
+  children
 }: {
-  title: string;
-  countLabel: string;
+  heading: string;
   children: React.ReactNode;
-  className?: string;
 }) {
   return (
-    <section
-      className={`surface-subtle rounded-card p-2.5 sm:p-3 ${className ?? ""}`}
-    >
-      <div className="mb-2 flex items-center justify-between gap-3 px-1">
-        <p className="type-kicker text-primary/88">{title}</p>
-        <p className="type-ui type-tabular text-fg/65">{countLabel}</p>
-      </div>
-      <div className="grid gap-1">{children}</div>
-    </section>
-  );
-}
-
-function SearchHint({
-  children,
-  tone = "default"
-}: {
-  children: React.ReactNode;
-  tone?: "default" | "accent";
-}) {
-  return (
-    <div
-      className={`rounded-xl border px-3 py-3 text-sm leading-6 ${
-        tone === "accent"
-          ? "border-primary/24 bg-primary/11 text-fg/92"
-          : "surface-subtle text-fg/72"
-      }`}
+    <Command.Group
+      heading={heading}
+      className="px-2 py-1.5 text-xs text-muted [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.12em]"
     >
       {children}
-    </div>
+    </Command.Group>
   );
 }
 
 export function GlobalCommandPalette() {
   const router = useRouter();
-  const prefersReducedMotion = useReducedMotion() ?? false;
   const inputRef = useRef<HTMLInputElement | null>(null);
-  // The element focused when the palette opened, so focus returns there on close. Captured manually
-  // because forceMount (kept for the exit animation) disrupts Radix's own focus-restore capture.
   const lastFocusedRef = useRef<HTMLElement | null>(null);
   const suggestionCacheRef = useRef<Map<string, SummonerSearchItem[]>>(new Map());
   const [open, setOpen] = useState(false);
-  const [panelOpening, setPanelOpening] = useState(DEFAULT_PANEL_OPENING);
   const [query, setQuery] = useState("");
   const [region, setRegion] = useState("na");
+  const [selectedValue, setSelectedValue] = useState("");
   const [champions, setChampions] = useState<ChampionSearchItem[]>([]);
   const [ddragonVersion, setDdragonVersion] = useState<string | null>(null);
   const [championsLoaded, setChampionsLoaded] = useState(false);
@@ -268,43 +152,39 @@ export function GlobalCommandPalette() {
   const [summonerLoading, setSummonerLoading] = useState(false);
 
   const debouncedQuery = useDebouncedValue(query, 120);
-  const normalizedQuery = debouncedQuery.trim().toLowerCase();
+  const trimmedQuery = debouncedQuery.trim();
   const parsedRiotId = parseRiotIdInput(query.trim());
 
   useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k" && !e.altKey && !e.shiftKey) {
-        if (isEditableTarget(e.target)) return;
-        e.preventDefault();
-        lastFocusedRef.current = document.activeElement as HTMLElement | null;
-        setPanelOpening(capturePanelOpening(null, prefersReducedMotion));
-        setOpen(true);
-      }
-      // Escape (and outside-click / focus-out) close is owned by the Radix Dialog below, which also
-      // dismisses a nested Region dropdown first — so no manual Escape handling here.
-    }
-
-    function onOpenEvent(event: Event) {
+    function openPalette() {
       lastFocusedRef.current = document.activeElement as HTMLElement | null;
-      setPanelOpening(
-        capturePanelOpening(getGlobalSearchOpenDetail(event).origin, prefersReducedMotion)
-      );
       setOpen(true);
     }
 
+    function onKeyDown(event: KeyboardEvent) {
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.key.toLowerCase() === "k" &&
+        !event.altKey &&
+        !event.shiftKey &&
+        !isEditableTarget(event.target)
+      ) {
+        event.preventDefault();
+        openPalette();
+      }
+    }
+
     window.addEventListener("keydown", onKeyDown);
-    window.addEventListener(GLOBAL_SEARCH_OPEN_EVENT, onOpenEvent);
+    window.addEventListener(GLOBAL_SEARCH_OPEN_EVENT, openPalette);
     return () => {
       window.removeEventListener("keydown", onKeyDown);
-      window.removeEventListener(GLOBAL_SEARCH_OPEN_EVENT, onOpenEvent);
+      window.removeEventListener(GLOBAL_SEARCH_OPEN_EVENT, openPalette);
     };
-  }, [prefersReducedMotion]);
+  }, []);
 
   useEffect(() => {
     if (!open) return;
-    const rafId = window.requestAnimationFrame(() => {
-      inputRef.current?.focus();
-    });
+    const rafId = window.requestAnimationFrame(() => inputRef.current?.focus());
     return () => window.cancelAnimationFrame(rafId);
   }, [open]);
 
@@ -313,44 +193,41 @@ export function GlobalCommandPalette() {
 
     let active = true;
     void fetch("/api/static/champions", { cache: "force-cache" })
-      .then(async (res) => {
-        if (!res.ok) throw new Error("Failed to load champions.");
-        const json = (await res.json()) as ChampionsResponse;
-        const parsed = Object.entries(json.champions)
-          .map(([championId, data]) => ({
-            championId: Number(championId),
-            name: data.name,
-            slug: data.id
-          }))
-          .filter((item) => Number.isFinite(item.championId))
-          .sort((a, b) => a.name.localeCompare(b.name));
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Failed to load champions.");
+        const payload = (await response.json()) as ChampionsResponse;
+        if (!active) return;
 
-        if (!active) return;
-        setDdragonVersion(json.version);
-        setChampions(parsed);
-        setChampionsLoaded(true);
+        setDdragonVersion(payload.version);
+        setChampions(
+          Object.entries(payload.champions)
+            .map(([championId, champion]) => ({
+              championId: Number(championId),
+              name: champion.name,
+              slug: champion.id
+            }))
+            .filter((champion) => Number.isFinite(champion.championId))
+            .sort((a, b) => a.name.localeCompare(b.name))
+        );
       })
-      .catch(() => {
-        if (!active) return;
-        setChampionsLoaded(true);
+      .catch(() => undefined)
+      .finally(() => {
+        if (active) setChampionsLoaded(true);
       });
 
     return () => {
       active = false;
     };
-  }, [open, championsLoaded]);
+  }, [championsLoaded, open]);
 
   useEffect(() => {
-    if (!open) return;
-
-    const trimmedQuery = debouncedQuery.trim();
-    if (trimmedQuery.length < 2) {
+    if (!open || trimmedQuery.length < 2) {
       setSummonerResults([]);
       setSummonerLoading(false);
       return;
     }
 
-    const cacheKey = `${region}|${trimmedQuery.toLowerCase()}`;
+    const cacheKey = `${region}|${trimmedQuery.toLocaleLowerCase()}`;
     const cached = suggestionCacheRef.current.get(cacheKey);
     if (cached) {
       setSummonerResults(cached);
@@ -360,466 +237,334 @@ export function GlobalCommandPalette() {
 
     const abortController = new AbortController();
     setSummonerLoading(true);
-
-    void fetch(buildLolPublicSummonerSearchPath(region, trimmedQuery, 8), {
+    void fetch(buildLolPublicSummonerSearchPath(region, trimmedQuery, 6), {
       cache: "no-store",
       signal: abortController.signal
     })
-      .then(async (res) => {
-        if (!res.ok) throw new Error("Summoner search failed.");
-        const json = (await res.json()) as SummonerSearchResponse;
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Summoner search failed.");
+        const payload = (await response.json()) as SummonerSearchResponse;
         if (abortController.signal.aborted) return;
-        const items = Array.isArray(json.items) ? json.items : [];
+        const items = Array.isArray(payload.items) ? payload.items : [];
         setSummonerResults(items);
-
         suggestionCacheRef.current.set(cacheKey, items);
         if (suggestionCacheRef.current.size > 60) {
-          const oldest = suggestionCacheRef.current.keys().next().value as string | undefined;
-          if (oldest) suggestionCacheRef.current.delete(oldest);
+          const oldestKey = suggestionCacheRef.current.keys().next().value as string | undefined;
+          if (oldestKey) suggestionCacheRef.current.delete(oldestKey);
         }
       })
       .catch(() => {
-        if (abortController.signal.aborted) return;
-        setSummonerResults([]);
+        if (!abortController.signal.aborted) setSummonerResults([]);
       })
       .finally(() => {
-        if (abortController.signal.aborted) return;
-        setSummonerLoading(false);
+        if (!abortController.signal.aborted) setSummonerLoading(false);
       });
 
-    return () => {
-      abortController.abort();
-    };
-  }, [debouncedQuery, open, region]);
+    return () => abortController.abort();
+  }, [open, region, trimmedQuery]);
 
   const championResults = useMemo(() => {
-    if (!normalizedQuery) return champions.slice(0, 8);
+    if (!trimmedQuery) return champions.slice(0, 5);
     return champions
-      .filter((champion) => champion.name.toLowerCase().includes(normalizedQuery))
-      .sort((a, b) => {
-        const aStarts = a.name.toLowerCase().startsWith(normalizedQuery) ? 0 : 1;
-        const bStarts = b.name.toLowerCase().startsWith(normalizedQuery) ? 0 : 1;
-        return aStarts - bStarts || a.name.localeCompare(b.name);
-      })
-      .slice(0, 10);
-  }, [champions, normalizedQuery]);
+      .map((champion) => ({
+        champion,
+        score: Math.min(
+          searchMatchScore(champion.name, trimmedQuery) ?? Number.POSITIVE_INFINITY,
+          searchMatchScore(champion.slug, trimmedQuery) ?? Number.POSITIVE_INFINITY
+        )
+      }))
+      .filter((result) => Number.isFinite(result.score))
+      .sort(
+        (a, b) =>
+          a.score - b.score ||
+          a.champion.name.length - b.champion.name.length ||
+          a.champion.name.localeCompare(b.champion.name)
+      )
+      .slice(0, 8)
+      .map((result) => result.champion);
+  }, [champions, trimmedQuery]);
 
-  const tierResults = useMemo(() => {
-    if (!normalizedQuery) return TIER_LINKS;
-    return TIER_LINKS.filter((item) =>
-      item.label.toLowerCase().includes(normalizedQuery)
-    );
-  }, [normalizedQuery]);
+  const navigationResults = useMemo(() => {
+    if (!trimmedQuery) return NAVIGATION_ITEMS;
+    return NAVIGATION_ITEMS.map((item) => ({
+      item,
+      score: searchMatchScore(`${item.label} ${item.keywords}`, trimmedQuery)
+    }))
+      .filter((result) => result.score != null)
+      .sort((a, b) => a.score! - b.score! || a.item.label.localeCompare(b.item.label))
+      .map((result) => result.item);
+  }, [trimmedQuery]);
 
-  const summonerResultPaths = useMemo(
-    () =>
-      summonerResults.map((item) =>
-        `/lol/summoners/${item.region}/${encodeRiotIdPath({
-          gameName: item.gameName,
-          tagLine: item.tagLine
-        })}`
-      ),
-    [summonerResults]
-  );
+  const directPlayerPath = parsedRiotId
+    ? `/lol/summoners/${region}/${encodeRiotIdPath(parsedRiotId)}`
+    : null;
+  const directPlayerValue = parsedRiotId
+    ? resultValue("direct-player", `${parsedRiotId.gameName}-${parsedRiotId.tagLine}-${region}`)
+    : null;
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    if (directPlayerValue) {
+      setSelectedValue(directPlayerValue);
+      return;
+    }
+    if (championResults[0]) {
+      setSelectedValue(resultValue("champion", championResults[0].championId));
+      return;
+    }
+    if (navigationResults[0]) {
+      setSelectedValue(resultValue("navigation", navigationResults[0].href));
+      return;
+    }
+    if (summonerResults[0]) {
+      setSelectedValue(
+        resultValue(
+          "player",
+          `${summonerResults[0].platformRegion}-${summonerResults[0].gameName}-${summonerResults[0].tagLine}`
+        )
+      );
+      return;
+    }
+    setSelectedValue("");
+  }, [
+    championResults,
+    directPlayerValue,
+    navigationResults,
+    open,
+    summonerResults
+  ]);
 
   const prefetchTargets = useMemo(() => {
-    const paths = summonerResultPaths.slice(0, 3);
-    if (paths.length === 0 && parsedRiotId) {
-      paths.push(`/lol/summoners/${region}/${encodeRiotIdPath(parsedRiotId)}`);
-    }
-
-    for (const championPath of championResults
+    const targets = championResults
       .slice(0, 3)
-      .map((c) => `/lol/champions/${c.championId}`)) {
-      paths.push(championPath);
-    }
-    for (const tier of tierResults.slice(0, 2)) paths.push(tier.href);
-    return paths;
-  }, [championResults, tierResults, parsedRiotId, region, summonerResultPaths]);
+      .map((champion) => `/lol/champions/${champion.championId}`);
+    if (directPlayerPath) targets.push(directPlayerPath);
+    for (const item of navigationResults.slice(0, 2)) targets.push(item.href);
+    return targets;
+  }, [championResults, directPlayerPath, navigationResults]);
 
   useEffect(() => {
     if (!open) return;
-    for (const path of prefetchTargets) {
-      router.prefetch(path);
-    }
+    for (const target of prefetchTargets) router.prefetch(target);
   }, [open, prefetchTargets, router]);
 
   function navigate(path: string) {
     setOpen(false);
     setQuery("");
+    setSelectedValue("");
     router.push(path);
   }
 
-  function handleQueryKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key !== "Enter") return;
-    if (!parsedRiotId) return;
-
-    e.preventDefault();
-    e.stopPropagation();
-    navigate(`/lol/summoners/${region}/${encodeRiotIdPath(parsedRiotId)}`);
+  function renderChampionGroup() {
+    if (championResults.length === 0) return null;
+    return (
+      <ResultGroup heading="Champions">
+        {championResults.map((champion) => (
+          <Command.Item
+            key={champion.championId}
+            value={resultValue("champion", champion.championId)}
+            onSelect={() => navigate(`/lol/champions/${champion.championId}`)}
+            className={RESULT_ITEM_CLASS}
+          >
+            {ddragonVersion ? (
+              <Image
+                src={championIconUrl(ddragonVersion, champion.slug)}
+                alt=""
+                width={34}
+                height={34}
+                className="size-[34px] rounded-md"
+              />
+            ) : (
+              <span className="size-[34px] rounded-md bg-surface-2" />
+            )}
+            <span className="min-w-0 flex-1 truncate font-medium">{champion.name}</span>
+            <span className="text-xs text-muted group-data-[selected=true]:text-fg/65">
+              Champion
+            </span>
+          </Command.Item>
+        ))}
+      </ResultGroup>
+    );
   }
 
-  const regionLabel = LOL_REGION_OPTIONS.find((item) => item.value === region)?.label ?? region.toUpperCase();
-  const directOpenPath = parsedRiotId
-    ? `/lol/summoners/${region}/${encodeRiotIdPath(parsedRiotId)}`
-    : null;
-  const showEmpty =
-    championResults.length === 0 &&
-    tierResults.length === 0 &&
-    summonerResults.length === 0 &&
-    !parsedRiotId;
-  const sectionVariants = prefersReducedMotion
-    ? {
-        hidden: { opacity: 0 },
-        visible: {
-          opacity: 1,
-          transition: { duration: 0.12 }
-        }
-      }
-    : resultsSectionVariants;
-  return (
-    // Radix Dialog supplies the modal a11y the hand-rolled overlay lacked: role="dialog" + aria-modal,
-    // a focus trap, focus return to the launcher on close, Escape-to-close, and page scroll lock — while
-    // forceMount keeps the nodes present so framer-motion still owns the enter/exit animation.
-    <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Portal forceMount>
-        <AnimatePresence initial={false}>
-          {open ? (
-            <div className="command-palette-overlay fixed inset-0 z-50">
-              <Dialog.Overlay asChild forceMount>
-                <motion.div
-                  className="absolute inset-0 bg-bg/80 backdrop-blur-md"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: prefersReducedMotion ? 0.12 : 0.2, ease: PANEL_ENTRY_EASE }}
-                />
-              </Dialog.Overlay>
-
-              <div
-            className="command-palette-shell absolute inset-x-0 top-0 flex justify-center px-3"
-            style={{ paddingTop: `${panelOpening.topOffset}px` }}
+  function renderPlayerGroup() {
+    if (!directPlayerPath && summonerResults.length === 0 && !summonerLoading) return null;
+    return (
+      <ResultGroup heading="Players">
+        {directPlayerPath && parsedRiotId && directPlayerValue ? (
+          <Command.Item
+            value={directPlayerValue}
+            onSelect={() => navigate(directPlayerPath)}
+            className={RESULT_ITEM_CLASS}
           >
-            <Dialog.Content
-              asChild
-              forceMount
-              aria-label="Global search"
-              aria-modal="true"
-              aria-describedby={undefined}
-              onOpenAutoFocus={(event) => {
-                event.preventDefault();
-                inputRef.current?.focus();
-              }}
-              onCloseAutoFocus={(event) => {
-                event.preventDefault();
-                lastFocusedRef.current?.focus?.();
-              }}
+            <span className="flex size-[34px] items-center justify-center rounded-md bg-primary/12 font-semibold text-primary">
+              #
+            </span>
+            <span className="min-w-0 flex-1 truncate font-medium">
+              {parsedRiotId.gameName}
+              <span className="text-fg/55">#{parsedRiotId.tagLine}</span>
+            </span>
+            <span className="text-xs uppercase text-muted">{region}</span>
+          </Command.Item>
+        ) : null}
+        {summonerResults.map((summoner) => {
+          const path = `/lol/summoners/${summoner.region}/${encodeRiotIdPath(summoner)}`;
+          const value = resultValue(
+            "player",
+            `${summoner.platformRegion}-${summoner.gameName}-${summoner.tagLine}`
+          );
+          return (
+            <Command.Item
+              key={value}
+              value={value}
+              onSelect={() => navigate(path)}
+              className={RESULT_ITEM_CLASS}
             >
-            <motion.div
-              className="command-palette-panel pointer-events-auto w-[min(880px,calc(100vw-24px))] overflow-hidden border border-border/70 bg-surface shadow-overlay"
-              initial={panelOpening.enterState}
-              animate={{
-                opacity: 1,
-                x: 0,
-                y: 0,
-                scaleX: 1,
-                scaleY: 1,
-                borderRadius: 24
-              }}
-              exit={
-                prefersReducedMotion
-                  ? { opacity: 0, y: -6 }
-                  : {
-                      opacity: 0,
-                      y: -16,
-                      scaleX: 0.985,
-                      scaleY: 0.98
-                    }
-              }
-              transition={
-                prefersReducedMotion
-                  ? { duration: 0.12 }
-                  : {
-                      type: "spring",
-                      stiffness: 300,
-                      damping: 32,
-                      mass: 0.82,
-                      opacity: { duration: 0.16, ease: PANEL_ENTRY_EASE }
-                    }
-              }
-              style={{ transformOrigin: "top center" }}
-            >
-              <VisuallyHidden.Root asChild>
-                <Dialog.Title>Global search</Dialog.Title>
-              </VisuallyHidden.Root>
-              <Command label="Global search input" shouldFilter={false} className="relative w-full">
-                <motion.div
-                  variants={resultsContainerVariants}
-                  initial="hidden"
-                  animate="visible"
-                  exit="exit"
-                  className="border-b border-border/50 px-4 pb-4 pt-4 sm:px-5 sm:pb-5 sm:pt-5"
-                >
-                  <motion.div variants={sectionVariants} className="flex items-center justify-between gap-3">
-                    <p className="type-kicker text-primary">Search</p>
-                    <span className="type-caption hidden text-muted sm:inline">Esc to close</span>
-                  </motion.div>
+              {ddragonVersion ? (
+                <Image
+                  src={profileIconSrc(ddragonVersion, summoner.profileIconId)}
+                  alt=""
+                  width={34}
+                  height={34}
+                  className="size-[34px] rounded-md"
+                />
+              ) : (
+                <span className="size-[34px] rounded-md bg-surface-2" />
+              )}
+              <span className="min-w-0 flex-1 truncate font-medium">
+                {summoner.gameName}
+                <span className="text-fg/55">#{summoner.tagLine}</span>
+              </span>
+              <span className="text-xs text-muted">{summoner.platformRegion}</span>
+            </Command.Item>
+          );
+        })}
+        {summonerLoading ? (
+          <p className="px-3 py-2 text-sm text-muted">Searching players…</p>
+        ) : null}
+      </ResultGroup>
+    );
+  }
 
-                  <motion.div
-                    variants={sectionVariants}
-                    className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-end"
-                  >
-                    <div className="relative flex-1">
-                      <SearchIcon className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-primary/75" />
-                      <Command.Input
-                        ref={inputRef}
-                        value={query}
-                        onValueChange={setQuery}
-                        onKeyDown={handleQueryKeyDown}
-                        placeholder="Search champions, tier list, or summoner"
-                        className="type-ui h-12 w-full rounded-control border border-border/65 bg-surface-2/55 pl-11 pr-4 text-fg shadow-inset outline-none transition placeholder:text-muted/70 focus:border-primary/65 focus:bg-surface-2/70 focus:ring-2 focus:ring-primary/18"
-                        aria-label="Global search input"
-                      />
-                    </div>
+  function renderNavigationGroup() {
+    if (navigationResults.length === 0) return null;
+    return (
+      <ResultGroup heading="Navigation">
+        {navigationResults.map((item) => (
+          <Command.Item
+            key={item.href}
+            value={resultValue("navigation", item.href)}
+            onSelect={() => navigate(item.href)}
+            className={RESULT_ITEM_CLASS}
+          >
+            <span className="flex size-[34px] items-center justify-center rounded-md bg-surface-2 text-muted">
+              ↗
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate font-medium">{item.label}</span>
+              <span className="block truncate text-xs text-muted">{item.detail}</span>
+            </span>
+          </Command.Item>
+        ))}
+      </ResultGroup>
+    );
+  }
 
-                    <div className="sm:w-[124px]">
-                      <label className="type-kicker mb-2 block text-fg/65">Region</label>
-                      <Select
-                        value={region}
-                        onValueChange={setRegion}
-                        options={[...LOL_REGION_OPTIONS]}
-                        ariaLabel="Summoner region"
-                        className="h-12 w-full rounded-control border-border/65 bg-surface-2/55 text-fg shadow-inset"
-                      />
-                    </div>
-                  </motion.div>
+  const hasResults =
+    championResults.length > 0 ||
+    navigationResults.length > 0 ||
+    summonerResults.length > 0 ||
+    Boolean(directPlayerPath) ||
+    summonerLoading;
+  const championFirst = !parsedRiotId && championResults.length > 0;
 
-                  {parsedRiotId && directOpenPath ? (
-                    <motion.button
-                      variants={sectionVariants}
-                      type="button"
-                      onClick={() => navigate(directOpenPath)}
-                      className="surface-chip-accent mt-3 flex w-full items-center justify-between gap-3 rounded-control px-4 py-3 text-left transition hover:border-primary/38 hover:bg-primary/13"
-                    >
-                      <div className="grid gap-1">
-                        <span className="type-kicker text-primary/92">Direct Open</span>
-                        <span className="type-ui text-fg/92">
-                          {parsedRiotId.gameName}#{parsedRiotId.tagLine} in {regionLabel}
-                        </span>
-                      </div>
-                      <span className="type-kicker rounded-full border border-primary/30 px-2.5 py-1 text-primary">
-                        Enter
-                      </span>
-                    </motion.button>
-                  ) : null}
-                </motion.div>
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          setQuery("");
+          setSelectedValue("");
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-bg/76" />
+        <Dialog.Content
+          aria-label="Global search"
+          aria-modal="true"
+          aria-describedby={undefined}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            inputRef.current?.focus();
+          }}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            lastFocusedRef.current?.focus?.();
+          }}
+          className="fixed left-1/2 top-[max(1rem,8vh)] z-50 w-[min(720px,calc(100vw-24px))] -translate-x-1/2 overflow-hidden rounded-2xl border border-border/75 bg-surface shadow-overlay focus:outline-none"
+        >
+          <VisuallyHidden.Root asChild>
+            <Dialog.Title>Global search</Dialog.Title>
+          </VisuallyHidden.Root>
+          <Command
+            label="Global search input"
+            shouldFilter={false}
+            value={selectedValue}
+            onValueChange={setSelectedValue}
+          >
+            <div className="flex items-center gap-2 border-b border-border/55 p-3">
+              <SearchIcon className="ml-1 size-5 shrink-0 text-muted" />
+              <Command.Input
+                ref={inputRef}
+                value={query}
+                onValueChange={setQuery}
+                placeholder="Search champions, players, or pages"
+                aria-label="Global search input"
+                className="h-11 min-w-0 flex-1 bg-transparent px-1 text-base text-fg outline-none placeholder:text-muted"
+              />
+              <Select
+                value={region}
+                onValueChange={setRegion}
+                options={[...LOL_REGION_OPTIONS]}
+                ariaLabel="Summoner region"
+                className="h-10 w-[106px] shrink-0"
+              />
+            </div>
 
-                <Command.List className="max-h-[min(68vh,640px)] overflow-y-auto px-3 pb-4 pt-4 sm:px-4 sm:pb-5">
-                  {showEmpty ? (
-                    <motion.div
-                      initial={{ opacity: 0, y: prefersReducedMotion ? 0 : 10 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.18, ease: PANEL_ENTRY_EASE }}
-                    >
-                      <Command.Empty className="surface-subtle rounded-card px-4 py-8 text-left">
-                        <p className="type-kicker text-primary/88">No Match Yet</p>
-                        <p className="mt-3 text-base text-fg/88">
-                          Nothing lines up with that search.
-                        </p>
-                        <p className="mt-2 max-w-[48ch] text-sm leading-6 text-fg/62">
-                          Try a champion name, a route like tier list or pro solo queue, or a full Riot ID like
-                          <span className="font-medium text-fg/82"> Kronic#NA1</span>.
-                        </p>
-                      </Command.Empty>
-                    </motion.div>
-                  ) : (
-                    <motion.div
-                      variants={resultsContainerVariants}
-                      initial="hidden"
-                      animate="visible"
-                      exit="exit"
-                      className="grid gap-3 md:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)]"
-                    >
-                      <motion.div variants={sectionVariants}>
-                        <SearchSection
-                          title="Summoners"
-                          countLabel={summonerLoading ? "Searching" : `${summonerResults.length}`}
-                          className="md:row-span-2"
-                        >
-                          {summonerResults.map((item) => {
-                            const path = `/lol/summoners/${item.region}/${encodeRiotIdPath({
-                              gameName: item.gameName,
-                              tagLine: item.tagLine
-                            })}`;
+            <Command.List className="max-h-[min(66vh,560px)] overflow-y-auto py-1">
+              {!hasResults ? (
+                <Command.Empty className="px-5 py-10 text-center text-sm text-muted">
+                  No results. Try a champion, page, or Riot ID.
+                </Command.Empty>
+              ) : parsedRiotId ? (
+                <>
+                  {renderPlayerGroup()}
+                  {renderChampionGroup()}
+                  {renderNavigationGroup()}
+                </>
+              ) : championFirst ? (
+                <>
+                  {renderChampionGroup()}
+                  {renderPlayerGroup()}
+                  {renderNavigationGroup()}
+                </>
+              ) : (
+                <>
+                  {renderNavigationGroup()}
+                  {renderPlayerGroup()}
+                  {renderChampionGroup()}
+                </>
+              )}
+            </Command.List>
 
-                            return (
-                              <Command.Item
-                                key={`summoner-${item.platformRegion}-${item.gameName}-${item.tagLine}`}
-                                value={`summoner-${item.gameName}-${item.tagLine}-${item.platformRegion}`}
-                                onSelect={() => navigate(path)}
-                                className={RESULT_ITEM_CLASS}
-                              >
-                                {ddragonVersion ? (
-                                  <Image
-                                    src={profileIconSrc(ddragonVersion, item.profileIconId)}
-                                    alt=""
-                                    width={36}
-                                    height={36}
-                                    className="h-9 w-9 rounded-lg border border-border/55 object-cover"
-                                    sizes="36px"
-                                  />
-                                ) : (
-                                  <span className="type-caption inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border/55 bg-surface/60 text-muted">
-                                    ?
-                                  </span>
-                                )}
-                                <div className="min-w-0 flex-1">
-                                  <p className="type-ui truncate font-medium text-fg">
-                                    {item.gameName}
-                                    <span className="text-fg/58">#{item.tagLine}</span>
-                                  </p>
-                                  <p className="type-caption truncate text-fg/65">
-                                    Live profile lookup
-                                  </p>
-                                </div>
-                                <span className="type-kicker surface-chip rounded-full px-2 py-1 text-fg/68">
-                                  {item.platformRegion}
-                                </span>
-                              </Command.Item>
-                            );
-                          })}
-
-                          {summonerLoading ? (
-                            <SearchHint tone="accent">Searching live summoner suggestions for {regionLabel}.</SearchHint>
-                          ) : null}
-
-                          {!summonerLoading &&
-                          summonerResults.length === 0 &&
-                          parsedRiotId ? (
-                            <Command.Item
-                              key="summoner-open"
-                              value={`summoner-${parsedRiotId.gameName}-${parsedRiotId.tagLine}-${region}`}
-                              onSelect={() => navigate(directOpenPath!)}
-                              className={RESULT_ITEM_CLASS}
-                            >
-                              <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-primary/25 bg-primary/10 text-primary">
-                                <ArrowCornerIcon className="h-4 w-4" />
-                              </span>
-                              <div className="min-w-0 flex-1">
-                                <p className="type-ui truncate font-medium text-fg">
-                                  Open {parsedRiotId.gameName}#{parsedRiotId.tagLine}
-                                </p>
-                                <p className="type-caption text-fg/65">{regionLabel} direct profile route</p>
-                              </div>
-                            </Command.Item>
-                          ) : null}
-
-                          {!summonerLoading &&
-                          summonerResults.length === 0 &&
-                          !parsedRiotId &&
-                          query.trim().length > 0 ? (
-                            <SearchHint>
-                              No summoner suggestions yet. Enter a full Riot ID in the format
-                              <span className="font-medium text-fg/82"> GameName#TAG</span> to open the profile directly.
-                            </SearchHint>
-                          ) : null}
-
-                          {!summonerLoading &&
-                          summonerResults.length === 0 &&
-                          query.trim().length === 0 ? (
-                            <SearchHint>
-                              Start with a Riot ID, like <span className="font-medium text-fg/82">Kronic#NA1</span>, for a direct player jump.
-                            </SearchHint>
-                          ) : null}
-                        </SearchSection>
-                      </motion.div>
-
-                      <motion.div variants={sectionVariants}>
-                        <SearchSection
-                          title="Champions"
-                          countLabel={`${championResults.length}`}
-                        >
-                          {championResults.length > 0 ? (
-                            championResults.map((champion) => {
-                              const championHref = `/lol/champions/${champion.championId}`;
-                              return (
-                                <Command.Item
-                                  key={`champion-${champion.championId}`}
-                                  value={`champion-${champion.name}`}
-                                  onSelect={() => navigate(championHref)}
-                                  onMouseEnter={() => router.prefetch(championHref)}
-                                  onFocus={() => router.prefetch(championHref)}
-                                  className={RESULT_ITEM_CLASS}
-                                >
-                                  {ddragonVersion && champion.slug ? (
-                                    <Image
-                                      src={championIconUrl(ddragonVersion, champion.slug)}
-                                      alt=""
-                                      width={36}
-                                      height={36}
-                                      className="h-9 w-9 shrink-0 rounded-lg border border-border/50"
-                                    />
-                                  ) : (
-                                    <span className="surface-subtle inline-flex h-9 w-9 items-center justify-center rounded-lg text-primary/88">
-                                      <SparkIcon className="h-4 w-4" />
-                                    </span>
-                                  )}
-                                  <div className="min-w-0 flex-1">
-                                    <p className="type-ui truncate font-medium text-fg">{champion.name}</p>
-                                    <p className="type-caption text-fg/65">Champion profile and matchup data</p>
-                                  </div>
-                                </Command.Item>
-                              );
-                            })
-                          ) : (
-                            <SearchHint>No champions match that query.</SearchHint>
-                          )}
-                        </SearchSection>
-                      </motion.div>
-
-                      <motion.div variants={sectionVariants}>
-                        <SearchSection
-                          title="Pages"
-                          countLabel={`${tierResults.length}`}
-                        >
-                          {tierResults.length > 0 ? (
-                            tierResults.map((item) => {
-                              const parts = splitQuickLinkLabel(item.label);
-                              return (
-                                <Command.Item
-                                  key={item.href}
-                                  value={`tier-${item.label}`}
-                                  onSelect={() => navigate(item.href)}
-                                  className={RESULT_ITEM_CLASS}
-                                >
-                                  <span className="surface-subtle inline-flex h-9 w-9 items-center justify-center rounded-lg text-primary/84">
-                                    <ArrowCornerIcon className="h-4 w-4" />
-                                  </span>
-                                  <div className="min-w-0 flex-1">
-                                    <p className="type-ui truncate font-medium text-fg">{parts.title}</p>
-                                    <p className="type-caption truncate text-fg/65">
-                                      {parts.detail ?? "Open page"}
-                                    </p>
-                                  </div>
-                                </Command.Item>
-                              );
-                            })
-                          ) : (
-                            <SearchHint>No pages match that search.</SearchHint>
-                          )}
-                        </SearchSection>
-                      </motion.div>
-                    </motion.div>
-                  )}
-                </Command.List>
-              </Command>
-            </motion.div>
-            </Dialog.Content>
-          </div>
-        </div>
-      ) : null}
-        </AnimatePresence>
+            <div className="flex items-center justify-between border-t border-border/50 px-4 py-2 text-xs text-muted">
+              <span>↑↓ Select</span>
+              <span>Enter Open · Esc Close</span>
+            </div>
+          </Command>
+        </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
   );

--- a/apps/web/components/LeaderboardFilters.test.tsx
+++ b/apps/web/components/LeaderboardFilters.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { LeaderboardFilters } from "./LeaderboardFilters";
+
+const router = vi.hoisted(() => ({
+  replace: vi.fn()
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/lol/leaderboards",
+  useRouter: () => router
+}));
+
+vi.mock("@/components/ui/Select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    ariaLabel
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    ariaLabel: string;
+  }) => (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={() => onValueChange(ariaLabel === "Champion leaderboard filter" ? "145" : "MIDDLE")}
+    >
+      {value}
+    </button>
+  )
+}));
+
+describe("LeaderboardFilters", () => {
+  it("keeps the selected champion when a role is chosen before navigation settles", async () => {
+    const user = userEvent.setup();
+    router.replace.mockReset();
+    render(
+      <LeaderboardFilters
+        filters={{ region: "na", queue: "solo", championId: null, role: null }}
+        champions={{
+          "145": { id: "Kaisa", name: "Kai'Sa", title: "the Daughter of the Void" }
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Champion leaderboard filter" }));
+    await user.click(await screen.findByRole("button", { name: "Champion role" }));
+
+    expect(router.replace).toHaveBeenLastCalledWith(
+      "/lol/leaderboards?region=na&queue=solo&championId=145&role=MIDDLE",
+      { scroll: false }
+    );
+  });
+});

--- a/apps/web/components/LeaderboardFilters.tsx
+++ b/apps/web/components/LeaderboardFilters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { useTransition } from "react";
+import { useEffect, useState, useTransition } from "react";
 
 import { Select } from "@/components/ui/Select";
 import type { ChampionMap } from "@/lib/staticData";
@@ -32,6 +32,12 @@ export function LeaderboardFilters({
   const router = useRouter();
   const pathname = usePathname();
   const [pending, startTransition] = useTransition();
+  const [localFilters, setLocalFilters] = useState(filters);
+
+  useEffect(() => {
+    setLocalFilters(filters);
+  }, [filters]);
+
   const championOptions = [
     { value: "ALL", label: "All champions" },
     ...Object.entries(champions)
@@ -40,49 +46,56 @@ export function LeaderboardFilters({
   ];
 
   function update(next: Filters) {
+    setLocalFilters(next);
     startTransition(() => {
-      router.push(`${pathname}?${leaderboardSearchParams(next).toString()}`, { scroll: false });
+      router.replace(`${pathname}?${leaderboardSearchParams(next).toString()}`, { scroll: false });
     });
   }
 
   return (
-    <div aria-busy={pending} className="flex w-full flex-wrap gap-2 opacity-100 transition-opacity aria-busy:opacity-65">
+    <div
+      aria-busy={pending}
+      className="flex w-full flex-wrap items-center gap-2 opacity-100 transition-opacity aria-busy:opacity-65"
+    >
       <Select
-        value={filters.region}
-        onValueChange={(region) => update({ ...filters, region })}
+        value={localFilters.region}
+        onValueChange={(region) => update({ ...localFilters, region })}
         options={[...LOL_REGION_OPTIONS]}
         ariaLabel="Leaderboard region"
         className="min-w-24"
       />
       <Select
-        value={filters.queue}
-        onValueChange={(queue) => update({ ...filters, queue: queue as Filters["queue"] })}
+        value={localFilters.queue}
+        onValueChange={(queue) => update({ ...localFilters, queue: queue as Filters["queue"] })}
         options={QUEUE_OPTIONS}
         ariaLabel="Ranked queue"
         className="min-w-40"
       />
       <Select
-        value={filters.championId ? String(filters.championId) : "ALL"}
+        value={localFilters.championId ? String(localFilters.championId) : "ALL"}
         onValueChange={(championId) =>
           update({
-            ...filters,
+            ...localFilters,
             championId: championId === "ALL" ? null : Number(championId),
-            role: championId === "ALL" ? null : filters.role
+            role: championId === "ALL" ? null : localFilters.role
           })
         }
         options={championOptions}
         ariaLabel="Champion leaderboard filter"
         className="min-w-44"
       />
-      {filters.championId ? (
+      {localFilters.championId ? (
         <Select
-          value={filters.role ?? "ALL"}
-          onValueChange={(role) => update({ ...filters, role: role === "ALL" ? null : role })}
+          value={localFilters.role ?? "ALL"}
+          onValueChange={(role) => update({ ...localFilters, role: role === "ALL" ? null : role })}
           options={ROLE_OPTIONS}
           ariaLabel="Champion role"
           className="min-w-32"
         />
       ) : null}
+      <span className="sr-only" aria-live="polite">
+        {pending ? "Updating leaderboard" : ""}
+      </span>
     </div>
   );
 }

--- a/apps/web/components/MultiSearchClient.tsx
+++ b/apps/web/components/MultiSearchClient.tsx
@@ -101,11 +101,10 @@ export function MultiSearchClient() {
     <div className="grid gap-6">
       <header className="page-hero grid gap-5 p-5 md:grid-cols-[minmax(0,1fr)_minmax(320px,0.8fr)] md:p-7">
         <div className="max-w-2xl">
-          <p className="type-kicker text-primary">Champ select scout</p>
-          <h1 className="mt-3 type-page-title">Read the lobby before the game starts.</h1>
+          <p className="type-kicker text-primary">Multi-search</p>
+          <h1 className="mt-3 type-page-title">Compare your lobby.</h1>
           <p className="mt-3 max-w-[62ch] text-fg/72">
-            Paste up to five Riot IDs. Transcendence compares rank, main role, tracked form,
-            champion pool, and possible autofill pressure from stored match data.
+            Paste up to five Riot IDs to compare rank, main role, recent form, and champion pool.
           </p>
         </div>
         <div className="surface-subtle self-end rounded-card px-4 py-3">
@@ -177,8 +176,7 @@ export function MultiSearchClient() {
         <div className="rounded-card border border-dashed border-border px-6 py-10 text-center">
           <p className="type-section">Lobby comparison appears here</p>
           <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-muted">
-            Results use players already stored in Transcendence. Missing players are clearly marked,
-            so an incomplete sample never looks like a confident team read.
+            Results use stored profiles. Missing players are marked.
           </p>
         </div>
       )}

--- a/apps/web/components/ProScopeToggle.tsx
+++ b/apps/web/components/ProScopeToggle.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+export function ProScopeToggle({
+  checked,
+  href
+}: {
+  checked: boolean;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      role="switch"
+      aria-checked={checked}
+      className="type-ui inline-flex min-h-11 items-center gap-2.5 rounded-control px-1.5 py-1.5 text-fg/78 transition hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35"
+    >
+      <span
+        aria-hidden="true"
+        className="relative h-6 w-10 rounded-full border border-border/70 bg-surface-2 transition data-[checked=true]:border-primary/50 data-[checked=true]:bg-primary/18"
+        data-checked={checked}
+      >
+        <span
+          className="absolute left-0.5 top-0.5 size-[18px] rounded-full bg-fg/55 transition-transform duration-150 ease-[cubic-bezier(0.25,1,0.5,1)] data-[checked=true]:translate-x-4 data-[checked=true]:bg-primary"
+          data-checked={checked}
+        />
+      </span>
+      <span>Include high-elo one-tricks</span>
+    </Link>
+  );
+}

--- a/apps/web/components/SiteHeaderClient.tsx
+++ b/apps/web/components/SiteHeaderClient.tsx
@@ -17,7 +17,6 @@ const NAV_LINKS: NavLink[] = [
   { href: "/lol/leaderboards", label: "Leaderboards", mobileLabel: "Ranks" },
   { href: "/lol/champions", label: "Champions" },
   { href: "/lol/items", label: "Build Atlas", mobileLabel: "Items" },
-  { href: "/lol/multi-search", label: "Multi-Search", mobileLabel: "Scout" },
   { href: "/lol/live", label: "Live Game", mobileLabel: "Live" },
   { href: "/lol/pro-builds", label: "Pro Solo Q", mobileLabel: "Pro" }
 ];

--- a/apps/web/lib/adminTypes.ts
+++ b/apps/web/lib/adminTypes.ts
@@ -240,6 +240,28 @@ export type ProSummoner = {
   isPro: boolean;
   isHighEloOtp: boolean;
   isActive: boolean;
+  source: string;
+  sourceExternalId: string | null;
+  lastVerifiedAtUtc: string | null;
+  otpChampionId: number | null;
+  otpGames: number | null;
+  otpSampleSize: number | null;
+  otpEvaluatedAtUtc: string | null;
   createdAtUtc: string;
   updatedAtUtc: string;
+};
+
+export type ProPlayerDiscoveryCandidate = {
+  id: string;
+  source: string;
+  externalId: string;
+  proName: string;
+  teamName: string | null;
+  role: string | null;
+  soloQueueIds: string | null;
+  status: string;
+  approvedTrackedProSummonerId: string | null;
+  firstSeenAtUtc: string;
+  lastSeenAtUtc: string;
+  reviewedAtUtc: string | null;
 };

--- a/apps/web/lib/proBuilds.test.ts
+++ b/apps/web/lib/proBuilds.test.ts
@@ -37,9 +37,9 @@ describe("normalizeProBuildScope", () => {
     expect(normalizeProBuildScope(" highelo ")).toBe("highelo");
   });
 
-  it("falls back to all for invalid or missing values", () => {
-    expect(normalizeProBuildScope(undefined)).toBe("all");
-    expect(normalizeProBuildScope("pros")).toBe("all");
+  it("falls back to pro for invalid or missing values", () => {
+    expect(normalizeProBuildScope(undefined)).toBe("pro");
+    expect(normalizeProBuildScope("pros")).toBe("pro");
   });
 });
 
@@ -58,11 +58,11 @@ describe("buildProBuildFilterParams", () => {
     const params = buildProBuildFilterParams({
       role: "MIDDLE",
       region: "KR",
-      scope: "pro",
+      scope: "all",
       patch: "14.5"
     });
 
-    expect(params.toString()).toBe("role=MIDDLE&region=KR&scope=pro&patch=14.5");
+    expect(params.toString()).toBe("role=MIDDLE&region=KR&scope=all&patch=14.5");
   });
 });
 

--- a/apps/web/lib/proBuilds.ts
+++ b/apps/web/lib/proBuilds.ts
@@ -20,9 +20,9 @@ export function normalizeProBuildRole(role: string | undefined | null): ProBuild
 }
 
 export function normalizeProBuildScope(scope: string | undefined | null): ProBuildScope {
-  if (!scope) return "all";
+  if (!scope) return "pro";
   const normalized = scope.trim().toLowerCase();
-  return PRO_BUILD_SCOPES.includes(normalized as ProBuildScope) ? (normalized as ProBuildScope) : "all";
+  return PRO_BUILD_SCOPES.includes(normalized as ProBuildScope) ? (normalized as ProBuildScope) : "pro";
 }
 
 export function normalizeProBuildPatch(patch: string | undefined | null): string | null {
@@ -45,7 +45,7 @@ export function buildProBuildFilterParams({
   const params = new URLSearchParams();
   if (role !== "ALL") params.set("role", role);
   if (region !== "ALL") params.set("region", region);
-  if (scope && scope !== "all") params.set("scope", scope);
+  if (scope && scope !== "pro") params.set("scope", scope);
   if (patch) params.set("patch", patch);
   return params;
 }

--- a/apps/web/lib/searchNormalization.test.ts
+++ b/apps/web/lib/searchNormalization.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSearchText, searchMatchScore } from "@/lib/searchNormalization";
+
+describe("normalizeSearchText", () => {
+  it.each([
+    ["Kai'Sa", "kaisa"],
+    ["Dr. Mundo", "drmundo"],
+    ["Kha'Zix", "khazix"],
+    ["Kog'Maw", "kogmaw"],
+    ["Rek'Sai", "reksai"],
+    ["Bel'Veth", "belveth"]
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(normalizeSearchText(input)).toBe(expected);
+  });
+});
+
+describe("searchMatchScore", () => {
+  it("ranks exact normalized matches ahead of prefixes and substrings", () => {
+    expect(searchMatchScore("Kai'Sa", "kaisa")).toBe(0);
+    expect(searchMatchScore("Kassadin", "kas")).toBe(1);
+    expect(searchMatchScore("Dr. Mundo", "mundo")).toBe(2);
+    expect(searchMatchScore("Miss Fortune", "fortune")).toBe(2);
+    expect(searchMatchScore("Twisted Fate", "sted")).toBe(3);
+    expect(searchMatchScore("Ahri", "jinx")).toBeNull();
+  });
+});

--- a/apps/web/lib/searchNormalization.ts
+++ b/apps/web/lib/searchNormalization.ts
@@ -1,0 +1,25 @@
+export function normalizeSearchText(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, "");
+}
+
+export function searchMatchScore(candidate: string, query: string): number | null {
+  const normalizedCandidate = normalizeSearchText(candidate);
+  const normalizedQuery = normalizeSearchText(query);
+  if (!normalizedQuery) return 4;
+  if (normalizedCandidate === normalizedQuery) return 0;
+  if (normalizedCandidate.startsWith(normalizedQuery)) return 1;
+
+  const tokenMatch = candidate
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLocaleLowerCase()
+    .split(/[^\p{L}\p{N}]+/u)
+    .some((token) => token.startsWith(normalizedQuery));
+  if (tokenMatch) return 2;
+  if (normalizedCandidate.includes(normalizedQuery)) return 3;
+  return null;
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -186,6 +186,7 @@ Returns a public ranked leaderboard for one platform region. Query parameters:
 - `minimumChampionGames`: `1` to `100` (default `5`)
 
 Regional boards are ordered by tier, league points, wins, and losses. Champion boards are ordered by champion-game sample, ranked tier, league points, and champion win rate. Responses include the resolved platform region and queue, generation time, profile identity, current rank and record, plus champion games, wins, win rate, and KDA when champion filters are active.
+Champion-board region filtering uses the match's recorded platform region, so an account transfer does not move historical games between regional boards.
 
 Early-patch semantics:
 - Analytics endpoints default to the active patch and support a `patch` query parameter for stored historical patches.
@@ -302,7 +303,7 @@ Additional analytics fields:
 `GET /api/lol/analytics/champions/{championId}/pro-builds` supports optional filters:
 - `region` (`ALL` or supported platform-region token such as `NA1|EUW1|EUN1|KR`)
 - `role` — when omitted (or `ALL`), the champion's **most-played lane** is resolved from the cached win-rate aggregate (mirrors the profile endpoint) and echoed back as `role`, so the landing view is lane-scoped instead of the heavier cross-role aggregate. Any other unrecognized role is rejected with `400`.
-- `scope`: `pro` (official pros, `IsPro`), `highelo` (auto-discovered Challenger/GM/Master one-tricks, `IsHighEloOtp`), or `all` (either). Defaults to `all`.
+- `scope`: `pro` (reviewed professional accounts, `IsPro`), `highelo` (verified Master+ one-tricks, `IsHighEloOtp`), or `all` (either). Defaults to `pro`.
 - `patch`
 
 The cross-role aggregate (no resolvable lane) bounds its participant scan to the most-recent `Analytics:Compute:ProBuildMaxParticipantRows` rows (default 1500) so the wide `role=ALL` + `scope=all` + `region=ALL` pool cannot command-timeout.
@@ -315,7 +316,7 @@ Response includes:
 
 `GET /api/lol/analytics/pro/champions` (public) returns champions ranked by pick/play frequency among tracked pro / high-elo players (the "Pro Solo Queue Builds" home ranking). These are ranked solo-queue observations, not tournament drafts, esports schedules, or official match results. Optional filters:
 - `region` (`ALL` or supported platform-region token such as `NA1|EUW1|EUN1|KR`)
-- `scope`: `pro` (official pros, `IsPro`), `highelo` (auto-discovered Challenger/GM/Master one-tricks, `IsHighEloOtp`), or `all` (either). Defaults to `all`.
+- `scope`: `pro` (reviewed professional accounts, `IsPro`), `highelo` (verified Master+ one-tricks, `IsHighEloOtp`), or `all` (either). Defaults to `pro`.
 - `patch`
 
 Response: `{ patch, region, scope, champions[], sample }` where each champion entry is `{ championId, games, wins, winRate, uniquePlayers }`, ordered by games descending. Cached 24h (`analytics` + `proplayrate` tags).
@@ -460,6 +461,14 @@ Auth behavior notes:
 - `PUT /api/admin/pro-summoners/{id}`
 - `DELETE /api/admin/pro-summoners/{id}`
 - `POST /api/admin/pro-summoners/{id}/refresh`
+- `GET /api/admin/pro-summoners/candidates?status=pending|approved|rejected`
+- `POST /api/admin/pro-summoners/candidates/{id}/approve`
+- `POST /api/admin/pro-summoners/candidates/{id}/reject`
+
+The candidate endpoints expose staged Leaguepedia directory rows. Approval requires a confirmed
+Riot game name, tag line, and platform region (plus optional PUUID), creates the durable tracked
+professional account, and records the source identity. Candidate rows never appear in public
+pro-build analytics before approval.
 
 ### User Preferences (`UserOnly`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,7 @@ Transcendence is a backend + web monorepo:
 - Frontend analysis routes:
   - `/lol/tierlist`
   - `/lol/champions/*` is the unified champion surface: win rates, builds (with the full rune tree), confidence-ranked same-team partner synergy, inline matchups summary, a sortable "All Matchups" table (`?sort=winRate|games`, anchored at `#matchups`), and a quick link to pro builds. The page reads `/api/lol/analytics/champions/{championId}/profile` so the role selection, cached build, synergy, and matchup aggregates arrive through one backend request instead of a client-side analytics waterfall. The standalone `/lol/matchups` surface was removed; `/lol/matchups` and `/lol/matchups/:championId` now 308-redirect into `/lol/champions/*` (preserving query state) via `next.config.mjs` `redirects()`.
-  - `/lol/pro-builds/*`: the **Pro Solo Queue Builds** surface is explicitly scoped to ranked solo-queue observations from tracked pros/high-elo specialists; it is not an esports schedule, tournament draft, or official-results feed. The index hero is a champion playrate ranking with a `scope` segmented control (Pro / High-Elo / All) plus a public "Tracked Pros" roster panel. The toolbar, playrate table, roster, and champion search render from the first fetch batch; the fan-out recent-match feed and its item map stream independently behind `<Suspense>` with a stable row skeleton.
+  - `/lol/pro-builds/*`: the **Pro Solo Queue Builds** surface is explicitly scoped to ranked solo-queue observations from tracked pros and verified high-elo one-tricks; it is not an esports schedule, tournament draft, or official-results feed. The default scope is reviewed pros only, with one switch to include one-tricks, plus a public "Tracked Pros" roster panel. The toolbar, playrate table, roster, and champion search render from the first fetch batch; the fan-out recent-match feed and its item map stream independently behind `<Suspense>` with a stable row skeleton.
   - `/lol/items/*` and `/lol/runes/*` are the Build Atlas: searchable index and detail pages for
     resource pick rate, win rate, sample size, and champion-role fit. The indexes, detail pages,
     header, command palette, landing discovery, and sitemap all expose the new surfaces.
@@ -422,16 +422,26 @@ detail is archived off-box and pruned to keep the database from growing unbounde
 
 ### Pro Roster and Solo-Queue Builds
 
-- Tracked pro/high-ELO roster entries are stored in `TrackedProSummoners` with optional pro/team metadata.
-- The same roster table is also used as a high-value analytics seed source. Automated high-elo refresh writes active roster rows with `IsPro=false`; pro-build analytics can select `pro`, `highelo`, or `all` roster scope.
-- Admin API (`/api/admin/pro-summoners`) allows manual curation and updates.
+- Tracked pro/high-ELO roster entries are stored in `TrackedProSummoners` with optional pro/team
+  metadata, source provenance, verification time, and one-trick evidence.
+- `pro-roster-discovery` reads Leaguepedia's structured player directory daily and upserts
+  `ProPlayerDiscoveryCandidates`. Because community-maintained solo-queue IDs can be incomplete or
+  stale, candidates remain private until an admin confirms the current Riot ID and platform. Approval
+  records the source external ID on the durable PUUID-backed roster row.
+- `high-elo-profile-refresh` still uses Riot's current Master/Grandmaster/Challenger leagues as the
+  discovery pool, but only sets `IsHighEloOtp` when the account has a complete latest-50 Ranked
+  Solo/Duo sample with at least 30 games on one champion. The job stores champion, sample, and
+  evaluation evidence and retires legacy auto-created rows that lack that evidence.
+- The same roster table is also used as a high-value analytics seed source. Pro-build analytics can
+  select `pro`, `highelo`, or `all`; missing/invalid scope defaults to `pro`.
+- Admin API (`/api/admin/pro-summoners`) allows manual curation, candidate approval/rejection, and updates.
 - Champion pro-build analytics joins tracked roster participants against ranked solo/duo match data using the selected roster scope for:
   - recent tracked ranked solo-queue matches
   - top players
   - common builds
 - When `role` is omitted the endpoint resolves the champion's most-played lane from the cached win-rate aggregate (mirrors the `/profile` endpoint) and computes lane-scoped pro builds, so the default `/lol/pro-builds/{championId}` landing view is a single lane rather than the heavy cross-role aggregate. The cross-role path (no resolvable lane) bounds its participant scan to the most-recent `Analytics:Compute:ProBuildMaxParticipantRows` rows (default 1500): without a `TeamPosition` filter, `role=ALL` + `scope=all` + `region=ALL` over a multi-thousand-PUUID roster otherwise materializes the heavy item/rune projection unbounded and command-timeouts.
 - Cross-champion pro analytics live on a dedicated `ProAnalyticsController` (`/api/lol/analytics/pro/*`, separate from the `{championId}` champion routes to avoid route ambiguity):
-  - `GET /pro/champions` ranks champions by tracked-player pick frequency. A `scope` parameter selects the roster predicate — `pro` (`IsPro`), `highelo` (`IsHighEloOtp`), or `all` (`IsPro || IsHighEloOtp`, the default) — so the surface stays populated from the continuously-ingested high-elo roster even when the manually-curated `IsPro` set is sparse. Aggregation mirrors the pro-build compute: materialize `{ ChampionId, Win, Puuid }` scalar rows (ranked solo/duo, patch, region→platform), then group in memory (games / wins / win rate / distinct players). Cached 24h (`proplayrate` tag).
+  - `GET /pro/champions` ranks champions by tracked-player pick frequency. A `scope` parameter selects the roster predicate — `pro` (`IsPro`, the default), `highelo` (`IsHighEloOtp`), or `all` (`IsPro || IsHighEloOtp`). Aggregation mirrors the pro-build compute: materialize `{ ChampionId, Win, Puuid }` scalar rows (ranked solo/duo, patch, region→platform), then group in memory (games / wins / win rate / distinct players). Cached 24h (`proplayrate` tag).
   - `GET /pro/players` exposes a public, slimmed projection of the `IsActive && IsPro` roster (no internal identifiers) for the Tracked Pros panel. Cached 24h (`proroster` tag).
   - Both tags compose under the shared `analytics` cache tag, so the existing analytics cache invalidation clears them.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -337,12 +337,14 @@ Note:
 
 ## OpenAPI + TypeScript Client
 
-Source of truth: `openapi/transcendence.v1.json` (committed). The generated client schema is rebuilt locally from that spec and is not committed.
+Source of truth: `openapi/transcendence.v1.json` (committed). The generated client schema is rebuilt from that spec and committed with API changes.
 
 ```bash
 pnpm api:gen
 pnpm api:check
 ```
+
+The exporter starts the WebAPI with the internal `OpenApi:ExportOnly=true` flag, which skips database-backed admin bootstrap work. It also clears the previous contract before downloading Swagger so a startup failure cannot pass by reusing stale output.
 
 If hooks are installed (`pnpm hooks:install`), pre-commit runs path-aware checks automatically before each commit:
 - `pnpm precommit:api-sync` runs only when staged files touch API-relevant paths (`Transcendence.WebAPI/`, `Transcendence.Service.Core/`, `Transcendence.Data/`, `scripts/openapi/export.sh`, committed OpenAPI spec), regenerates the client locally, and stages the refreshed spec.
@@ -354,8 +356,11 @@ Key worker settings live under `Jobs:*` in `Transcendence.Service/appsettings.js
 The public Web API also consumes `Jobs:MultiRegionIngestion` from `Transcendence.WebAPI/appsettings.json` so `/api/analytics/regions` and region-filter normalization stay aligned with the ingestion regions exposed to the frontend.
 
 Production defaults in `Transcendence.Service/appsettings.json` are coverage-first for LoL:
-- `stable` keeps adaptive refresh (self-paced, ramp-aware), champion analytics ingestion, summoner maintenance, high-elo profile refresh, and low-frequency timeline backfill enabled.
-- `high-elo-profile-refresh` keeps the tracked high-value roster populated for analytics ingestion.
+- `stable` keeps adaptive refresh (self-paced, ramp-aware), champion analytics ingestion, summoner maintenance, high-elo profile refresh, pro-roster discovery, and low-frequency timeline backfill enabled.
+- `high-elo-profile-refresh` refreshes Master+ accounts and admits only evidence-backed one-tricks (30 or more games on one champion in the latest 50 stored Ranked Solo/Duo games).
+- `pro-roster-discovery` stages Leaguepedia player-directory rows for admin review; source outages are non-fatal and retain the last good candidate set.
+- `Jobs:Schedule:EnableProRosterDiscovery` defaults to `true`; `Jobs:Schedule:ProRosterDiscoveryCron` defaults to `15 3 * * *`.
+- `Jobs:ProRosterDiscovery:Endpoint`, `PageSize`, `MaxPages`, and `PageDelaySeconds` control the external directory read. Pages are paced at 65 seconds by default to respect the source's anonymous Cargo rate limit, and successfully read pages are retained if a later page is throttled. Candidates must still be approved under `/admin/pro-summoners` before they enter public analytics.
 - `match-timeline-backfill` is intentionally slower than ingestion because tier lists and core champion stats do not require timeline rows.
 - `Jobs:Schedule:PurgeBacklogOnPatchRolloverOnStartup` is disabled and startup rollover logic preserves queued current-patch catch-up work.
 
@@ -368,7 +373,7 @@ Which recurring jobs are active is determined by:
 - the per-job `Enable*` flags under `Jobs:Schedule` (for example `EnableChampionAnalyticsIngestion`, `EnableMatchTimelineBackfill`), and
 - the resolved **scheduling profile** (`Jobs:Schedule:Profile`, falling back to `DefaultProfile`, default `stable`), whose `Jobs:SchedulingProfiles:Profiles:<name>:JobOverrides` can flip a job's `Enabled`/`Cron`/`MandatoryBaseline`. Profile overrides win over the descriptor defaults. `poll-live-games` is enabled in `stable`, bounded by `Jobs:LiveGamePolling`, and defaults to opted-in favorite summoners only.
 
-The base `appsettings.json` ships `Jobs:Schedule:Profile = "stable"` (there is no `appsettings.Development.json`), so a local worker resolves the **same `stable` profile as production** unless you override `Jobs:Schedule:Profile` (or individual `Enable*` / `JobOverrides` values) via user-secrets or environment variables. Under `stable` the enabled jobs are the LoL analytics-coverage set (adaptive analytics refresh, champion-analytics ingestion, summoner maintenance, each a single self-pacing job that tightens cadence during the new-patch ramp window, plus match-timeline backfill, live-game polling for opted-in favorites, and high-elo profile refresh), plus the baseline jobs (`detect-patch`, `retry-failed-matches`, `refresh-lock-lifecycle-cleanup`); `rune-selection-integrity-backfill` and the daily `refresh-champion-analytics` are disabled.
+The base `appsettings.json` ships `Jobs:Schedule:Profile = "stable"` (there is no `appsettings.Development.json`), so a local worker resolves the **same `stable` profile as production** unless you override `Jobs:Schedule:Profile` (or individual `Enable*` / `JobOverrides` values) via user-secrets or environment variables. Under `stable` the enabled jobs are the LoL analytics-coverage set (adaptive analytics refresh, champion-analytics ingestion, summoner maintenance, each a single self-pacing job that tightens cadence during the new-patch ramp window, plus match-timeline backfill, live-game polling for opted-in favorites, high-elo profile refresh, and pro-roster discovery), plus the baseline jobs (`detect-patch`, `retry-failed-matches`, `refresh-lock-lifecycle-cleanup`); `rune-selection-integrity-backfill` and the daily `refresh-champion-analytics` are disabled.
 
 The worker watchdog requests graceful generic-host shutdown on a stale producer heartbeat, waiting
 `Worker:Watchdog:GracefulShutdownTimeout` (default `00:00:15`) before its hard-exit/container-restart

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -3633,6 +3633,195 @@
         ]
       }
     },
+    "/api/admin/pro-summoners/candidates": {
+      "get": {
+        "tags": [
+          "ProSummoners"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "pending"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProPlayerDiscoveryCandidateDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProPlayerDiscoveryCandidateDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProPlayerDiscoveryCandidateDto"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          { }
+        ]
+      }
+    },
+    "/api/admin/pro-summoners/candidates/{id}/approve": {
+      "post": {
+        "tags": [
+          "ProSummoners"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ApproveProPlayerCandidateRequest"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ApproveProPlayerCandidateRequest"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/ApproveProPlayerCandidateRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackedProSummonerDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackedProSummonerDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackedProSummonerDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          { }
+        ]
+      }
+    },
+    "/api/admin/pro-summoners/candidates/{id}/reject": {
+      "post": {
+        "tags": [
+          "ProSummoners"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          { }
+        ]
+      }
+    },
     "/api/admin/pro-summoners/{id}/refresh": {
       "post": {
         "tags": [
@@ -6309,6 +6498,33 @@
         },
         "additionalProperties": false
       },
+      "ApproveProPlayerCandidateRequest": {
+        "required": [
+          "gameName",
+          "platformRegion",
+          "tagLine"
+        ],
+        "type": "object",
+        "properties": {
+          "gameName": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "tagLine": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "platformRegion": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "puuid": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "AuthMeResponse": {
         "required": [
           "roles"
@@ -8926,6 +9142,67 @@
         },
         "additionalProperties": false
       },
+      "ProPlayerDiscoveryCandidateDto": {
+        "required": [
+          "externalId",
+          "firstSeenAtUtc",
+          "id",
+          "lastSeenAtUtc",
+          "proName",
+          "source",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "source": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "proName": {
+            "type": "string"
+          },
+          "teamName": {
+            "type": "string",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "nullable": true
+          },
+          "soloQueueIds": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          },
+          "approvedTrackedProSummonerId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "firstSeenAtUtc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastSeenAtUtc": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reviewedAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ProPlayerDto": {
         "required": [
           "platformRegion"
@@ -10434,6 +10711,7 @@
           "isPro",
           "platformRegion",
           "puuid",
+          "source",
           "updatedAtUtc"
         ],
         "type": "object",
@@ -10472,6 +10750,38 @@
           },
           "isActive": {
             "type": "boolean"
+          },
+          "source": {
+            "type": "string"
+          },
+          "sourceExternalId": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastVerifiedAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "otpChampionId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "otpGames": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "otpSampleSize": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "otpEvaluatedAtUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           },
           "createdAtUtc": {
             "type": "string",

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -3082,6 +3082,185 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/pro-summoners/candidates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: {
+                    status?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["ProPlayerDiscoveryCandidateDto"][];
+                        "application/json": components["schemas"]["ProPlayerDiscoveryCandidateDto"][];
+                        "text/json": components["schemas"]["ProPlayerDiscoveryCandidateDto"][];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/pro-summoners/candidates/{id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["ApproveProPlayerCandidateRequest"];
+                    "text/json": components["schemas"]["ApproveProPlayerCandidateRequest"];
+                    "application/*+json": components["schemas"]["ApproveProPlayerCandidateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["TrackedProSummonerDto"];
+                        "application/json": components["schemas"]["TrackedProSummonerDto"];
+                        "text/json": components["schemas"]["TrackedProSummonerDto"];
+                    };
+                };
+                /** @description Bad Request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/pro-summoners/candidates/{id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/pro-summoners/{id}/refresh": {
         parameters: {
             query?: never;
@@ -4682,6 +4861,12 @@ export interface components {
             /** Format: date-time */
             lastUsedAt?: string | null;
         };
+        ApproveProPlayerCandidateRequest: {
+            gameName: string;
+            tagLine: string;
+            platformRegion: string;
+            puuid?: string | null;
+        };
         AuthMeResponse: {
             subject?: string | null;
             name?: string | null;
@@ -5414,6 +5599,25 @@ export interface components {
             spell2Id: number;
             skillOrder?: components["schemas"]["SkillOrderDto"] | null;
         };
+        ProPlayerDiscoveryCandidateDto: {
+            /** Format: uuid */
+            id: string;
+            source: string;
+            externalId: string;
+            proName: string;
+            teamName?: string | null;
+            role?: string | null;
+            soloQueueIds?: string | null;
+            status: string;
+            /** Format: uuid */
+            approvedTrackedProSummonerId?: string | null;
+            /** Format: date-time */
+            firstSeenAtUtc: string;
+            /** Format: date-time */
+            lastSeenAtUtc: string;
+            /** Format: date-time */
+            reviewedAtUtc?: string | null;
+        };
         ProPlayerDto: {
             proName?: string | null;
             teamName?: string | null;
@@ -5876,6 +6080,18 @@ export interface components {
             isPro: boolean;
             isHighEloOtp: boolean;
             isActive: boolean;
+            source: string;
+            sourceExternalId?: string | null;
+            /** Format: date-time */
+            lastVerifiedAtUtc?: string | null;
+            /** Format: int32 */
+            otpChampionId?: number | null;
+            /** Format: int32 */
+            otpGames?: number | null;
+            /** Format: int32 */
+            otpSampleSize?: number | null;
+            /** Format: date-time */
+            otpEvaluatedAtUtc?: string | null;
             /** Format: date-time */
             createdAtUtc: string;
             /** Format: date-time */

--- a/scripts/openapi/export.sh
+++ b/scripts/openapi/export.sh
@@ -50,11 +50,14 @@ APP_ARGS=(
   "--Swagger:Enable=$Swagger__Enable"
   # The export only boots the API to dump swagger against a throwaway connection — never migrate.
   "--Database:AutoMigrate=false"
+  "--OpenApi:ExportOnly=true"
 )
 
 SWAGGER_URL="${SWAGGER_URL:-http://127.0.0.1:5057/swagger/v1/swagger.json}"
 SWAGGER_OUT="$ROOT/openapi/transcendence.v1.json"
 TMP_ROOT="${TMPDIR:-/tmp}"
+# A failed export must never pass by reusing the previously committed contract.
+: > "$SWAGGER_OUT"
 
 if LOG_FILE="$(mktemp "${TMP_ROOT%/}/trn-openapi-XXXXXX.log" 2>/dev/null)"; then
   :
@@ -80,8 +83,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
+EXPORTED=false
 for _ in $(seq 1 60); do
   if curl --fail --silent --show-error "$SWAGGER_URL" -o "$SWAGGER_OUT"; then
+    EXPORTED=true
     break
   fi
 
@@ -94,7 +99,7 @@ for _ in $(seq 1 60); do
   sleep 1
 done
 
-if [[ ! -s "$SWAGGER_OUT" ]]; then
+if [[ "$EXPORTED" != true || ! -s "$SWAGGER_OUT" ]]; then
   echo "Failed to download swagger from $SWAGGER_URL."
   cat "$LOG_FILE"
   exit 1

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsComputeServiceTests.cs
@@ -15,6 +15,18 @@ namespace Transcendence.Service.Core.Tests;
 
 public class ChampionAnalyticsComputeServiceTests
 {
+    [Theory]
+    [InlineData(null, "pro")]
+    [InlineData("", "pro")]
+    [InlineData("unknown", "pro")]
+    [InlineData("PRO", "pro")]
+    [InlineData("all", "all")]
+    [InlineData(" highelo ", "highelo")]
+    public void NormalizeProScope_DefaultsToPros(string? input, string expected)
+    {
+        ChampionProComputeService.NormalizeProScope(input).Should().Be(expected);
+    }
+
     [Fact]
     public async Task ComputeTierListAsync_DoesNotPopulatePatchMovementFromPreviousPatchHotPath()
     {

--- a/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionAnalyticsServiceTests.cs
@@ -358,8 +358,8 @@ public class ChampionAnalyticsServiceTests
                 Patch = "15.1"
             });
         harness.ProService
-            .Setup(x => x.ComputeProBuildsFromStatsAsync(103, "ALL", "MIDDLE", "all", "15.1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ChampionProBuildsResponse(103, "15.1", "MIDDLE", "ALL", "all", [], [], []));
+            .Setup(x => x.ComputeProBuildsFromStatsAsync(103, "ALL", "MIDDLE", "pro", "15.1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChampionProBuildsResponse(103, "15.1", "MIDDLE", "ALL", "pro", [], [], []));
         await harness.Db.SaveChangesAsync();
 
         var resolvedRole = await harness.Service.RefreshDefaultProfileCacheAsync(
@@ -383,7 +383,7 @@ public class ChampionAnalyticsServiceTests
             x => x.ComputeMatchupsFromStatsAsync(103, "MIDDLE", "EMERALD_PLUS", "ALL", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
         harness.ProService.Verify(
-            x => x.ComputeProBuildsFromStatsAsync(103, "ALL", "MIDDLE", "all", "15.1", It.IsAny<CancellationToken>()),
+            x => x.ComputeProBuildsFromStatsAsync(103, "ALL", "MIDDLE", "pro", "15.1", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/tests/Transcendence.Service.Core.Tests/HighEloOtpQualificationTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/HighEloOtpQualificationTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using Transcendence.Service.Core.Services.Jobs;
+
+namespace Transcendence.Service.Core.Tests;
+
+public sealed class HighEloOtpQualificationTests
+{
+    [Fact]
+    public void RequiresAFiftyGameSample()
+    {
+        var result = AddOrUpdateHighEloProfiles.EvaluateOtp(Enumerable.Repeat(145, 49).ToList());
+
+        result.IsQualified.Should().BeFalse();
+        result.SampleSize.Should().Be(49);
+    }
+
+    [Theory]
+    [InlineData(29, false)]
+    [InlineData(30, true)]
+    [InlineData(40, true)]
+    public void RequiresThirtyGamesOnOneChampion(int championGames, bool expected)
+    {
+        var sample = Enumerable.Repeat(145, championGames)
+            .Concat(Enumerable.Range(1, 50 - championGames))
+            .ToList();
+
+        var result = AddOrUpdateHighEloProfiles.EvaluateOtp(sample);
+
+        result.IsQualified.Should().Be(expected);
+        result.ChampionId.Should().Be(145);
+        result.ChampionGames.Should().Be(championGames);
+        result.SampleSize.Should().Be(50);
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/ProRosterDiscoveryJobTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ProRosterDiscoveryJobTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Transcendence.Data;
+using Transcendence.Service.Core.Services.Jobs;
+using Transcendence.Service.Core.Services.Jobs.Configuration;
+using Transcendence.Service.Core.Tests.Support;
+
+namespace Transcendence.Service.Core.Tests;
+
+public sealed class ProRosterDiscoveryJobTests
+{
+    [Fact]
+    public void ParsesActionableLeaguepediaPlayers()
+    {
+        const string payload = """
+            {
+              "cargoquery": [
+                {
+                  "title": {
+                    "ID": "Faker",
+                    "OverviewPage": "Faker",
+                    "PlayerName": "Lee Sang-hyeok",
+                    "Team": "T1",
+                    "Role": "Mid",
+                    "SoloqueueIds": "Hide on bush#KR1"
+                  }
+                },
+                {
+                  "title": {
+                    "ID": "NoAccount",
+                    "OverviewPage": "NoAccount",
+                    "Team": "Example",
+                    "Role": "Top",
+                    "SoloqueueIds": ""
+                  }
+                }
+              ]
+            }
+            """;
+
+        var players = ProRosterDiscoveryJob.ParsePlayers(payload);
+
+        players.Should().ContainSingle();
+        players[0].Should().Be(new ProRosterDiscoveryJob.DiscoveredProPlayer(
+            "Faker",
+            "Faker",
+            "T1",
+            "Mid",
+            "Hide on bush#KR1"));
+    }
+
+    [Fact]
+    public void RejectsSourceErrorsEvenWhenTheHttpStatusWasSuccessful()
+    {
+        const string payload = """{"error":{"code":"ratelimited","info":"Try later"}}""";
+
+        var action = () => ProRosterDiscoveryJob.ParsePlayers(payload);
+
+        action.Should().Throw<InvalidOperationException>().WithMessage("*ratelimited*");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PreservesSuccessfulPagesWhenALaterPageIsThrottled()
+    {
+        const string firstPage = """
+            {
+              "cargoquery": [
+                {
+                  "title": {
+                    "ID": "Faker",
+                    "Team": "T1",
+                    "Role": "Mid",
+                    "SoloqueueIds": "Hide on bush#KR1"
+                  }
+                }
+              ]
+            }
+            """;
+        const string throttledPage = """{"error":{"code":"ratelimited","info":"Try later"}}""";
+        await using var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        var dbOptions = new DbContextOptionsBuilder<TranscendenceContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var db = new SqliteCompatibleTranscendenceContext(dbOptions);
+        await db.Database.EnsureCreatedAsync();
+        using var httpClient = new HttpClient(new SequenceHandler(firstPage, throttledPage));
+        var job = new ProRosterDiscoveryJob(
+            httpClient,
+            db,
+            Options.Create(new ProRosterDiscoveryOptions
+            {
+                PageSize = 1,
+                MaxPages = 2,
+                PageDelaySeconds = 0
+            }),
+            NullLogger<ProRosterDiscoveryJob>.Instance);
+
+        await job.ExecuteAsync(CancellationToken.None);
+
+        var candidate = await db.ProPlayerDiscoveryCandidates.SingleAsync();
+        candidate.ExternalId.Should().Be("Faker");
+        candidate.Status.Should().Be("pending");
+    }
+
+    private sealed class SequenceHandler(params string[] payloads) : HttpMessageHandler
+    {
+        private int index;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var payload = payloads[Math.Min(index++, payloads.Length - 1)];
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/tests/Transcendence.Service.Core.Tests/TrackedProSummonerServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/TrackedProSummonerServiceTests.cs
@@ -132,6 +132,43 @@ public class TrackedProSummonerServiceTests
         (await harness.Db.TrackedProSummoners.AnyAsync()).Should().BeFalse();
     }
 
+    [Fact]
+    public async Task ApproveCandidateAsync_PreservesCompetitiveIdentityAndSource()
+    {
+        await using var harness = await TrackedProHarness.CreateAsync();
+        var candidate = new ProPlayerDiscoveryCandidate
+        {
+            Id = Guid.NewGuid(),
+            Source = "leaguepedia",
+            ExternalId = "Faker",
+            ProName = "Faker",
+            TeamName = "T1",
+            Role = "Mid",
+            SoloQueueIds = "Hide on bush#KR1",
+            Status = "pending"
+        };
+        harness.Db.ProPlayerDiscoveryCandidates.Add(candidate);
+        await harness.Db.SaveChangesAsync();
+
+        var result = await harness.Service.ApproveCandidateAsync(
+            candidate.Id,
+            new ApproveProPlayerCandidateRequest("Hide on bush", "KR1", "KR", "faker-puuid"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(new
+        {
+            Puuid = "faker-puuid",
+            PlatformRegion = "KR",
+            ProName = "Faker",
+            TeamName = "T1",
+            IsPro = true,
+            Source = "leaguepedia",
+            SourceExternalId = "Faker"
+        });
+        candidate.Status.Should().Be("approved");
+        candidate.ApprovedTrackedProSummonerId.Should().Be(result.Value!.Id);
+    }
+
     private static TrackedProSummoner NewTracked(string puuid) => new()
     {
         Id = Guid.NewGuid(),


### PR DESCRIPTION
## Summary

- Fix champion/role leaderboard filtering so rapid selections retain both filters, add a loading state, and use match-region data.
- Make Pro Solo Q pro-only by default, with an optional high-elo one-trick switch and evidence-backed OTP qualification (30 of the latest 50 stored Ranked Solo/Duo games on one champion).
- Add a daily Leaguepedia roster-discovery pipeline that stages candidates for admin approval, preserves competitive names/team/source lineage, and never publishes unreviewed identities.
- Pace Leaguepedia pagination and retain successful pages when a later page is throttled. The live source returned a rate-limit response during the final probe, so source failure remains non-fatal and the last good candidate set is preserved.
- Remove Multi-Search from the crowded top bar, keep it in the command palette, and redesign command search as a compact single-column UI with punctuation-insensitive champion-first matching.
- Simplify marketing-heavy explanatory copy across the affected LoL pages.
- Add the EF migration, admin endpoints/UI, generated OpenAPI/client updates, architecture/development/API documentation, and regression coverage.
- Make OpenAPI export deterministic: export-only startup skips database-backed bootstrap work and a failed export can no longer pass by reusing a stale contract.

## Why

Leaderboard filter navigation could race against stale route props, causing a champion selection to disappear when a role was selected. Pro Solo Q also mixed every high-elo profile into the default experience and had no durable, reviewable way to maintain real professional identities or prove one-trick status. The header and command menu compounded this with crowded navigation and ambiguous search priority.

## User impact

- Champion + role leaderboards work together reliably.
- Pro Picks opens with professionals only; users may opt into verified high-elo one-tricks.
- Admins get a review queue for sourced pro accounts rather than silently publishing uncertain identities.
- Champion names such as `kaisa`, `drmundo`, and `khazix` are preferred over summoner results without requiring punctuation.
- The top bar and supporting copy are quieter and easier to scan.

## Validation

- `pnpm backend:test` — 309 Core, 70 WebAPI, and 28 integration tests passed.
- Focused roster throttling regression — 3 tests passed after the final paging change.
- `pnpm web:lint` — passed.
- `pnpm web:test` — 41 files / 202 tests passed.
- `pnpm web:build` — production build passed, 38 static pages generated.
- `pnpm api:check` — fresh zero-warning WebAPI export and generated client are in sync.
- `bash scripts/ci/check-migrations.sh` — regenerated migration passes hot-table DDL policy.
- `dotnet ef migrations has-pending-model-changes` — no model drift.
- `pnpm audit --audit-level=moderate` — no known vulnerabilities.
- `.NET` direct and transitive package vulnerability scan — no vulnerable packages.
- Browser + live backend checks: rapid Jinx/Middle leaderboard selection retained both filters; `kaisa` selected Kai’Sa above player matches; Pro Picks defaulted to pro-only and the one-trick switch routed to `scope=all`.

## Deployment notes

- Includes EF-CLI-generated migration `20260724042007_ImproveLeaderboardsAndProRosterDiscovery`.
- Adds the enabled daily `pro-roster-discovery` maintenance job (`15 3 * * *`, UTC).
- Leaguepedia pages are paced at 65 seconds by default to respect anonymous Cargo throttling; candidates require explicit admin approval before entering public analytics.