### PR TITLE
Polish profile match history

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -510,6 +510,67 @@ body::before {
     border-color: color-mix(in oklch, var(--t-primary), transparent 45%);
     box-shadow: 0 0 0 2px color-mix(in oklch, var(--t-primary), transparent 30%);
   }
+  .match-card-summary {
+    container: match-summary / inline-size;
+  }
+  .match-snapshot-grid {
+    display: grid;
+    min-width: 0;
+    gap: 1rem;
+  }
+  .match-snapshot-identity,
+  .match-snapshot-loadout,
+  .match-snapshot-stats {
+    min-width: 0;
+  }
+  .match-snapshot-stats {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    border-top: 1px solid color-mix(in oklch, var(--t-border), transparent 35%);
+    padding-top: 0.75rem;
+  }
+
+  @container match-summary (min-width: 36rem) {
+    .match-snapshot-grid {
+      grid-template-columns: minmax(0, 1fr) auto;
+      align-items: center;
+    }
+    .match-snapshot-identity {
+      grid-column: 1;
+      grid-row: 1;
+    }
+    .match-snapshot-loadout {
+      grid-column: 1 / -1;
+      grid-row: 2;
+    }
+    .match-snapshot-stats {
+      grid-column: 2;
+      grid-row: 1;
+      flex-direction: column;
+      align-items: flex-end;
+      justify-self: end;
+      border-top: 0;
+      padding-top: 0;
+      text-align: right;
+    }
+  }
+
+  @container match-summary (min-width: 52rem) {
+    .match-snapshot-grid {
+      grid-template-columns: minmax(15rem, 1fr) minmax(14.5rem, auto) minmax(9rem, 0.55fr);
+    }
+    .match-snapshot-identity,
+    .match-snapshot-loadout,
+    .match-snapshot-stats {
+      grid-column: auto;
+      grid-row: auto;
+    }
+    .match-snapshot-loadout {
+      align-self: center;
+    }
+  }
   .match-detail-shell {
     position: relative; border-radius: var(--radius-card);
     border: 1px solid var(--t-border); background: var(--t-surface-2);

--- a/apps/web/app/lol/champions/[championId]/page.tsx
+++ b/apps/web/app/lol/champions/[championId]/page.tsx
@@ -26,6 +26,7 @@ import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { pickMostSevereAnalyticsSample, type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { formatGames, matchupVerdict } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
 import { normalizeAnalyticsPatch } from "@/lib/lolPatchFilters";
 import { resolveDefaultedRankTier, rankTierDisplayLabel, rankTierLadderOrdinal } from "@/lib/ranks";
@@ -74,10 +75,9 @@ export async function generateMetadata({
     params,
     searchParams ?? Promise.resolve({} as ChampionSearchParams)
   ]);
-  const championNumber = Number(championId);
   const queue = analyticsQueueOption(resolvedSearchParams.queue);
   const selectedPatch = normalizeAnalyticsPatch(resolvedSearchParams.patch);
-  let championName = Number.isFinite(championNumber) ? `Champion ${championNumber}` : "Champion";
+  let championName = "Champion analytics";
   let patch = selectedPatch;
 
   try {
@@ -85,10 +85,11 @@ export async function generateMetadata({
       fetchChampionMap(),
       selectedPatch ? Promise.resolve([]) : fetchLolAnalyticsPatches(queue.value)
     ]);
-    championName = champions[championId]?.name ?? championName;
+    const champion = champions[championId];
+    if (champion?.name?.trim()) championName = championDisplayName(champion);
     patch ??= patches.find((candidate) => candidate.isActive)?.patch ?? patches[0]?.patch ?? null;
   } catch {
-    // Metadata degrades to the route identity if static data is temporarily unavailable.
+    // Metadata stays human-readable if static data is temporarily unavailable.
   }
 
   const patchLabel = patch ? ` for patch ${patch}` : "";
@@ -211,7 +212,7 @@ export default async function ChampionDetailPage({
     return (
       <BackendErrorCard
         title="Champion"
-        message="Invalid champion id."
+        message="That champion route is invalid."
       />
     );
   }
@@ -219,7 +220,7 @@ export default async function ChampionDetailPage({
   // Identity (cached static data) — paints the shell immediately while the profile streams in.
   const { version, champions } = await fetchChampionMap();
   const champ = champions[String(championId)];
-  const champName = champ?.name ?? `Champion ${championId}`;
+  const champName = championDisplayName(champ);
   const champSlug = champ?.id ?? "Unknown";
   return (
     <div className="grid gap-8">
@@ -525,7 +526,7 @@ async function ChampionSections({
       winRate: entry.winRate ?? null,
       games: entry.games ?? null,
       opponentSlug: opponent?.id ?? "Unknown",
-      opponentName: opponent?.name ?? `Champion ${opponentId}`,
+      opponentName: championDisplayName(opponent),
       verdict: matchupVerdict(entry.winRate)
     };
   });

--- a/apps/web/app/lol/items/[itemId]/page.tsx
+++ b/apps/web/app/lol/items/[itemId]/page.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
 
 import { BuildResourceDetailPage } from "@/components/BuildResourcePages";
+import { itemDisplayName } from "@/lib/gameDisplay";
 import { fetchItemMap } from "@/lib/staticData";
 
 export async function generateMetadata({ params }: { params: Promise<{ itemId: string }> }): Promise<Metadata> {
   const { itemId } = await params;
   const itemMap = await fetchItemMap().catch(() => null);
-  const name = itemMap?.items[itemId]?.name ?? `Item ${itemId}`;
+  const name = itemDisplayName(itemMap?.items[itemId]);
   return {
     title: `${name} Stats and Best Champions`,
     description: `${name} ranked pick rate, win rate, sample size, and champion-role usage.`

--- a/apps/web/app/lol/page.tsx
+++ b/apps/web/app/lol/page.tsx
@@ -12,6 +12,7 @@ import { fetchLolAnalyticsStatus } from "@/lib/lolAnalyticsStatus";
 import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { getBackendBaseUrl } from "@/lib/env";
 import { formatGames, formatPercent } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl, fetchChampionMap } from "@/lib/staticData";
 import { normalizeTierListEntries } from "@/lib/tierlist";
@@ -146,7 +147,7 @@ export default async function HomePage({
                 <tbody>
                   {topRows.map((entry, index) => {
                     const champ = champions[String(entry.championId)];
-                    const name = champ?.name ?? `Champion ${entry.championId}`;
+                    const name = championDisplayName(champ);
                     const title = champ?.title ?? "";
                     return (
                       <tr key={`${entry.championId}-${entry.role}`} className="border-b border-border/20">
@@ -195,7 +196,7 @@ export default async function HomePage({
               ) : (
                 trendingRows.map((entry, index) => {
                   const champ = champions[String(entry.championId)];
-                  const name = champ?.name ?? `Champion ${entry.championId}`;
+                  const name = championDisplayName(champ);
                   return (
                     <Link
                       key={`${entry.championId}-trend`}

--- a/apps/web/app/lol/pro-builds/[championId]/page.tsx
+++ b/apps/web/app/lol/pro-builds/[championId]/page.tsx
@@ -17,6 +17,7 @@ import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { pickMostSevereAnalyticsSample, type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { formatDateTimeMs, formatRelativeTime } from "@/lib/format";
+import { championDisplayName, itemDisplayName } from "@/lib/gameDisplay";
 import { fetchLolAnalyticsPatches } from "@/lib/lolAnalyticsPatches";
 import {
   buildProBuildFilterParams,
@@ -72,14 +73,13 @@ function ProItemsRow({
     <div className="flex flex-wrap items-center gap-1.5">
       {cleaned.map((itemId, idx) => {
         const meta = items[String(itemId)];
-        const title = meta
-          ? `${meta.name}${meta.plaintext ? ` - ${meta.plaintext}` : ""}`
-          : `Item ${itemId}`;
+        const name = itemDisplayName(meta);
+        const title = meta?.plaintext ? `${name}: ${meta.plaintext}` : name;
         return (
           <Image
             key={`${itemId}-${idx}`}
             src={itemIconUrl(itemVersion, itemId)}
-            alt={meta?.name ?? `Item ${itemId}`}
+            alt={name}
             title={title}
             width={size}
             height={size}
@@ -149,7 +149,7 @@ export default async function ProBuildsChampionPage({
   );
   const championId = Number(resolvedParams.championId);
   if (!Number.isFinite(championId) || championId <= 0) {
-    return <BackendErrorCard title="Pro Solo Queue Builds" message="Invalid champion id." />;
+    return <BackendErrorCard title="Pro Solo Queue Builds" message="That champion route is invalid." />;
   }
 
   const roleFilter = normalizeProBuildRole(resolvedSearchParams?.role);
@@ -229,7 +229,7 @@ export default async function ProBuildsChampionPage({
   const winrates = winratesRes.ok ? winratesRes.body : null;
   const proBuilds = proBuildsRes.ok ? proBuildsRes.body : null;
   const champion = champions[String(championId)];
-  const championName = champion?.name ?? `Champion ${championId}`;
+  const championName = championDisplayName(champion);
   const recentMatches = proBuilds?.recentProMatches ?? [];
   const topPlayers = proBuilds?.topPlayers ?? [];
   const commonBuilds = proBuilds?.commonBuilds ?? [];
@@ -511,7 +511,6 @@ export default async function ProBuildsChampionPage({
                       <p className={`text-sm font-semibold ${resultClass}`}>
                         {match.win ? "Win" : "Loss"}
                       </p>
-                      <p className="type-caption text-muted">{match.matchId ?? "Unknown match"}</p>
                     </div>
                   </div>
 

--- a/apps/web/app/lol/pro-builds/page.tsx
+++ b/apps/web/app/lol/pro-builds/page.tsx
@@ -16,6 +16,7 @@ import { resolveAnalyticsRegion } from "@/lib/analyticsRegions";
 import { type AnalyticsSampleLike } from "@/lib/analyticsSample";
 import { getBackendBaseUrl, getErrorVerbosity } from "@/lib/env";
 import { formatDateTimeMs, formatGames, formatRelativeTime } from "@/lib/format";
+import { championDisplayName, itemDisplayName } from "@/lib/gameDisplay";
 import { buildProBuildPageHref, normalizeProBuildScope, type ProBuildScope } from "@/lib/proBuilds";
 import { encodeRiotIdPath } from "@/lib/riotid";
 import { championIconUrl, fetchChampionMap, fetchItemMap, itemIconUrl } from "@/lib/staticData";
@@ -273,7 +274,7 @@ export default async function ProBuildsIndexPage({
                   const championId = entry.championId ?? 0;
                   const champion = championById.get(championId);
                   const slug = champion?.slug ?? "Unknown";
-                  const name = champion?.name ?? `Champion ${championId}`;
+                  const name = championDisplayName(champion);
                   return (
                     <tr
                       key={championId || idx}
@@ -367,7 +368,7 @@ export default async function ProBuildsIndexPage({
             type="text"
             name="q"
             defaultValue={championQuery ?? ""}
-            placeholder="Search champion name or id (e.g., Ahri or 103)"
+            placeholder="Search champion name (for example, Ahri)"
             className="control-input min-w-[220px] flex-1"
           />
           <button
@@ -537,7 +538,7 @@ async function RecentProMatches({
           {recentMatchesFeed.map((entry, idx) => {
             const champion = championById.get(entry.championId);
             const championSlug = champion?.slug ?? "Unknown";
-            const championName = champion?.name ?? `Champion ${entry.championId}`;
+            const championName = championDisplayName(champion);
             const playedAt = entry.match.playedAt ?? 0;
             const hasTimestamp = Number.isFinite(playedAt) && playedAt > 0;
             const items = (entry.match.items ?? [])
@@ -587,8 +588,8 @@ async function RecentProMatches({
                             <Image
                               key={`${itemId}-${itemIdx}`}
                               src={itemIconUrl(itemStatic.version, itemId)}
-                              alt={itemMeta?.name ?? `Item ${itemId}`}
-                              title={itemMeta?.name ?? `Item ${itemId}`}
+                              alt={itemDisplayName(itemMeta)}
+                              title={itemDisplayName(itemMeta)}
                               width={24}
                               height={24}
                               className="rounded-md border border-border/40"
@@ -602,7 +603,6 @@ async function RecentProMatches({
                       <p className={`text-sm font-semibold ${entry.match.win ? "text-wr-high" : "text-wr-low"}`}>
                         {entry.match.win ? "Win" : "Loss"}
                       </p>
-                      <p className="text-xs text-muted">{entry.match.matchId ?? "Unknown match id"}</p>
                       <p className="mt-1 text-xs text-muted">Patch {entry.patch ?? "Unknown"}</p>
                     </div>
 

--- a/apps/web/app/lol/runes/[runeId]/page.tsx
+++ b/apps/web/app/lol/runes/[runeId]/page.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
 
 import { BuildResourceDetailPage } from "@/components/BuildResourcePages";
+import { runeDisplayName } from "@/lib/gameDisplay";
 import { fetchRunesReforged } from "@/lib/staticData";
 
 export async function generateMetadata({ params }: { params: Promise<{ runeId: string }> }): Promise<Metadata> {
   const { runeId } = await params;
   const runeData = await fetchRunesReforged().catch(() => null);
-  const name = runeData?.runeById[runeId]?.name ?? `Rune ${runeId}`;
+  const name = runeDisplayName(runeData?.runeById[runeId]);
   return {
     title: `${name} Stats and Best Champions`,
     description: `${name} ranked pick rate, win rate, sample size, and champion-role usage.`

--- a/apps/web/app/lol/summoners/[region]/[riotId]/loading.tsx
+++ b/apps/web/app/lol/summoners/[region]/[riotId]/loading.tsx
@@ -31,8 +31,8 @@ export default function Loading() {
       </div>
 
       {/* Sidebar + main, matching the xl:grid-cols split of the live page */}
-      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(280px,0.32fr)_minmax(0,1fr)] xl:items-start">
-        <div className="grid content-start gap-5">
+      <div className="grid min-w-0 grid-cols-1 gap-6 xl:grid-cols-[20rem_minmax(0,1fr)] xl:items-start">
+        <div className="grid min-w-0 content-start gap-5">
           <Card className="profile-section-card p-5">
             <Skeleton className="h-3 w-28" />
             <Skeleton className="mt-3 h-24 w-full" />
@@ -42,7 +42,7 @@ export default function Loading() {
             <Skeleton className="mt-3 h-40 w-full" />
           </Card>
         </div>
-        <div className="grid gap-6">
+        <div className="grid min-w-0 gap-6">
           <Card className="profile-section-card p-5">
             <Skeleton className="h-3 w-28" />
             <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
@@ -55,7 +55,7 @@ export default function Loading() {
             <Skeleton className="h-6 w-40" />
             <div className="mt-5 flex flex-col gap-4">
               {Array.from({ length: 4 }).map((_, i) => (
-                <Skeleton key={i} className="h-24 w-full rounded-panel" />
+                <Skeleton key={i} className="h-28 w-full rounded-panel" />
               ))}
             </div>
           </Card>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -10,6 +10,7 @@ import { LaneIcon } from "@/components/ui/LaneIcon";
 import { fetchBackendJson } from "@/lib/backendCall";
 import { cn } from "@/lib/cn";
 import { getBackendBaseUrl } from "@/lib/env";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { selectStarterPicks } from "@/lib/homeGuidance";
 import { fetchLolAnalyticsStatus } from "@/lib/lolAnalyticsStatus";
 import { platformRegionToSlug } from "@/lib/lolRegions";
@@ -255,7 +256,7 @@ export default async function LandingPage() {
             <div className="grid">
               {lolTop.map((entry, index) => {
                 const champ = champions[String(entry.championId)];
-                const name = champ?.name ?? `Champion ${entry.championId}`;
+                const name = championDisplayName(champ);
                 return (
                   <Link
                     key={`${entry.championId}-${entry.role}`}

--- a/apps/web/components/BuildBreakdown.tsx
+++ b/apps/web/components/BuildBreakdown.tsx
@@ -5,6 +5,7 @@ import type { components } from "@transcendence/api-client";
 import { cn } from "@/lib/cn";
 import { WinRateText } from "@/components/WinRateText";
 import { Confidence } from "@/components/ui/Confidence";
+import { itemDisplayName } from "@/lib/gameDisplay";
 import { itemIconUrl, summonerSpellIconUrl } from "@/lib/staticData";
 
 type SummonerSpellPairDto = components["schemas"]["SummonerSpellPairDto"];
@@ -76,13 +77,12 @@ function ItemIcon({
     );
   }
   const meta = items[String(itemId)];
-  const title = meta
-    ? `${meta.name}${meta.plaintext ? ` — ${meta.plaintext}` : ""}`
-    : `Item ${itemId}`;
+  const name = itemDisplayName(meta);
+  const title = meta?.plaintext ? `${name}: ${meta.plaintext}` : name;
   return (
     <Image
       src={itemIconUrl(version, itemId)}
-      alt={meta?.name ?? `Item ${itemId}`}
+      alt={name}
       title={title}
       width={size}
       height={size}

--- a/apps/web/components/BuildResourceDetail.tsx
+++ b/apps/web/components/BuildResourceDetail.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/ui/Card";
 import { LaneIcon } from "@/components/ui/LaneIcon";
 import { buildResourceHref, type BuildResourceDetailResponse, type BuildResourceKind } from "@/lib/buildResources";
 import { formatGames, formatPercent, winRateColorClass } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { roleDisplayLabel } from "@/lib/roles";
 import {
   championIconUrl,
@@ -51,13 +52,18 @@ export function BuildResourceDetail({
           {icon ? (
             <Image src={icon} alt="" width={112} height={112} sizes="112px" priority className="h-24 w-24 rounded-2xl border border-border/60 bg-bg shadow-card sm:h-28 sm:w-28" />
           ) : (
-            <div className="grid h-24 w-24 place-items-center rounded-2xl border border-border/60 bg-bg text-sm text-muted sm:h-28 sm:w-28">{resource.resourceId}</div>
+            <div
+              className="grid h-24 w-24 place-items-center rounded-2xl border border-border/60 bg-bg text-2xl font-semibold text-muted sm:h-28 sm:w-28"
+              aria-label={`${isItems ? "Item" : "Rune"} icon unavailable`}
+            >
+              ?
+            </div>
           )}
           <div className="min-w-0">
             <div className="flex flex-wrap gap-2">
               <Badge>{activeRegionLabel}</Badge>
               <Badge className="border-primary/35 bg-primary/10 text-primary">Patch {response.patch}</Badge>
-              <Badge>{isItems ? "Item" : "Rune"} {resource.resourceId}</Badge>
+              <Badge>{isItems ? "Item" : "Rune"}</Badge>
             </div>
             <h1 className="type-display mt-4">{resource.name}</h1>
             {description ? <p className="type-lead mt-3 max-w-3xl">{description}</p> : null}
@@ -104,7 +110,7 @@ export function BuildResourceDetail({
                       <td className="px-5 py-3 sm:px-6">
                         <Link href={`/lol/champions/${row.championId}?${query.toString()}`} className="inline-flex items-center gap-2.5 font-semibold text-fg hover:text-primary">
                           {champion && champions ? <Image src={championIconUrl(champions.version, champion.id)} alt="" width={34} height={34} sizes="34px" className="rounded-lg" /> : null}
-                          <span>{champion?.name ?? `Champion ${row.championId}`}</span>
+                          <span>{championDisplayName(champion)}</span>
                         </Link>
                       </td>
                       <td className="px-3 py-3 text-fg/72">

--- a/apps/web/components/BuildResourceIndex.tsx
+++ b/apps/web/components/BuildResourceIndex.tsx
@@ -13,6 +13,7 @@ import {
   type BuildResourceSort
 } from "@/lib/buildResources";
 import { formatGames, formatPercent, winRateColorClass } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { roleDisplayLabel } from "@/lib/roles";
 import {
   championIconUrl,
@@ -92,7 +93,7 @@ export function BuildResourceIndex({
               <input
                 name="q"
                 defaultValue={query}
-                placeholder={isItems ? "Trinity Force or 3078" : "Press the Attack or 8005"}
+                placeholder={isItems ? "Trinity Force" : "Press the Attack"}
                 className="h-11 rounded-control border border-border/70 bg-bg/70 px-3 text-sm text-fg outline-none transition placeholder:text-muted focus:border-primary/45 focus:ring-2 focus:ring-primary/15"
               />
             </label>
@@ -119,7 +120,7 @@ export function BuildResourceIndex({
       ) : entries.length === 0 ? (
         <Card className="p-6">
           <h2 className="type-section">No matching {kind}</h2>
-          <p className="type-ui mt-2 text-muted">Try a different name, numeric ID, or region.</p>
+          <p className="type-ui mt-2 text-muted">Try a different name or region.</p>
         </Card>
       ) : (
         <section className="grid gap-3 lg:grid-cols-2">
@@ -140,13 +141,17 @@ export function BuildResourceIndex({
                   {icon ? (
                     <Image src={icon} alt="" width={56} height={56} sizes="56px" className="h-14 w-14 shrink-0 rounded-xl border border-border/55 bg-bg object-cover" />
                   ) : (
-                    <div className="grid h-14 w-14 shrink-0 place-items-center rounded-xl border border-border/55 bg-bg text-xs text-muted">{entry.resourceId}</div>
+                    <div
+                      className="grid h-14 w-14 shrink-0 place-items-center rounded-xl border border-border/55 bg-bg text-lg font-semibold text-muted"
+                      aria-label={`${noun} icon unavailable`}
+                    >
+                      ?
+                    </div>
                   )}
                   <div className="min-w-0 flex-1">
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
                         <h2 className="type-section truncate transition group-hover:text-primary">{entry.name}</h2>
-                        <p className="type-meta mt-1 text-muted">ID {entry.resourceId}</p>
                       </div>
                       <span className="type-meta shrink-0 text-primary">Explore →</span>
                     </div>
@@ -168,7 +173,7 @@ export function BuildResourceIndex({
                       return (
                         <span key={`${champion.championId}-${champion.role}`} className="inline-flex items-center gap-1.5 rounded-full border border-border/45 bg-bg/55 py-1 pl-1 pr-2 text-xs text-fg/72">
                           {meta && champions ? <Image src={championIconUrl(champions.version, meta.id)} alt="" width={22} height={22} sizes="22px" className="rounded-full" /> : null}
-                          <span>{meta?.name ?? `Champion ${champion.championId}`} · {roleDisplayLabel(champion.role)}</span>
+                          <span>{championDisplayName(meta)} · {roleDisplayLabel(champion.role)}</span>
                         </span>
                       );
                     })}

--- a/apps/web/components/ChampionSynergyPanel.tsx
+++ b/apps/web/components/ChampionSynergyPanel.tsx
@@ -5,6 +5,7 @@ import type { components } from "@transcendence/api-client";
 import { Card } from "@/components/ui/Card";
 import { LaneIcon } from "@/components/ui/LaneIcon";
 import { formatGames, formatPercent, winRateColorClass } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl } from "@/lib/staticData";
 import { formatStrengthDelta } from "@/lib/tierlist";
@@ -83,7 +84,7 @@ export function ChampionSynergyPanel({
                   ) : null}
                   <div className="min-w-0">
                     <p className="truncate font-semibold text-fg transition group-hover:text-primary">
-                      {champion?.name ?? `Champion ${partner.partnerChampionId}`}
+                      {championDisplayName(champion)}
                     </p>
                     <p className="mt-0.5 inline-flex items-center gap-1 text-xs text-muted">
                       <LaneIcon role={partner.partnerRole} className="h-3.5 w-3.5" />

--- a/apps/web/components/ItemBuildDisplay.tsx
+++ b/apps/web/components/ItemBuildDisplay.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 
 import { cn } from "@/lib/cn";
 import { formatGames, formatPercent, winRateColorClass } from "@/lib/format";
+import { itemDisplayName } from "@/lib/gameDisplay";
 import { itemIconUrl } from "@/lib/staticData";
 
 type ItemMeta = { name: string; plaintext?: string };
@@ -52,14 +53,13 @@ function ItemRow({
             );
           }
           const meta = items[String(itemId)];
-          const title = meta
-            ? `${meta.name}${meta.plaintext ? ` \u2014 ${meta.plaintext}` : ""}`
-            : `Item ${itemId}`;
+          const name = itemDisplayName(meta);
+          const title = meta?.plaintext ? `${name}: ${meta.plaintext}` : name;
           return (
             <Image
               key={`${idx}-${itemId}`}
               src={itemIconUrl(version, itemId)}
-              alt={meta?.name ?? `Item ${itemId}`}
+              alt={name}
               title={title}
               width={iconSize}
               height={iconSize}

--- a/apps/web/components/LiveGameCard.tsx
+++ b/apps/web/components/LiveGameCard.tsx
@@ -112,7 +112,7 @@ function ParticipantRow({
         {participant.championId != null ? (
           <Image
             src={championSquareIconUrlById(participant.championId)}
-            alt={`Champion ${participant.championId}`}
+            alt="Selected champion"
             width={36}
             height={36}
             className="size-9 shrink-0 rounded-control border border-border bg-surface"
@@ -156,7 +156,7 @@ function ParticipantRow({
                 <span key={entry.championId} className="inline-flex items-center gap-1">
                   <Image
                     src={championSquareIconUrlById(entry.championId)}
-                    alt={`Champion ${entry.championId}`}
+                    alt="Recent champion"
                     width={20}
                     height={20}
                     className="size-5 rounded-sm border border-border"

--- a/apps/web/components/MultiSearchClient.tsx
+++ b/apps/web/components/MultiSearchClient.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
 import { Select } from "@/components/ui/Select";
 import { formatPercent, kdaColorClass, winRateColorClass } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { LOL_REGION_OPTIONS } from "@/lib/lolRegions";
 import { parseLobbyText } from "@/lib/multiSearch";
 import { rankTierColorClass, rankTierDisplayLabel } from "@/lib/ranks";
@@ -310,7 +311,7 @@ function PlayerRow({ result, region, staticData }: { result: MultiSearchResult; 
             {result.topChampions!.slice(0, 3).map((champion) => {
               const identity = staticData?.champions[String(champion.championId)];
               return (
-                <span key={champion.championId} className="group/champion relative" title={`${identity?.name ?? `Champion ${champion.championId}`}: ${champion.games} games, ${formatPercent(champion.winRate)} WR`}>
+                <span key={champion.championId} className="group/champion relative" title={`${championDisplayName(identity)}: ${champion.games} games, ${formatPercent(champion.winRate)} WR`}>
                   {identity && staticData ? (
                     <Image src={championIconUrl(staticData.version, identity.id)} alt={identity.name} width={34} height={34} className="h-[34px] w-[34px] rounded-md border border-border/55" />
                   ) : (

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -193,8 +193,8 @@ export function SummonerProfileClient({
             />
           )
         ) : (
-          <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(280px,0.32fr)_minmax(0,1fr)] xl:items-start">
-            <div className="order-2 xl:order-1">
+          <div className="grid min-w-0 grid-cols-1 gap-6 xl:grid-cols-[20rem_minmax(0,1fr)] xl:items-start">
+            <div className="order-2 min-w-0 xl:order-1">
               <ProfileSidebar
                 profile={lookup.profile}
                 championStatic={staticData.championStatic}
@@ -206,7 +206,7 @@ export function SummonerProfileClient({
                 tagLine={tagLine}
               />
             </div>
-            <div className="order-1 grid gap-6 xl:order-2">
+            <div className="order-1 grid min-w-0 gap-6 [&>*]:min-w-0 [&>*]:max-w-full xl:order-2">
               <PerformanceCard
                 matches={matches.history?.items ?? []}
                 overviewStats={lookup.profile.overviewStats}

--- a/apps/web/components/TierListTable.tsx
+++ b/apps/web/components/TierListTable.tsx
@@ -18,6 +18,7 @@ import { Tooltip } from "@/components/ui/Tooltip";
 import { cn } from "@/lib/cn";
 import { formatEbStory } from "@/lib/confidence";
 import { formatGames, formatPercent } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { roleDisplayLabel } from "@/lib/roles";
 import { championIconUrl } from "@/lib/staticData";
 import {
@@ -323,7 +324,7 @@ export function TierListTable({
 
   function renderRow(entry: RowEntry) {
     const champion = champions[String(entry.championId)];
-    const championName = champion?.name ?? `Champion ${entry.championId}`;
+    const championName = championDisplayName(champion);
     const championSlug = champion?.id ?? "Unknown";
     const championSubtitle = champion?.title ?? "";
     const rowParams = new URLSearchParams();

--- a/apps/web/components/lol-profile/MatchHistorySection.test.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.test.tsx
@@ -3,13 +3,43 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { MatchHistorySection } from "./MatchHistorySection";
+import type { MatchSummary } from "./shared";
 
 type TestOverrides = {
   queue?: string;
   historyBusy?: boolean;
   historyError?: string | null;
+  visibleMatches?: MatchSummary[];
   onQueueChange?: (value: string) => void;
   onNextPage?: () => void;
+  onToggleExpanded?: (matchId: string) => void;
+};
+
+const MATCH: MatchSummary = {
+  matchId: "NA1_123",
+  matchDate: Date.UTC(2026, 6, 22, 12, 0, 0),
+  durationSeconds: 2032,
+  queueId: 420,
+  queueType: "RANKED_SOLO_5x5",
+  win: true,
+  championId: 236,
+  teamPosition: "BOTTOM",
+  kills: 24,
+  deaths: 10,
+  assists: 10,
+  visionScore: 23,
+  damageToChamps: 53_985,
+  csPerMin: 8.4,
+  summonerSpell1Id: 4,
+  summonerSpell2Id: 21,
+  items: [6675, 3508, 3031, 3026, 3036, 3156, 3363],
+  runesDetail: {
+    primaryStyleId: 8000,
+    subStyleId: 8300,
+    primarySelections: [8005, 8009, 9103, 8014],
+    subSelections: [8345, 8347],
+    statShards: [5005, 5008, 5001]
+  }
 };
 
 function props(overrides: TestOverrides = {}): React.ComponentProps<typeof MatchHistorySection> {
@@ -39,7 +69,7 @@ function props(overrides: TestOverrides = {}): React.ComponentProps<typeof Match
       history: null,
       historyBusy: overrides.historyBusy ?? false,
       historyError: overrides.historyError ?? null,
-      visibleMatches: [],
+      visibleMatches: overrides.visibleMatches ?? [],
       onPreviousPage: vi.fn(),
       onNextPage: overrides.onNextPage ?? vi.fn()
     },
@@ -47,7 +77,7 @@ function props(overrides: TestOverrides = {}): React.ComponentProps<typeof Match
       expandedMatchId: null,
       details: {},
       detailBusy: {},
-      onToggleExpanded: vi.fn()
+      onToggleExpanded: overrides.onToggleExpanded ?? vi.fn()
     },
     prefersReducedMotion: true,
   };
@@ -82,5 +112,28 @@ describe("MatchHistorySection", () => {
     expect(onQueueChange).toHaveBeenCalledWith("RANKED_SOLO_DUO");
     await user.click(screen.getByRole("button", { name: "Next" }));
     expect(onNextPage).toHaveBeenCalledOnce();
+  });
+
+  it("groups champion loadout, items, core stats, and expansion in one snapshot", async () => {
+    const user = userEvent.setup();
+    const onToggleExpanded = vi.fn();
+    render(
+      <MatchHistorySection
+        {...props({ visibleMatches: [MATCH], onToggleExpanded })}
+      />
+    );
+
+    const matchButton = screen.getByRole("button", {
+      name: "Victory on Unknown champion. KDA 24/10/10. 33:52."
+    });
+    expect(screen.getByLabelText("Summoner spells")).toBeTruthy();
+    expect(screen.getByLabelText("Rune preview")).toBeTruthy();
+    expect(screen.getByLabelText("Item build preview")).toBeTruthy();
+    expect(screen.getByText("8.4 CS/min")).toBeTruthy();
+    expect(screen.getByText("3.40 KDA")).toBeTruthy();
+    expect(screen.getByText("Details")).toBeTruthy();
+
+    await user.click(matchButton);
+    expect(onToggleExpanded).toHaveBeenCalledWith("NA1_123");
   });
 });

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -14,10 +14,12 @@ import { cn } from "@/lib/cn";
 import { MatchScoreboard } from "@/components/lol-profile/MatchScoreboard";
 import { useStaticData } from "@/components/lol-profile/StaticDataContext";
 import {
+  formatCompactNumber,
   formatDateTimeMs,
   formatDurationSeconds,
   formatRelativeTime
 } from "@/lib/format";
+import { championDisplayName, itemDisplayName } from "@/lib/gameDisplay";
 import { formatQueueLabel } from "@/lib/queues";
 import { roleDisplayLabel } from "@/lib/roles";
 import { encodeRiotIdPath } from "@/lib/riotid";
@@ -114,201 +116,201 @@ function MatchHistoryCard({
   const { championStatic, itemStatic, spellStatic, runeStatic } = useStaticData();
   const queueLabel = formatQueueLabel(match.queueType, match.queueId);
   const champion = championStatic?.champions[String(match.championId)];
-  const championName = champion?.name ?? `Champion ${match.championId}`;
+  const championName = championDisplayName(champion);
   const roleLabel = match.teamPosition ? roleDisplayLabel(match.teamPosition) : "Unknown";
   const primaryRuneId = sortRuneSelections(match.runesDetail?.primarySelections ?? [], runeStatic?.runeSortById)[0] ?? 0;
   const primaryRuneMeta = runeStatic?.runeById[String(primaryRuneId)];
   const subStyleMeta = runeStatic?.styleById[String(match.runesDetail?.subStyleId ?? 0)];
   const spellIds = [match.summonerSpell1Id, match.summonerSpell2Id];
   const itemSlots = Array.from({ length: 7 }, (_, idx) => match.items[idx] ?? 0);
+  const relativeTime = formatRelativeTime(match.matchDate);
+  const exactDateTime = formatDateTimeMs(match.matchDate);
   const matchMetaId = `match-meta-${match.matchId}`;
   const matchPanelId = `match-panel-${match.matchId}`;
 
   return (
     <div
-      className={`match-card-shell ${
+      className={`match-card-shell min-w-0 max-w-full ${
         match.win ? "match-card-shell--win border-win/28" : "match-card-shell--loss border-loss/28"
       } rounded-panel border`}
     >
       <button
-        className="relative z-10 w-full px-4 py-4 text-left focus-visible:outline-none md:px-5 md:py-5"
+        className="match-card-summary relative z-10 block w-full min-w-0 max-w-full px-4 py-4 text-left focus-visible:outline-none md:px-5 md:py-5"
         onClick={() => void onToggleExpanded(match.matchId)}
         aria-expanded={expanded}
         aria-controls={matchPanelId}
         aria-describedby={matchMetaId}
         aria-label={`${match.win ? "Victory" : "Defeat"} on ${championName}. KDA ${match.kills}/${match.deaths}/${match.assists}. ${formatDurationSeconds(match.durationSeconds)}.`}
       >
-        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.95fr)_auto] xl:items-center">
-          <div className="grid gap-3">
-            <div className="flex flex-wrap items-center gap-2">
+        <div className="match-snapshot-grid">
+          <div className="match-snapshot-identity min-w-0">
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
               <span
-                className={`type-overline rounded-full px-2.5 py-1 ${
-                  match.win ? "bg-win/15 text-win" : "bg-loss/15 text-loss"
-                }`}
+                className={`type-overline font-semibold ${match.win ? "text-win" : "text-loss"}`}
               >
                 {match.win ? "VICTORY" : "DEFEAT"}
               </span>
-              <span className="type-caption surface-chip rounded-full px-2.5 py-1 font-medium text-fg/92">
-                {queueLabel}
-              </span>
-              <span className="type-caption surface-chip rounded-full px-2.5 py-1 font-medium text-fg/92">
-                {roleLabel}
-              </span>
-              <span className="type-caption surface-chip rounded-full px-2.5 py-1 font-medium text-fg/92">
+              <span className="text-border-strong" aria-hidden="true">·</span>
+              <span className="type-caption font-medium text-fg/82">{queueLabel}</span>
+              <span className="text-border-strong" aria-hidden="true">·</span>
+              <span className="type-caption tabular-nums text-fg/72">
                 {formatDurationSeconds(match.durationSeconds)}
               </span>
             </div>
 
-            <div className="grid gap-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center">
-              <div className="flex min-w-0 items-center gap-3">
+            <div className="mt-3 flex min-w-0 items-center gap-3">
+              <div className="flex shrink-0 items-center gap-2">
                 {champion && championStatic ? (
                   <Image
                     src={championIconUrl(championStatic.version, champion.id)}
                     alt={championName}
-                    width={52}
-                    height={52}
+                    width={48}
+                    height={48}
                     className="rounded-control border border-border/60 shadow-soft"
                   />
                 ) : (
-                  <div className="h-[52px] w-[52px] rounded-control border border-border/60 bg-surface/60" />
+                  <div className="h-12 w-12 rounded-control border border-border/60 bg-surface/60" />
                 )}
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-end gap-x-3 gap-y-1">
-                    <p className="truncate text-lg font-semibold">{championName}</p>
-                    <p className="text-xs text-muted">{formatRelativeTime(match.matchDate)}</p>
+
+                <div className="grid grid-cols-2 items-center gap-1.5">
+                  <div className="flex flex-col gap-1" aria-label="Summoner spells">
+                    {spellIds.map((spellId, spellIdx) => {
+                      const spellMeta = spellStatic?.spells[String(spellId)];
+                      return spellMeta && spellStatic ? (
+                        <Image
+                          key={`${match.matchId}-spell-${spellIdx}-${spellId}`}
+                          src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
+                          alt={spellMeta.name}
+                          title={spellMeta.name}
+                          width={21}
+                          height={21}
+                          className="rounded border border-border/50"
+                        />
+                      ) : (
+                        <span
+                          key={`${match.matchId}-spell-empty-${spellIdx}-${spellId}`}
+                          className="h-[21px] w-[21px] rounded border border-border/40 bg-surface/60"
+                          aria-hidden="true"
+                        />
+                      );
+                    })}
                   </div>
-                  <p id={matchMetaId} className="mt-1 text-sm text-fg/72">
-                    {formatDateTimeMs(match.matchDate)}
-                  </p>
+
+                  <div className="flex flex-col items-center gap-1" aria-label="Rune preview">
+                    {primaryRuneMeta ? (
+                      <Image
+                        src={runeIconUrl(primaryRuneMeta.icon)}
+                        alt={primaryRuneMeta.name}
+                        title={primaryRuneMeta.name}
+                        width={22}
+                        height={22}
+                        className="rounded-full border border-border/40 bg-surface-2/70 p-0.5"
+                      />
+                    ) : (
+                      <span
+                        className="h-[22px] w-[22px] rounded-full border border-border/40 bg-surface-2/70"
+                        aria-hidden="true"
+                      />
+                    )}
+                    {subStyleMeta ? (
+                      <Image
+                        src={runeIconUrl(subStyleMeta.icon)}
+                        alt={subStyleMeta.name}
+                        title={subStyleMeta.name}
+                        width={18}
+                        height={18}
+                        className="rounded-full border border-border/30 bg-surface-2/70 p-0.5"
+                      />
+                    ) : (
+                      <span
+                        className="h-[18px] w-[18px] rounded-full border border-border/30 bg-surface-2/70"
+                        aria-hidden="true"
+                      />
+                    )}
+                  </div>
                 </div>
+              </div>
+
+              <div className="min-w-0">
+                <p className="truncate text-lg font-semibold leading-tight text-fg">{championName}</p>
+                <p className="mt-1 truncate type-caption text-muted">
+                  {roleLabel}
+                  <span className="px-1.5" aria-hidden="true">·</span>
+                  <time id={matchMetaId} title={exactDateTime} aria-label={`${relativeTime}; ${exactDateTime}`}>
+                    {relativeTime}
+                  </time>
+                </p>
               </div>
             </div>
           </div>
 
-          <div className="grid gap-3">
-            <div className="surface-subtle grid gap-3 rounded-card p-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center">
-              <div className="flex items-center gap-3">
-                <div className="flex items-center gap-1.5" aria-label="Summoner spells">
-                  {spellIds.map((spellId, spellIdx) => {
-                    const spellMeta = spellStatic?.spells[String(spellId)];
-                    return spellMeta && spellStatic ? (
+          <div className="match-snapshot-loadout min-w-0">
+            <div className="flex flex-wrap items-center gap-1" aria-label="Item build preview">
+              {itemSlots.map((itemId, itemIdx) => {
+                const itemMeta = itemStatic?.items[String(itemId)];
+                return (
+                  <span
+                    key={`${match.matchId}-item-slot-${itemIdx}`}
+                    className={cn(
+                      "inline-flex shrink-0",
+                      itemIdx === 6 && "ml-1 border-l border-border/65 pl-2"
+                    )}
+                  >
+                    {!itemId ? (
+                      <span
+                        className="h-7 w-7 rounded border border-border/35 bg-surface/55"
+                        aria-hidden="true"
+                      />
+                    ) : itemStatic ? (
                       <Image
-                        key={`${match.matchId}-spell-${spellIdx}-${spellId}`}
-                        src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
-                        alt={spellMeta.name}
-                        title={spellMeta.name}
-                        width={24}
-                        height={24}
-                        className="rounded-md border border-border/50"
+                        src={itemIconUrl(itemStatic.version, itemId)}
+                        alt={itemDisplayName(itemMeta)}
+                        title={itemDisplayName(itemMeta)}
+                        width={28}
+                        height={28}
+                        className="rounded border border-border/35"
                       />
                     ) : (
-                      <div
-                        key={`${match.matchId}-spell-empty-${spellIdx}-${spellId}`}
-                        className="h-6 w-6 rounded-md border border-border/40 bg-surface/60"
+                      <span
+                        className="h-7 w-7 rounded border border-border/35 bg-surface/55"
                         aria-hidden="true"
                       />
-                    );
-                  })}
-                </div>
-
-                <div className="flex items-center gap-1.5" aria-label="Rune preview">
-                  {primaryRuneMeta ? (
-                    <Image
-                      src={runeIconUrl(primaryRuneMeta.icon)}
-                      alt={primaryRuneMeta.name}
-                      title={primaryRuneMeta.name}
-                      width={24}
-                      height={24}
-                      className="rounded-full border border-border/40 bg-surface-2/70 p-0.5"
-                    />
-                  ) : (
-                    <span
-                      className="h-6 w-6 rounded-full border border-border/40 bg-surface-2/70"
-                      aria-hidden="true"
-                    />
-                  )}
-                  {subStyleMeta ? (
-                    <Image
-                      src={runeIconUrl(subStyleMeta.icon)}
-                      alt={subStyleMeta.name}
-                      title={subStyleMeta.name}
-                      width={24}
-                      height={24}
-                      className="rounded-full border border-border/40 bg-surface-2/70 p-0.5"
-                    />
-                  ) : (
-                    <span
-                      className="h-6 w-6 rounded-full border border-border/40 bg-surface-2/70"
-                      aria-hidden="true"
-                    />
-                  )}
-                </div>
-              </div>
-
-              <div className="flex flex-wrap items-center gap-1.5 sm:justify-end" aria-label="Item build preview">
-                {itemSlots.map((itemId, itemIdx) => {
-                  if (!itemId) {
-                    return (
-                      <div
-                        key={`${match.matchId}-item-empty-${itemIdx}`}
-                        className="h-6 w-6 rounded-md border border-border/35 bg-surface/60"
-                        aria-hidden="true"
-                      />
-                    );
-                  }
-
-                  const itemMeta = itemStatic?.items[String(itemId)];
-                  return itemStatic ? (
-                    <Image
-                      key={`${match.matchId}-item-${itemIdx}-${itemId}`}
-                      src={itemIconUrl(itemStatic.version, itemId)}
-                      alt={itemMeta?.name ?? `Item ${itemId}`}
-                      title={itemMeta?.name ?? `Item ${itemId}`}
-                      width={24}
-                      height={24}
-                      className="rounded-md border border-border/35"
-                    />
-                  ) : (
-                    <div
-                      key={`${match.matchId}-item-loading-${itemIdx}-${itemId}`}
-                      className="h-6 w-6 rounded-md border border-border/35 bg-surface/60"
-                      aria-hidden="true"
-                    />
-                  );
-                })}
-              </div>
+                    )}
+                  </span>
+                );
+              })}
             </div>
 
-            <div className="flex flex-wrap gap-2 text-xs text-fg/70">
-              <span className="surface-chip rounded-full px-2.5 py-1">
-                {match.damageToChamps.toLocaleString()} damage
-              </span>
-              <span className="surface-chip rounded-full px-2.5 py-1">
-                {match.visionScore} vision
-              </span>
-              <span className="surface-chip rounded-full px-2.5 py-1">
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 type-caption text-fg/68">
+              <span className="tabular-nums">{formatCompactNumber(match.damageToChamps)} dmg</span>
+              <span className="tabular-nums">{match.visionScore} vision</span>
+              <span className="tabular-nums">
                 {match.csPerMin.toFixed(1)} CS/min
               </span>
             </div>
           </div>
 
-          <div className="grid gap-2 xl:justify-items-end">
-            <div className="surface-subtle rounded-card px-4 py-3 text-right">
-              <p className="text-xl font-semibold leading-tight tracking-tight text-fg">
-                <span>{match.kills}</span>/<span className="text-loss/90">{match.deaths}</span>/<span>{match.assists}</span>
+          <div className="match-snapshot-stats">
+            <div>
+              <p className="text-xl font-semibold leading-tight tracking-tight text-fg tabular-nums">
+                <span>{match.kills}</span>
+                <span className="text-muted"> / </span>
+                <span className="text-loss/90">{match.deaths}</span>
+                <span className="text-muted"> / </span>
+                <span>{match.assists}</span>
               </p>
-              <p className="mt-1 text-xs font-medium text-fg/82">
+              <p className="mt-1 type-caption font-medium text-fg/78 tabular-nums">
                 {matchKdaRatio(match).toFixed(2)} KDA
               </p>
             </div>
             <span className="flex items-center justify-end gap-1.5 type-overline text-muted">
+              {expanded ? "Collapse" : "Details"}
               <ChevronRightIcon
                 className={cn(
                   "size-3 shrink-0 transition-transform duration-150",
                   expanded && "rotate-90"
                 )}
               />
-              {expanded ? "Collapse details" : "Expand details"}
             </span>
           </div>
         </div>
@@ -377,8 +379,8 @@ export function MatchHistorySection({
   prefersReducedMotion,
 }: MatchHistorySectionProps) {
   return (
-    <section className="flex flex-col gap-5">
-      <Card className="profile-section-card rounded-panel p-5 md:p-6">
+    <section className="flex min-w-0 max-w-full flex-col gap-5">
+      <Card className="profile-section-card min-w-0 max-w-full rounded-panel p-5 md:p-6">
         <div className="flex flex-col gap-3">
           <div className="flex flex-wrap items-end justify-between gap-3">
             <div>

--- a/apps/web/components/lol-profile/MatchScoreboard.test.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MatchScoreboard } from "./MatchScoreboard";
+import { TooltipProvider } from "@/components/ui/Tooltip";
+import type { MatchDetail, MatchParticipant } from "./shared";
+
+function participant(overrides: Partial<MatchParticipant>): MatchParticipant {
+  return {
+    puuid: "puuid",
+    gameName: "Player",
+    tagLine: "NA1",
+    teamId: 100,
+    championId: 1,
+    teamPosition: "TOP",
+    win: false,
+    kills: 2,
+    deaths: 4,
+    assists: 6,
+    champLevel: 16,
+    goldEarned: 12_000,
+    totalDamageDealtToChampions: 20_000,
+    physicalDamageDealtToChampions: 10_000,
+    magicDamageDealtToChampions: 9_000,
+    trueDamageDealtToChampions: 1_000,
+    visionScore: 18,
+    totalMinionsKilled: 180,
+    neutralMinionsKilled: 12,
+    summonerSpell1Id: 4,
+    summonerSpell2Id: 12,
+    items: [3078, 3053, 3065, 3111, 0, 0, 3340],
+    runes: {
+      primaryStyleId: 8000,
+      subStyleId: 8400,
+      primarySelections: [8005, 9111, 9104, 8014],
+      subSelections: [8444, 8451],
+      statShards: [5005, 5008, 5001]
+    },
+    ...overrides
+  };
+}
+
+const DETAIL: MatchDetail = {
+  matchId: "NA1_123",
+  matchDate: Date.UTC(2026, 6, 22, 12, 0, 0),
+  duration: 1800,
+  queueId: 420,
+  queueType: "RANKED_SOLO_5x5",
+  patch: "16.14",
+  participants: [
+    participant({ puuid: "kronic", gameName: "Kronic", tagLine: "NA1" }),
+    participant({
+      puuid: "opponent",
+      gameName: "Opponent",
+      tagLine: "NA1",
+      teamId: 200,
+      win: true,
+      kills: 7,
+      deaths: 2,
+      assists: 5
+    })
+  ],
+  bans: [],
+  objectives: []
+};
+
+describe("MatchScoreboard", () => {
+  it("always renders the detailed scoreboard without a density choice", () => {
+    render(
+      <TooltipProvider>
+        <MatchScoreboard
+          detail={DETAIL}
+          summonerId=""
+          region="na"
+          gameName="Kronic"
+          tagLine="NA1"
+        />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByRole("group", { name: "Match detail view" })).toBeTruthy();
+    expect(screen.queryByRole("group", { name: "Scoreboard density" })).toBeNull();
+    expect(screen.queryByText("Compact")).toBeNull();
+    expect(screen.queryByText("Detailed")).toBeNull();
+    expect(screen.getAllByRole("columnheader", { name: "Vision" })).toHaveLength(2);
+    expect(screen.getAllByRole("columnheader", { name: "Gold" })).toHaveLength(2);
+    expect(screen.getAllByLabelText("Summoner spells")).toHaveLength(2);
+  });
+});

--- a/apps/web/components/lol-profile/MatchScoreboard.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 
 import { ParticipantRuneCard } from "@/components/lol-profile/ParticipantRuneCard";
-import { ScoreboardTeamTable, type ScoreboardDensity } from "@/components/lol-profile/ScoreboardTeamTable";
+import { ScoreboardTeamTable } from "@/components/lol-profile/ScoreboardTeamTable";
 import { useStaticData } from "@/components/lol-profile/StaticDataContext";
 import { GoldDiffChart } from "@/components/lol-profile/GoldDiffChart";
 import { SegmentedControl } from "@/components/ui/SegmentedControl";
@@ -77,11 +77,6 @@ function RuneTabCell({
     </div>
   );
 }
-
-const DENSITY_OPTIONS = [
-  { value: "compact" as const, label: "Compact" },
-  { value: "full" as const, label: "Detailed" }
-];
 
 const TAKEAWAY_TONE_CLASS: Record<TakeawayTone, string> = {
   good: "text-success",
@@ -170,10 +165,10 @@ function ObjectivesStrip({ objectives }: { objectives: MatchTeamObjectives[] }) 
   );
 }
 
-// Compact, tabbed post-game view that replaces the old 10-tall-cards detail panel.
-// Overview = two dense team scoreboards (op.gg-style); Runes = role-aligned rune
-// pages for side-by-side comparison. Runes also surface via a hover tooltip on each
-// scoreboard row's keystone, so a single player can be inspected without leaving Overview.
+// Tabbed post-game view. Overview always uses the complete scoreboard; Runes
+// aligns both teams by role for side-by-side comparison. Runes also surface via
+// a tooltip on each scoreboard row's keystone, so a single player can be
+// inspected without leaving Overview.
 export function MatchScoreboard({
   detail,
   summonerId,
@@ -189,7 +184,6 @@ export function MatchScoreboard({
 }) {
   const [tab, setTab] = useState<ScoreboardTab>("overview");
   const [timeline, setTimeline] = useState<MatchTimeline | null>(null);
-  const [density, setDensity] = useState<ScoreboardDensity>("compact");
 
   // Lazy-load the gold/xp-diff curve once the scoreboard mounts (i.e. the match is expanded).
   // Optional decoration — only present for matches with ingested timeline frames.
@@ -247,15 +241,6 @@ export function MatchScoreboard({
               <GoldDiffChart frames={timeline.frames} />
             </div>
           ) : null}
-          <div className="flex items-center justify-end px-1">
-            <SegmentedControl<ScoreboardDensity>
-              options={DENSITY_OPTIONS}
-              value={density}
-              onValueChange={setDensity}
-              ariaLabel="Scoreboard density"
-              className="w-fit"
-            />
-          </div>
           <ScoreboardTeamTable
             participants={blue}
             teamId={100}
@@ -265,7 +250,6 @@ export function MatchScoreboard({
             region={region}
             gameName={gameName}
             tagLine={tagLine}
-            density={density}
           />
           <ScoreboardTeamTable
             participants={red}
@@ -276,7 +260,6 @@ export function MatchScoreboard({
             region={region}
             gameName={gameName}
             tagLine={tagLine}
-            density={density}
           />
         </div>
       ) : (

--- a/apps/web/components/lol-profile/ProfileSidebar.tsx
+++ b/apps/web/components/lol-profile/ProfileSidebar.tsx
@@ -6,10 +6,11 @@ import { Badge } from "@/components/ui/Badge";
 import { Card } from "@/components/ui/Card";
 import { DataBar } from "@/components/ui/DataBar";
 import { Sparkline } from "@/components/ui/Sparkline";
-import { championIconUrl } from "@/lib/staticData";
 import { formatPercent, plural, winRateColorClass } from "@/lib/format";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { rankEmblemUrl, rankTierDisplayLabel, rankToLadderPoints } from "@/lib/ranks";
 import { encodeRiotIdPath } from "@/lib/riotid";
+import { championIconUrl } from "@/lib/staticData";
 
 import {
   rankColorClass,
@@ -72,7 +73,7 @@ export function ProfileSidebar({
   const soloDelta = soloSeries.length >= 2 ? soloSeries.at(-1)! - soloSeries[0] : null;
 
   return (
-    <aside className="grid content-start gap-5 xl:sticky xl:top-24">
+    <aside className="grid min-w-0 content-start gap-5 [&>*]:min-w-0 [&>*]:max-w-full xl:sticky xl:top-24">
       <Card className="profile-section-card p-5">
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -207,7 +208,7 @@ export function ProfileSidebar({
                   )}
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium text-fg group-hover:text-primary">
-                      {champion?.name ?? `Champion ${m.championId}`}
+                      {championDisplayName(champion)}
                     </p>
                     <p className="type-caption text-muted tabular-nums">{m.championPoints.toLocaleString()} pts</p>
                   </div>
@@ -243,7 +244,7 @@ export function ProfileSidebar({
                   <div>
                     <p className="type-kicker text-muted">#{index + 1}</p>
                     <p className="mt-1 text-sm font-semibold text-fg group-hover:text-primary">
-                      {champion?.name ?? `Champion ${championStat.championId}`}
+                      {championDisplayName(champion)}
                     </p>
                   </div>
                   <DataBar value={championStat.winRate} games={championStat.games} />

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -7,6 +7,7 @@ import { TableScroll, Table, Th, Td } from "@/components/ui/Table";
 import { Tooltip } from "@/components/ui/Tooltip";
 import { cn } from "@/lib/cn";
 import { formatCompactNumber } from "@/lib/format";
+import { itemDisplayName } from "@/lib/gameDisplay";
 import { encodeRiotIdPath } from "@/lib/riotid";
 import { roleDisplayLabel } from "@/lib/roles";
 import {
@@ -26,8 +27,6 @@ import {
 } from "@/components/lol-profile/shared";
 
 const ROLE_ORDER: Record<string, number> = { TOP: 0, JUNGLE: 1, MIDDLE: 2, BOTTOM: 3, UTILITY: 4 };
-
-export type ScoreboardDensity = "compact" | "full";
 
 function RuneTrigger({ participant }: { participant: MatchParticipant }) {
   const { runeStatic } = useStaticData();
@@ -89,7 +88,6 @@ function ScoreboardRow({
   participant,
   durationSeconds,
   maxDamage,
-  density,
   region,
   gameName,
   tagLine
@@ -97,7 +95,6 @@ function ScoreboardRow({
   participant: MatchParticipant;
   durationSeconds: number;
   maxDamage: number;
-  density: ScoreboardDensity;
   region: string;
   gameName: string;
   tagLine: string;
@@ -140,26 +137,24 @@ function ScoreboardRow({
             ) : null}
           </div>
 
-          {density === "full" ? (
-            <span className="flex shrink-0 flex-col gap-0.5" aria-label="Summoner spells">
-              {[participant.summonerSpell1Id, participant.summonerSpell2Id].map((spellId, spellIdx) => {
-                const spellMeta = spellStatic?.spells[String(spellId)];
-                return spellMeta && spellStatic ? (
-                  <Image
-                    key={`${spellId}-${spellIdx}`}
-                    src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
-                    alt={spellMeta.name}
-                    title={spellMeta.name}
-                    width={16}
-                    height={16}
-                    className="rounded border border-border/40"
-                  />
-                ) : (
-                  <span key={`${spellId}-${spellIdx}`} className="h-4 w-4 rounded border border-border/40 bg-surface/60" />
-                );
-              })}
-            </span>
-          ) : null}
+          <span className="flex shrink-0 flex-col gap-0.5" aria-label="Summoner spells">
+            {[participant.summonerSpell1Id, participant.summonerSpell2Id].map((spellId, spellIdx) => {
+              const spellMeta = spellStatic?.spells[String(spellId)];
+              return spellMeta && spellStatic ? (
+                <Image
+                  key={`${spellId}-${spellIdx}`}
+                  src={summonerSpellIconUrl(spellStatic.version, spellMeta.id)}
+                  alt={spellMeta.name}
+                  title={spellMeta.name}
+                  width={16}
+                  height={16}
+                  className="rounded border border-border/40"
+                />
+              ) : (
+                <span key={`${spellId}-${spellIdx}`} className="h-4 w-4 rounded border border-border/40 bg-surface/60" />
+              );
+            })}
+          </span>
 
           <RuneTrigger participant={participant} />
 
@@ -223,17 +218,13 @@ function ScoreboardRow({
         ) : null}
       </Td>
 
-      {density === "full" ? (
-        <>
-          <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
-            {participant.visionScore}
-          </Td>
+      <Td align="right" className="whitespace-nowrap text-sm tabular-nums text-fg/82">
+        {participant.visionScore}
+      </Td>
 
-          <Td align="right" className="hidden whitespace-nowrap text-sm tabular-nums text-fg/82 sm:table-cell">
-            {formatCompactNumber(participant.goldEarned)}
-          </Td>
-        </>
-      ) : null}
+      <Td align="right" className="whitespace-nowrap text-sm tabular-nums text-fg/82">
+        {formatCompactNumber(participant.goldEarned)}
+      </Td>
 
       <Td>
         <div className="flex flex-wrap items-center gap-1">
@@ -248,8 +239,8 @@ function ScoreboardRow({
               <Image
                 key={`${itemId}-${itemIdx}`}
                 src={itemIconUrl(itemStatic.version, itemId)}
-                alt={itemMeta?.name ?? `Item ${itemId}`}
-                title={itemMeta?.name ?? `Item ${itemId}`}
+                alt={itemDisplayName(itemMeta)}
+                title={itemDisplayName(itemMeta)}
                 width={22}
                 height={22}
                 className="rounded border border-border/35"
@@ -272,8 +263,7 @@ export function ScoreboardTeamTable({
   bans,
   region,
   gameName,
-  tagLine,
-  density = "compact"
+  tagLine
 }: {
   participants: MatchParticipant[];
   teamId: 100 | 200;
@@ -283,7 +273,6 @@ export function ScoreboardTeamTable({
   region: string;
   gameName: string;
   tagLine: string;
-  density?: ScoreboardDensity;
 }) {
   const { championStatic } = useStaticData();
   const ordered = participants
@@ -334,19 +323,15 @@ export function ScoreboardTeamTable({
       </div>
 
       <TableScroll className="match-detail-shell">
-        <Table className="min-w-[600px]">
+        <Table className="min-w-[760px]">
           <thead>
             <tr>
               <Th>{isBlue ? "Blue Team" : "Red Team"}</Th>
               <Th align="right">KDA</Th>
               <Th align="right">CS</Th>
               <Th align="right">Damage</Th>
-              {density === "full" ? (
-                <>
-                  <Th align="right" className="hidden sm:table-cell">Vision</Th>
-                  <Th align="right" className="hidden sm:table-cell">Gold</Th>
-                </>
-              ) : null}
+              <Th align="right">Vision</Th>
+              <Th align="right">Gold</Th>
               <Th>Items</Th>
             </tr>
           </thead>
@@ -357,7 +342,6 @@ export function ScoreboardTeamTable({
                 participant={participant}
                 durationSeconds={durationSeconds}
                 maxDamage={maxDamage}
-                density={density}
                 region={region}
                 gameName={gameName}
                 tagLine={tagLine}

--- a/apps/web/components/lol-profile/useSummonerProfileData.ts
+++ b/apps/web/components/lol-profile/useSummonerProfileData.ts
@@ -22,6 +22,7 @@ import {
   type SummonerLookupResponse,
   type SummonerProfileResponse
 } from "@/components/lol-profile/shared";
+import { championDisplayName } from "@/lib/gameDisplay";
 import { computeNextPollDelayMs } from "@/lib/polling";
 import { formatQueueLabel } from "@/lib/queues";
 import {
@@ -270,7 +271,7 @@ export function useMatchHistory({
     return (history?.facets?.championIds ?? [])
       .map((id) => ({
         id,
-        label: championStatic?.champions[String(id)]?.name ?? `Champion ${id}`
+        label: championDisplayName(championStatic?.champions[String(id)])
       }))
       .sort((a, b) => a.label.localeCompare(b.label));
   }, [championStatic?.champions, history?.facets?.championIds]);

--- a/apps/web/lib/gameDisplay.test.ts
+++ b/apps/web/lib/gameDisplay.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  championDisplayName,
+  itemDisplayName,
+  runeDisplayName,
+  spellDisplayName
+} from "@/lib/gameDisplay";
+
+describe("game resource display names", () => {
+  it("uses the resource name when static data is available", () => {
+    expect(championDisplayName({ name: "Ahri" })).toBe("Ahri");
+    expect(itemDisplayName({ name: "Trinity Force" })).toBe("Trinity Force");
+    expect(runeDisplayName({ name: "Press the Attack" })).toBe("Press the Attack");
+    expect(spellDisplayName({ name: "Flash" })).toBe("Flash");
+  });
+
+  it("uses human-readable fallbacks without exposing resource identifiers", () => {
+    expect(championDisplayName(null)).toBe("Unknown champion");
+    expect(itemDisplayName(undefined)).toBe("Unknown item");
+    expect(runeDisplayName({ name: " " })).toBe("Unknown rune");
+    expect(spellDisplayName(null)).toBe("Unknown summoner spell");
+  });
+});

--- a/apps/web/lib/gameDisplay.ts
+++ b/apps/web/lib/gameDisplay.ts
@@ -1,0 +1,24 @@
+type NamedGameResource = {
+  name?: string | null;
+};
+
+function normalizedName(resource: NamedGameResource | null | undefined): string | null {
+  const name = resource?.name?.trim();
+  return name ? name : null;
+}
+
+export function championDisplayName(resource: NamedGameResource | null | undefined): string {
+  return normalizedName(resource) ?? "Unknown champion";
+}
+
+export function itemDisplayName(resource: NamedGameResource | null | undefined): string {
+  return normalizedName(resource) ?? "Unknown item";
+}
+
+export function runeDisplayName(resource: NamedGameResource | null | undefined): string {
+  return normalizedName(resource) ?? "Unknown rune";
+}
+
+export function spellDisplayName(resource: NamedGameResource | null | undefined): string {
+  return normalizedName(resource) ?? "Unknown summoner spell";
+}

--- a/apps/web/lib/queues.test.ts
+++ b/apps/web/lib/queues.test.ts
@@ -6,6 +6,8 @@ describe("formatQueueLabel", () => {
   it("normalizes known queue ids", () => {
     expect(formatQueueLabel("420")).toBe("Ranked Solo/Duo");
     expect(formatQueueLabel("450")).toBe("ARAM");
+    expect(formatQueueLabel("480")).toBe("Swiftplay");
+    expect(formatQueueLabel("QUEUE_480")).toBe("Swiftplay");
     expect(formatQueueLabel(undefined, 490)).toBe("Quickplay");
     expect(formatQueueLabel("900")).toBe("ARURF");
   });
@@ -17,8 +19,9 @@ describe("formatQueueLabel", () => {
   });
 
   it("handles unknown values safely", () => {
-    expect(formatQueueLabel("12345")).toBe("Queue 12345");
+    expect(formatQueueLabel("12345")).toBe("Other mode");
+    expect(formatQueueLabel("QUEUE_12345")).toBe("Other mode");
     expect(formatQueueLabel("ultra_brawl_mode")).toBe("Ultra Brawl Mode");
-    expect(formatQueueLabel("")).toBe("Unknown Queue");
+    expect(formatQueueLabel("")).toBe("Other mode");
   });
 });

--- a/apps/web/lib/queues.ts
+++ b/apps/web/lib/queues.ts
@@ -4,6 +4,7 @@ const QUEUE_ID_LABELS: Record<number, string> = {
   430: "Normal Blind",
   440: "Ranked Flex",
   450: "ARAM",
+  480: "Swiftplay",
   490: "Quickplay",
   700: "Clash",
   900: "ARURF",
@@ -57,17 +58,22 @@ export function formatQueueLabel(queueType?: string | null, queueId?: number | n
   }
 
   const raw = (queueType ?? "").trim();
-  if (!raw) return "Unknown Queue";
+  if (!raw) return "Other mode";
 
   if (/^\d+$/.test(raw)) {
     const parsed = Number(raw);
     const byParsedId = QUEUE_ID_LABELS[parsed];
-    return byParsedId ?? `Queue ${parsed}`;
+    return byParsedId ?? "Other mode";
   }
 
   const token = normalizeToken(raw);
   const byToken = QUEUE_TOKEN_LABELS[token];
   if (byToken) return byToken;
+
+  const numericQueueToken = token.match(/^QUEUE_(\d+)$/);
+  if (numericQueueToken) {
+    return QUEUE_ID_LABELS[Number(numericQueueToken[1])] ?? "Other mode";
+  }
 
   if (raw.includes("_")) {
     return titleCaseWords(raw.replaceAll("_", " "));

--- a/apps/web/lib/staticData.ts
+++ b/apps/web/lib/staticData.ts
@@ -1,5 +1,7 @@
 import { cache } from "react";
 
+import { runeDisplayName } from "@/lib/gameDisplay";
+
 export type ChampionMap = {
   version: string;
   champions: Record<string, { id: string; name: string; title?: string; difficulty?: number }>;
@@ -277,7 +279,7 @@ export const fetchRunesReforged = cache(async (): Promise<RuneStaticData> => {
       for (const perk of perks ?? []) {
         if (!perk?.id || !perk?.iconPath) continue;
         runeById[String(perk.id)] = {
-          name: perk.name?.trim() || `Rune ${perk.id}`,
+          name: runeDisplayName(perk),
           icon: communityDragonAssetUrl(perk.iconPath)
         };
       }


### PR DESCRIPTION
## Summary

- rework collapsed profile match cards around outcome, game context, champion loadout, items, and core performance stats
- use one complete expanded scoreboard view and fix profile sidebar/card containment across responsive layouts
- replace public-facing champion, item, rune, match, and queue IDs with readable names or neutral fallbacks
- add regression coverage for match expansion, queue labels, and game-resource fallbacks

## Validation

- `pnpm web:lint`
- `pnpm web:test` — 206 tests passed
- `pnpm web:build`
- local browser QA at mobile and desktop widths against the live backend
