### PR TITLE
Add profile performance indicators

### DIFF
--- a/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Implementations/SummonerStatsService.cs
@@ -710,8 +710,11 @@ public class SummonerMatchHistoryService(
     ILogger<SummonerMatchHistoryService> logger)
     : ISummonerMatchHistoryService
 {
-    private const string RecentMatchesCacheKeyPrefix = "stats:recent:";
-    private const string MatchDetailCacheKeyPrefix = "match:detail:";
+    // Versioned because both payloads now carry required performance summaries.
+    // A new prefix avoids deserializing pre-deploy distributed-cache entries that
+    // were written against the older record constructors.
+    private const string RecentMatchesCacheKeyPrefix = "stats:recent:v2:";
+    private const string MatchDetailCacheKeyPrefix = "match:detail:v2:";
     private const string MatchTimelineCacheKeyPrefix = "match:timeline:";
     private const string SummonerStatsCacheTagPrefix = "summoner-stats:";
 
@@ -833,6 +836,13 @@ public class SummonerMatchHistoryService(
         if (participantData.Count == 0)
             return new PagedResult<RecentMatchSummary>([], page, pageSize, total, facets);
 
+        // The page projection contains only the viewed summoner. Load the bounded set of
+        // participants from those matches once so the displayed score is relative to real
+        // teammates, rather than an opaque absolute KDA threshold.
+        var performanceByParticipant = await LoadMatchPerformanceAsync(
+            participantData.Select(value => value.MatchEntityId).Distinct().ToList(),
+            ct);
+
         // Get items and runes for these participants
         var participantIds = participantData.Select(p => p.ParticipantId).Distinct().ToList();
 
@@ -952,11 +962,50 @@ public class SummonerMatchHistoryService(
                 p.SummonerSpell2Id,
                 itemList,
                 runeSummary,
-                runeDetail
+                runeDetail,
+                performanceByParticipant.GetValueOrDefault(p.ParticipantId) ??
+                BuildFallbackPerformance(p)
             );
         }).ToList();
 
         return new PagedResult<RecentMatchSummary>(items, page, pageSize, total, facets);
+    }
+
+    private async Task<IReadOnlyDictionary<Guid, MatchPerformanceSummary>> LoadMatchPerformanceAsync(
+        IReadOnlyCollection<Guid> matchIds,
+        CancellationToken ct)
+    {
+        if (matchIds.Count == 0)
+            return new Dictionary<Guid, MatchPerformanceSummary>();
+
+        var participants = await db.MatchParticipants
+            .AsNoTracking()
+            .Where(participant => matchIds.Contains(participant.MatchId))
+            .Select(participant => new MatchPerformanceScorer.Input(
+                participant.MatchId,
+                participant.Id,
+                participant.TeamId,
+                participant.Win,
+                participant.Kills,
+                participant.Deaths,
+                participant.Assists,
+                participant.GoldEarned,
+                participant.TotalDamageDealtToChampions,
+                participant.VisionScore,
+                participant.TotalMinionsKilled + participant.NeutralMinionsKilled,
+                participant.Match.Duration))
+            .ToListAsync(ct);
+
+        return MatchPerformanceScorer.Score(participants);
+    }
+
+    private static MatchPerformanceSummary BuildFallbackPerformance(RecentMatchProjection participant)
+    {
+        var csPerMin = participant.Duration > 0
+            ? (participant.TotalMinionsKilled + participant.NeutralMinionsKilled) /
+              (participant.Duration / 60.0)
+            : 0;
+        return new MatchPerformanceSummary(5.5, 1, 1, null, 0, 0, 0, 0, Math.Round(csPerMin, 2));
     }
 
     private static async Task<MatchHistoryFacets> LoadMatchHistoryFacetsAsync(
@@ -1206,7 +1255,27 @@ public class SummonerMatchHistoryService(
                     return new RuneSelectionMetadata(first.RunePathId, first.Slot);
                 });
 
-        var participants = match.Participants.Select(p => MapParticipant(p, runeMetadata)).ToList();
+        var performanceByParticipant = MatchPerformanceScorer.Score(
+            match.Participants.Select(participant => new MatchPerformanceScorer.Input(
+                participant.MatchId,
+                participant.Id,
+                participant.TeamId,
+                participant.Win,
+                participant.Kills,
+                participant.Deaths,
+                participant.Assists,
+                participant.GoldEarned,
+                participant.TotalDamageDealtToChampions,
+                participant.VisionScore,
+                participant.TotalMinionsKilled + participant.NeutralMinionsKilled,
+                match.Duration)));
+        var participants = match.Participants
+            .Select(participant => MapParticipant(
+                participant,
+                runeMetadata,
+                performanceByParticipant.GetValueOrDefault(participant.Id) ??
+                new MatchPerformanceSummary(5.5, 1, 1, null, 0, 0, 0, 0, 0)))
+            .ToList();
 
         var bans = match.Bans
             .GroupBy(b => b.TeamId)
@@ -1246,7 +1315,8 @@ public class SummonerMatchHistoryService(
 
     private static ParticipantDetailDto MapParticipant(
         Data.Models.LoL.Match.MatchParticipant p,
-        Dictionary<int, RuneSelectionMetadata> runeMetadata)
+        Dictionary<int, RuneSelectionMetadata> runeMetadata,
+        MatchPerformanceSummary performance)
     {
         var items = p.Items
             .OrderBy(i => i.SlotIndex)
@@ -1285,7 +1355,8 @@ public class SummonerMatchHistoryService(
             p.SummonerSpell1Id,
             p.SummonerSpell2Id,
             items,
-            runes
+            runes,
+            performance
         );
     }
 

--- a/Transcendence.Service.Core/Services/Analysis/MatchPerformanceScorer.cs
+++ b/Transcendence.Service.Core/Services/Analysis/MatchPerformanceScorer.cs
@@ -1,0 +1,141 @@
+using Transcendence.Service.Core.Services.Analysis.Models;
+
+namespace Transcendence.Service.Core.Services.Analysis;
+
+/// <summary>
+/// Produces a deterministic, role-tolerant team-impact score from stats already stored
+/// on each match participant. Every input is ranked within the participant's own team
+/// before weighting, so the score does not compare raw support vision to carry farm.
+/// </summary>
+internal static class MatchPerformanceScorer
+{
+    private const double KillParticipationWeight = 0.30;
+    private const double DamageWeight = 0.25;
+    private const double VisionWeight = 0.15;
+    private const double GoldWeight = 0.10;
+    private const double CsWeight = 0.10;
+    private const double SurvivalWeight = 0.10;
+
+    internal sealed record Input(
+        Guid MatchId,
+        Guid ParticipantId,
+        int TeamId,
+        bool Win,
+        int Kills,
+        int Deaths,
+        int Assists,
+        int GoldEarned,
+        int DamageToChampions,
+        int VisionScore,
+        int TotalCs,
+        int DurationSeconds);
+
+    private sealed record Candidate(
+        Input Input,
+        double Composite,
+        double KillParticipation,
+        double DamageShare,
+        double GoldShare,
+        double VisionShare,
+        double CsPerMin);
+
+    public static IReadOnlyDictionary<Guid, MatchPerformanceSummary> Score(IEnumerable<Input> inputs)
+    {
+        var result = new Dictionary<Guid, MatchPerformanceSummary>();
+
+        foreach (var team in inputs
+                     .Where(input => input.TeamId > 0)
+                     .GroupBy(input => new { input.MatchId, input.TeamId }))
+        {
+            var members = team.ToList();
+            if (members.Count == 0)
+                continue;
+
+            var teamKills = members.Sum(member => Math.Max(0, member.Kills));
+            var teamDamage = members.Sum(member => Math.Max(0, member.DamageToChampions));
+            var teamGold = members.Sum(member => Math.Max(0, member.GoldEarned));
+            var teamVision = members.Sum(member => Math.Max(0, member.VisionScore));
+
+            var killParticipation = members.ToDictionary(
+                member => member.ParticipantId,
+                member => teamKills > 0
+                    ? Math.Clamp((member.Kills + member.Assists) / (double)teamKills, 0, 1)
+                    : 0);
+            var damageShare = members.ToDictionary(
+                member => member.ParticipantId,
+                member => teamDamage > 0 ? Math.Max(0, member.DamageToChampions) / (double)teamDamage : 0);
+            var goldShare = members.ToDictionary(
+                member => member.ParticipantId,
+                member => teamGold > 0 ? Math.Max(0, member.GoldEarned) / (double)teamGold : 0);
+            var visionShare = members.ToDictionary(
+                member => member.ParticipantId,
+                member => teamVision > 0 ? Math.Max(0, member.VisionScore) / (double)teamVision : 0);
+            var csPerMin = members.ToDictionary(
+                member => member.ParticipantId,
+                member => member.DurationSeconds > 0
+                    ? Math.Max(0, member.TotalCs) / (member.DurationSeconds / 60.0)
+                    : 0);
+
+            var candidates = members.Select(member =>
+            {
+                var composite =
+                    KillParticipationWeight * Percentile(killParticipation.Values, killParticipation[member.ParticipantId]) +
+                    DamageWeight * Percentile(damageShare.Values, damageShare[member.ParticipantId]) +
+                    VisionWeight * Percentile(visionShare.Values, visionShare[member.ParticipantId]) +
+                    GoldWeight * Percentile(goldShare.Values, goldShare[member.ParticipantId]) +
+                    CsWeight * Percentile(csPerMin.Values, csPerMin[member.ParticipantId]) +
+                    SurvivalWeight * Percentile(members.Select(value => -(double)value.Deaths), -member.Deaths);
+
+                return new Candidate(
+                    member,
+                    composite,
+                    killParticipation[member.ParticipantId],
+                    damageShare[member.ParticipantId],
+                    goldShare[member.ParticipantId],
+                    visionShare[member.ParticipantId],
+                    csPerMin[member.ParticipantId]);
+            }).ToList();
+
+            var ordered = candidates
+                .OrderByDescending(candidate => candidate.Composite)
+                .ThenByDescending(candidate =>
+                    (candidate.Input.Kills + candidate.Input.Assists) / (double)Math.Max(1, candidate.Input.Deaths))
+                .ThenBy(candidate => candidate.Input.ParticipantId)
+                .ToList();
+
+            for (var index = 0; index < ordered.Count; index++)
+            {
+                var candidate = ordered[index];
+                var rank = index + 1;
+                var label = members.Count > 1 && rank == 1
+                    ? candidate.Input.Win ? "MVP" : "ACE"
+                    : null;
+
+                result[candidate.Input.ParticipantId] = new MatchPerformanceSummary(
+                    Math.Round(1 + 9 * candidate.Composite, 1, MidpointRounding.AwayFromZero),
+                    rank,
+                    members.Count,
+                    label,
+                    Math.Round(candidate.KillParticipation, 4),
+                    Math.Round(candidate.DamageShare, 4),
+                    Math.Round(candidate.GoldShare, 4),
+                    Math.Round(candidate.VisionShare, 4),
+                    Math.Round(candidate.CsPerMin, 2));
+            }
+        }
+
+        return result;
+    }
+
+    private static double Percentile(IEnumerable<double> values, double value)
+    {
+        const double epsilon = 0.0000001;
+        var population = values.ToList();
+        if (population.Count <= 1)
+            return 0.5;
+
+        var lower = population.Count(candidate => candidate < value - epsilon);
+        var equal = population.Count(candidate => Math.Abs(candidate - value) <= epsilon);
+        return (lower + (equal - 1) / 2.0) / (population.Count - 1);
+    }
+}

--- a/Transcendence.Service.Core/Services/Analysis/Models/StatsModels.cs
+++ b/Transcendence.Service.Core/Services/Analysis/Models/StatsModels.cs
@@ -139,7 +139,25 @@ public record RecentMatchSummary(
     int SummonerSpell2Id,
     IReadOnlyList<int> Items,  // 7 item IDs (6 items + trinket), 0 for empty slots
     MatchRuneSummary Runes,
-    MatchRuneDetail RunesDetail
+    MatchRuneDetail RunesDetail,
+    MatchPerformanceSummary Performance
+);
+
+/// <summary>
+/// A transparent, team-relative performance readout for one match participant.
+/// The score is derived from kill participation, damage, gold, vision, farm, and
+/// survival percentiles within that participant's team.
+/// </summary>
+public record MatchPerformanceSummary(
+    double Score,
+    int TeamRank,
+    int TeamSize,
+    string? Label,
+    double KillParticipation,
+    double DamageShare,
+    double GoldShare,
+    double VisionShare,
+    double CsPerMin
 );
 
 public record MatchRuneSummary(

--- a/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
+++ b/Transcendence.Service.Core/Services/RiotApi/DTOs/MatchDetailDto.cs
@@ -1,3 +1,5 @@
+using Transcendence.Service.Core.Services.Analysis.Models;
+
 namespace Transcendence.Service.Core.Services.RiotApi.DTOs;
 
 /// <summary>
@@ -84,7 +86,8 @@ public record ParticipantDetailDto(
     int SummonerSpell1Id,
     int SummonerSpell2Id,
     IReadOnlyList<int> Items,
-    ParticipantRunesDto Runes
+    ParticipantRunesDto Runes,
+    MatchPerformanceSummary Performance
 );
 
 /// <summary>

--- a/Transcendence.WebAPI/Controllers/SummonerStatsController.cs
+++ b/Transcendence.WebAPI/Controllers/SummonerStatsController.cs
@@ -151,7 +151,8 @@ public class SummonerStatsController(
                     m.RunesDetail.SubStyleId,
                     m.RunesDetail.PrimarySelections,
                     m.RunesDetail.SubSelections,
-                    m.RunesDetail.StatShards)
+                    m.RunesDetail.StatShards),
+                m.Performance
             )).ToList(),
             result.Page,
             result.PageSize,

--- a/Transcendence.WebAPI/Models/Stats/SummonerStatsDtos.cs
+++ b/Transcendence.WebAPI/Models/Stats/SummonerStatsDtos.cs
@@ -1,3 +1,5 @@
+using Transcendence.Service.Core.Services.Analysis.Models;
+
 namespace Transcendence.WebAPI.Models.Stats;
 
 public record SummonerOverviewDto(
@@ -81,7 +83,8 @@ public record RecentMatchSummaryDto(
     int SummonerSpell2Id,
     IReadOnlyList<int> Items,
     MatchRuneSummaryDto Runes,
-    MatchRuneDetailDto RunesDetail
+    MatchRuneDetailDto RunesDetail,
+    MatchPerformanceSummary Performance
 );
 
 public record MatchRuneSummaryDto(

--- a/apps/web/components/lol-profile/MatchHistorySection.test.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.test.tsx
@@ -39,6 +39,17 @@ const MATCH: MatchSummary = {
     primarySelections: [8005, 8009, 9103, 8014],
     subSelections: [8345, 8347],
     statShards: [5005, 5008, 5001]
+  },
+  performance: {
+    score: 9.1,
+    teamRank: 1,
+    teamSize: 5,
+    label: "MVP",
+    killParticipation: 0.74,
+    damageShare: 0.32,
+    goldShare: 0.26,
+    visionShare: 0.16,
+    csPerMin: 8.4
   }
 };
 
@@ -131,6 +142,11 @@ describe("MatchHistorySection", () => {
     expect(screen.getByLabelText("Item build preview")).toBeTruthy();
     expect(screen.getByText("8.4 CS/min")).toBeTruthy();
     expect(screen.getByText("3.40 KDA")).toBeTruthy();
+    expect(screen.getByText("MVP")).toBeTruthy();
+    expect(screen.getByText("9.1")).toBeTruthy();
+    expect(screen.getByTestId("performance-indicator").getAttribute("title")).toContain(
+      "74% kill participation"
+    );
     expect(screen.getByText("Details")).toBeTruthy();
 
     await user.click(matchButton);

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -12,6 +12,7 @@ import { SegmentedControl } from "@/components/ui/SegmentedControl";
 import { ChevronRightIcon } from "@/components/ui/icons";
 import { cn } from "@/lib/cn";
 import { MatchScoreboard } from "@/components/lol-profile/MatchScoreboard";
+import { PerformanceIndicator } from "@/components/lol-profile/PerformanceIndicator";
 import { useStaticData } from "@/components/lol-profile/StaticDataContext";
 import {
   formatCompactNumber,
@@ -291,7 +292,8 @@ function MatchHistoryCard({
           </div>
 
           <div className="match-snapshot-stats">
-            <div>
+            <div className="flex flex-col items-start gap-2 @min-[36rem]:items-end">
+              <PerformanceIndicator performance={match.performance} compact />
               <p className="text-xl font-semibold leading-tight tracking-tight text-fg tabular-nums">
                 <span>{match.kills}</span>
                 <span className="text-muted"> / </span>

--- a/apps/web/components/lol-profile/MatchScoreboard.test.tsx
+++ b/apps/web/components/lol-profile/MatchScoreboard.test.tsx
@@ -48,7 +48,22 @@ const DETAIL: MatchDetail = {
   queueType: "RANKED_SOLO_5x5",
   patch: "16.14",
   participants: [
-    participant({ puuid: "kronic", gameName: "Kronic", tagLine: "NA1" }),
+    participant({
+      puuid: "kronic",
+      gameName: "Kronic",
+      tagLine: "NA1",
+      performance: {
+        score: 8.7,
+        teamRank: 1,
+        teamSize: 5,
+        label: "ACE",
+        killParticipation: 0.72,
+        damageShare: 0.31,
+        goldShare: 0.24,
+        visionShare: 0.17,
+        csPerMin: 6.4
+      }
+    }),
     participant({
       puuid: "opponent",
       gameName: "Opponent",
@@ -57,7 +72,18 @@ const DETAIL: MatchDetail = {
       win: true,
       kills: 7,
       deaths: 2,
-      assists: 5
+      assists: 5,
+      performance: {
+        score: 9.2,
+        teamRank: 1,
+        teamSize: 5,
+        label: "MVP",
+        killParticipation: 0.78,
+        damageShare: 0.34,
+        goldShare: 0.27,
+        visionShare: 0.13,
+        csPerMin: 7.1
+      }
     })
   ],
   bans: [],
@@ -85,5 +111,7 @@ describe("MatchScoreboard", () => {
     expect(screen.getAllByRole("columnheader", { name: "Vision" })).toHaveLength(2);
     expect(screen.getAllByRole("columnheader", { name: "Gold" })).toHaveLength(2);
     expect(screen.getAllByLabelText("Summoner spells")).toHaveLength(2);
+    expect(screen.getByText("ACE")).toBeTruthy();
+    expect(screen.getByText("MVP")).toBeTruthy();
   });
 });

--- a/apps/web/components/lol-profile/PerformanceCard.tsx
+++ b/apps/web/components/lol-profile/PerformanceCard.tsx
@@ -4,6 +4,7 @@ import { LaneIcon } from "@/components/ui/LaneIcon";
 import { Stat } from "@/components/ui/Stat";
 import { cn } from "@/lib/cn";
 import { formatCompactNumber, formatGames, plural } from "@/lib/format";
+import { deriveRecentForm, type RecentFormTone } from "@/lib/matchPerformance";
 import { LANE_ROLES, roleDisplayLabel } from "@/lib/roles";
 
 import {
@@ -23,6 +24,45 @@ type RoleRow = {
   avgKda: number;
   topChampion: string | null;
 };
+
+const FORM_TONE_CLASS: Record<RecentFormTone, string> = {
+  up: "border-success/30 bg-success/8 text-success",
+  steady: "border-border bg-surface-2/60 text-fg/78",
+  down: "border-loss/30 bg-loss/8 text-loss"
+};
+
+const FORM_TEXT_CLASS: Record<RecentFormTone, string> = {
+  up: "text-success",
+  steady: "text-muted",
+  down: "text-loss"
+};
+
+function FormDirectionIcon({ tone }: { tone: RecentFormTone }) {
+  if (tone === "steady") {
+    return (
+      <svg viewBox="0 0 16 16" className="size-4" aria-hidden="true">
+        <path d="M3 8h10" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className={cn("size-4", tone === "down" && "rotate-90")}
+      aria-hidden="true"
+    >
+      <path
+        d="M3 11 11 3m-5 0h5v5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
 
 function formatStat(value: number | null | undefined, decimals: number): string {
   if (value == null || !Number.isFinite(value)) return "—";
@@ -107,8 +147,9 @@ export function PerformanceCard({
 
   const hasRoles = roleRows.length > 0;
   const hasAverages = overviewStats != null;
+  const recentForm = deriveRecentForm(matches);
   const coverageLabel = formatHistoryCoverage(fullHistory);
-  if (!hasRoles && !hasAverages) return null;
+  if (!hasRoles && !hasAverages && !recentForm) return null;
 
   return (
     <Card className="profile-section-card p-5">
@@ -116,6 +157,32 @@ export function PerformanceCard({
         <p className="type-kicker text-muted">{activeSeason?.displayName ?? "Active season"} · Solo/Duo</p>
         <h2 className="mt-2 type-section">How you play</h2>
       </div>
+
+      {recentForm ? (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-control border border-border/75 bg-surface-2/45 px-3 py-2.5">
+          <div className="flex items-center gap-2.5">
+            <span
+              className={cn(
+                "grid size-8 shrink-0 place-items-center rounded-control border",
+                FORM_TONE_CLASS[recentForm.tone]
+              )}
+            >
+              <FormDirectionIcon tone={recentForm.tone} />
+            </span>
+            <div>
+              <p className="type-overline text-muted">Recent form</p>
+              <p className="text-sm font-semibold text-fg">{recentForm.label}</p>
+            </div>
+          </div>
+          <div className="text-right tabular-nums">
+            <p className="text-sm font-semibold text-fg">{recentForm.recentAverage.toFixed(1)} impact</p>
+            <p className={cn("type-caption", FORM_TEXT_CLASS[recentForm.tone])}>
+              {recentForm.delta >= 0 ? "+" : ""}
+              {recentForm.delta.toFixed(1)} vs previous {recentForm.previousGames}
+            </p>
+          </div>
+        </div>
+      ) : null}
 
       {hasAverages ? (
         <div className="mt-4 grid gap-2">

--- a/apps/web/components/lol-profile/PerformanceIndicator.tsx
+++ b/apps/web/components/lol-profile/PerformanceIndicator.tsx
@@ -1,0 +1,57 @@
+import { cn } from "@/lib/cn";
+
+import type { MatchPerformance } from "@/components/lol-profile/shared";
+
+const LABEL_CLASS: Record<string, string> = {
+  MVP: "border-tier-s/40 bg-tier-s/12 text-tier-s",
+  ACE: "border-info/40 bg-info/10 text-info"
+};
+
+function percentage(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+export function performanceExplanation(performance: MatchPerformance): string {
+  const rank = `Team rank ${performance.teamRank} of ${performance.teamSize}`;
+  const inputs = [
+    `${percentage(performance.killParticipation)} kill participation`,
+    `${percentage(performance.damageShare)} damage share`,
+    `${percentage(performance.visionShare)} vision share`,
+    `${performance.csPerMin.toFixed(1)} CS/min`
+  ].join(", ");
+  return `${rank}. ${performance.score.toFixed(1)} impact score from team-relative combat, economy, vision, farm, and survival. ${inputs}.`;
+}
+
+export function PerformanceIndicator({
+  performance,
+  compact = false,
+  className
+}: {
+  performance?: MatchPerformance | null;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (!performance || !Number.isFinite(performance.score) || performance.teamSize < 2) return null;
+
+  const label = performance.label ?? `#${performance.teamRank} team`;
+  const labelClass = performance.label
+    ? LABEL_CLASS[performance.label] ?? "border-border-strong bg-surface-2 text-fg"
+    : "border-border/80 bg-surface-2/70 text-fg/78";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex w-fit items-center rounded-control border font-semibold tabular-nums",
+        compact ? "gap-1 px-1.5 py-0.5 type-caption" : "gap-1.5 px-2 py-1 text-xs",
+        labelClass,
+        className
+      )}
+      title={performanceExplanation(performance)}
+      aria-label={`${label}, ${performance.score.toFixed(1)} impact score. ${performanceExplanation(performance)}`}
+      data-testid="performance-indicator"
+    >
+      <span>{label}</span>
+      <span className="opacity-75">{performance.score.toFixed(1)}</span>
+    </span>
+  );
+}

--- a/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
+++ b/apps/web/components/lol-profile/ScoreboardTeamTable.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { ParticipantRuneCard } from "@/components/lol-profile/ParticipantRuneCard";
+import { PerformanceIndicator } from "@/components/lol-profile/PerformanceIndicator";
 import { useStaticData } from "@/components/lol-profile/StaticDataContext";
 import { TableScroll, Table, Th, Td } from "@/components/ui/Table";
 import { Tooltip } from "@/components/ui/Tooltip";
@@ -171,7 +172,10 @@ function ScoreboardRow({
                 {displayName}
               </p>
             )}
-            <p className="type-caption text-muted">{roleDisplayLabel(normalizeRoleKey(participant.teamPosition))}</p>
+            <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+              <p className="type-caption text-muted">{roleDisplayLabel(normalizeRoleKey(participant.teamPosition))}</p>
+              <PerformanceIndicator performance={participant.performance} compact />
+            </div>
           </div>
         </div>
       </Td>

--- a/apps/web/components/lol-profile/shared.ts
+++ b/apps/web/components/lol-profile/shared.ts
@@ -155,6 +155,18 @@ export type MatchRuneDetail = {
   statShards: number[];
 };
 
+export type MatchPerformance = {
+  score: number;
+  teamRank: number;
+  teamSize: number;
+  label?: string | null;
+  killParticipation: number;
+  damageShare: number;
+  goldShare: number;
+  visionShare: number;
+  csPerMin: number;
+};
+
 export type MatchSummary = {
   matchId: string;
   matchDate: number;
@@ -174,6 +186,7 @@ export type MatchSummary = {
   summonerSpell2Id: number;
   items: number[];
   runesDetail: MatchRuneDetail;
+  performance?: MatchPerformance | null;
 };
 
 export type PagedResultDto<T> = {
@@ -219,6 +232,7 @@ export type MatchDetail = {
     summonerSpell2Id: number;
     items: number[];
     runes: MatchRuneDetail;
+    performance?: MatchPerformance | null;
   }>;
   bans?: Array<{ teamId: number; bannedChampionIds: number[] }>;
   objectives?: MatchTeamObjectives[];

--- a/apps/web/lib/matchPerformance.test.ts
+++ b/apps/web/lib/matchPerformance.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveRecentForm } from "@/lib/matchPerformance";
+import type { MatchSummary } from "@/components/lol-profile/shared";
+
+function match(matchDate: number, score: number): Pick<MatchSummary, "matchDate" | "performance"> {
+  return {
+    matchDate,
+    performance: {
+      score,
+      teamRank: 1,
+      teamSize: 5,
+      label: null,
+      killParticipation: 0.5,
+      damageShare: 0.2,
+      goldShare: 0.2,
+      visionShare: 0.2,
+      csPerMin: 6
+    }
+  };
+}
+
+describe("deriveRecentForm", () => {
+  it("requires at least eight scored games", () => {
+    expect(deriveRecentForm(Array.from({ length: 7 }, (_, index) => match(index, 7)))).toBeNull();
+  });
+
+  it("ignores matches without enough teammates for a comparison", () => {
+    const matches = Array.from({ length: 10 }, (_, index) => {
+      const value = match(index, 7);
+      value.performance = { ...value.performance!, teamSize: 1 };
+      return value;
+    });
+
+    expect(deriveRecentForm(matches)).toBeNull();
+  });
+
+  it("compares the latest five games with the previous sample by date", () => {
+    const matches = [
+      ...Array.from({ length: 5 }, (_, index) => match(10 - index, 8)),
+      ...Array.from({ length: 5 }, (_, index) => match(5 - index, 6))
+    ];
+
+    expect(deriveRecentForm(matches)).toMatchObject({
+      tone: "up",
+      label: "Trending up",
+      recentAverage: 8,
+      previousAverage: 6,
+      delta: 2,
+      recentGames: 5,
+      previousGames: 5
+    });
+  });
+
+  it("treats changes under half a point as steady", () => {
+    const matches = [
+      ...Array.from({ length: 5 }, (_, index) => match(10 - index, 7.2)),
+      ...Array.from({ length: 5 }, (_, index) => match(5 - index, 7))
+    ];
+
+    expect(deriveRecentForm(matches)?.tone).toBe("steady");
+  });
+
+  it("reports a downward trajectory", () => {
+    const matches = [
+      ...Array.from({ length: 5 }, (_, index) => match(10 - index, 5.5)),
+      ...Array.from({ length: 5 }, (_, index) => match(5 - index, 7.5))
+    ];
+
+    expect(deriveRecentForm(matches)?.tone).toBe("down");
+  });
+});

--- a/apps/web/lib/matchPerformance.ts
+++ b/apps/web/lib/matchPerformance.ts
@@ -1,0 +1,74 @@
+import type { MatchSummary } from "@/components/lol-profile/shared";
+
+export type RecentFormTone = "up" | "steady" | "down";
+
+export type RecentForm = {
+  tone: RecentFormTone;
+  label: string;
+  recentAverage: number;
+  previousAverage: number;
+  delta: number;
+  recentGames: number;
+  previousGames: number;
+};
+
+function average(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+// Compares the latest five scored games with up to five games immediately before
+// them. Eight games are required so a single prior result never becomes a trend.
+export function deriveRecentForm(
+  matches: Array<Pick<MatchSummary, "matchDate" | "performance">>
+): RecentForm | null {
+  const scores = matches
+    .filter((match) =>
+      Number.isFinite(match.performance?.score) &&
+      (match.performance?.teamSize ?? 0) >= 2
+    )
+    .sort((a, b) => b.matchDate - a.matchDate)
+    .slice(0, 10)
+    .map((match) => match.performance?.score as number);
+
+  if (scores.length < 8) return null;
+
+  const recent = scores.slice(0, 5);
+  const previous = scores.slice(5);
+  const recentAverage = average(recent);
+  const previousAverage = average(previous);
+  const delta = recentAverage - previousAverage;
+
+  if (delta >= 0.5) {
+    return {
+      tone: "up",
+      label: "Trending up",
+      recentAverage,
+      previousAverage,
+      delta,
+      recentGames: recent.length,
+      previousGames: previous.length
+    };
+  }
+
+  if (delta <= -0.5) {
+    return {
+      tone: "down",
+      label: "Trending down",
+      recentAverage,
+      previousAverage,
+      delta,
+      recentGames: recent.length,
+      previousGames: previous.length
+    };
+  }
+
+  return {
+    tone: "steady",
+    label: "Holding steady",
+    recentAverage,
+    previousAverage,
+    delta,
+    recentGames: recent.length,
+    previousGames: previous.length
+  };
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -88,6 +88,17 @@ Profile responses include additional season/history metadata:
 - `championId` (optional; filters before pagination)
 - Responses include stable `facets.queues` and `facets.championIds` collected across the summoner's
   full stored history, independent of the current page and active filters.
+- Each match includes `performance`, a team-relative impact readout:
+  - `score` is a deterministic `1.0` to `10.0` weighted percentile score within that match and team
+  - `teamRank` / `teamSize` make the comparison scope explicit
+  - `label` is `MVP` for the top-ranked player on the winning team, `ACE` for the top-ranked player on
+    the losing team, and `null` otherwise
+  - `killParticipation`, `damageShare`, `goldShare`, `visionShare`, and `csPerMin` expose the real
+    inputs used for UI explanations
+  - weights are kill participation 30%, champion damage 25%, vision 15%, gold 10%, farm 10%, and
+    survival 10%; each input is percentile-ranked within the participant's team before weighting
+  - the score is computed from existing participant rows when the cached recent-history response is
+    built. It does not require a migration, stored label, or background precomputation.
 
 `GET /api/lol/summoners/search` supports:
 - `region` (required; platform route or alias such as `NA1` or `na`)
@@ -116,6 +127,8 @@ Stats and profile read surfaces now fail closed on backend errors:
   - `queueId` is included alongside `queueType`
 - `GET /api/lol/summoners/{summonerId}/matches/{matchId}`
   - Participant runes continue to return full selections (`primarySelections`, `subSelections`, `statShards`)
+  - Every participant includes the same `performance` readout used by recent history, allowing the
+    expanded scoreboard to show team rank and MVP/ACE labels without a second scoring implementation.
   - Match payload includes `queueId` and `queueType`
 
 #### Refresh Priority Behavior

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -8290,6 +8290,58 @@
         },
         "additionalProperties": false
       },
+      "MatchPerformanceSummary": {
+        "required": [
+          "csPerMin",
+          "damageShare",
+          "goldShare",
+          "killParticipation",
+          "score",
+          "teamRank",
+          "teamSize",
+          "visionShare"
+        ],
+        "type": "object",
+        "properties": {
+          "score": {
+            "type": "number",
+            "format": "double"
+          },
+          "teamRank": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "teamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "killParticipation": {
+            "type": "number",
+            "format": "double"
+          },
+          "damageShare": {
+            "type": "number",
+            "format": "double"
+          },
+          "goldShare": {
+            "type": "number",
+            "format": "double"
+          },
+          "visionShare": {
+            "type": "number",
+            "format": "double"
+          },
+          "csPerMin": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
       "MatchRuneDetailDto": {
         "required": [
           "primarySelections",
@@ -8802,6 +8854,7 @@
           "kills",
           "magicDamageDealtToChampions",
           "neutralMinionsKilled",
+          "performance",
           "physicalDamageDealtToChampions",
           "runes",
           "summonerSpell1Id",
@@ -8909,6 +8962,13 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/ParticipantRunesDto"
+              }
+            ]
+          },
+          "performance": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MatchPerformanceSummary"
               }
             ]
           }
@@ -9593,6 +9653,7 @@
           "kills",
           "matchDate",
           "matchId",
+          "performance",
           "queueId",
           "queueType",
           "runes",
@@ -9683,6 +9744,13 @@
             "allOf": [
               {
                 "$ref": "#/components/schemas/MatchRuneDetailDto"
+              }
+            ]
+          },
+          "performance": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MatchPerformanceSummary"
               }
             ]
           }

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -5364,6 +5364,25 @@ export interface components {
             queueType: string;
             queueFamily: string;
         };
+        MatchPerformanceSummary: {
+            /** Format: double */
+            score: number;
+            /** Format: int32 */
+            teamRank: number;
+            /** Format: int32 */
+            teamSize: number;
+            label?: string | null;
+            /** Format: double */
+            killParticipation: number;
+            /** Format: double */
+            damageShare: number;
+            /** Format: double */
+            goldShare: number;
+            /** Format: double */
+            visionShare: number;
+            /** Format: double */
+            csPerMin: number;
+        };
         MatchRuneDetailDto: {
             /** Format: int32 */
             primaryStyleId: number;
@@ -5542,6 +5561,7 @@ export interface components {
             summonerSpell2Id: number;
             items: number[];
             runes: components["schemas"]["ParticipantRunesDto"];
+            performance: components["schemas"]["MatchPerformanceSummary"];
         };
         ParticipantRunesDto: {
             /** Format: int32 */
@@ -5777,6 +5797,7 @@ export interface components {
             items: number[];
             runes: components["schemas"]["MatchRuneSummaryDto"];
             runesDetail: components["schemas"]["MatchRuneDetailDto"];
+            performance: components["schemas"]["MatchPerformanceSummary"];
         };
         RecentMatchSummaryDtoPagedResultDto: {
             items: components["schemas"]["RecentMatchSummaryDto"][];

--- a/tests/Transcendence.Service.Core.Tests/MatchPerformanceScorerTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/MatchPerformanceScorerTests.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using Transcendence.Service.Core.Services.Analysis;
+
+namespace Transcendence.Service.Core.Tests;
+
+public class MatchPerformanceScorerTests
+{
+    [Fact]
+    public void Score_LabelsTheTopWinningTeammateMvp()
+    {
+        var carry = Player(win: true, kills: 14, deaths: 2, assists: 9, damage: 34000, gold: 16500, vision: 22, cs: 270);
+        var inputs = new[]
+        {
+            carry,
+            Player(win: true, kills: 3, deaths: 5, assists: 8, damage: 13000, gold: 10500, vision: 18, cs: 150),
+            Player(win: true, kills: 2, deaths: 4, assists: 15, damage: 11000, gold: 9800, vision: 45, cs: 35),
+            Player(win: true, kills: 5, deaths: 6, assists: 7, damage: 19000, gold: 12000, vision: 16, cs: 190),
+            Player(win: true, kills: 4, deaths: 4, assists: 10, damage: 17000, gold: 11800, vision: 20, cs: 175)
+        };
+
+        var result = MatchPerformanceScorer.Score(inputs);
+
+        result[carry.ParticipantId].Label.Should().Be("MVP");
+        result[carry.ParticipantId].TeamRank.Should().Be(1);
+        result[carry.ParticipantId].TeamSize.Should().Be(5);
+        result[carry.ParticipantId].Score.Should().BeInRange(1, 10);
+    }
+
+    [Fact]
+    public void Score_LabelsTheTopLosingTeammateAce()
+    {
+        var standout = Player(win: false, kills: 8, deaths: 3, assists: 12, damage: 28000, gold: 14500, vision: 31, cs: 220);
+        var inputs = new[]
+        {
+            standout,
+            Player(win: false, kills: 1, deaths: 8, assists: 4, damage: 9000, gold: 9200, vision: 15, cs: 130),
+            Player(win: false, kills: 2, deaths: 7, assists: 7, damage: 12000, gold: 9800, vision: 38, cs: 30),
+            Player(win: false, kills: 3, deaths: 9, assists: 5, damage: 15000, gold: 10500, vision: 13, cs: 160),
+            Player(win: false, kills: 2, deaths: 6, assists: 6, damage: 13000, gold: 10100, vision: 18, cs: 145)
+        };
+
+        var result = MatchPerformanceScorer.Score(inputs);
+
+        result[standout.ParticipantId].Label.Should().Be("ACE");
+        result[standout.ParticipantId].TeamRank.Should().Be(1);
+    }
+
+    [Fact]
+    public void Score_AllowsVisionAndParticipationToOffsetLowFarm()
+    {
+        var support = Player(
+            win: true,
+            kills: 2,
+            deaths: 1,
+            assists: 25,
+            damage: 17500,
+            gold: 9500,
+            vision: 82,
+            cs: 28);
+        var farmLeader = Player(
+            win: true,
+            kills: 6,
+            deaths: 7,
+            assists: 5,
+            damage: 24000,
+            gold: 15800,
+            vision: 12,
+            cs: 305);
+        var inputs = new[]
+        {
+            support,
+            farmLeader,
+            Player(win: true, kills: 5, deaths: 5, assists: 8, damage: 21000, gold: 13200, vision: 18, cs: 210),
+            Player(win: true, kills: 4, deaths: 6, assists: 9, damage: 19000, gold: 12400, vision: 20, cs: 185),
+            Player(win: true, kills: 3, deaths: 4, assists: 11, damage: 18000, gold: 11700, vision: 25, cs: 165)
+        };
+
+        var result = MatchPerformanceScorer.Score(inputs);
+
+        result[support.ParticipantId].TeamRank.Should().BeLessThan(result[farmLeader.ParticipantId].TeamRank);
+        result[support.ParticipantId].KillParticipation.Should().BeGreaterThan(0.8);
+        result[support.ParticipantId].VisionShare.Should().BeGreaterThan(0.5);
+    }
+
+    [Fact]
+    public void Score_ReturnsNeutralFiniteResultForASingleParticipant()
+    {
+        var participant = Player(win: true);
+
+        var result = MatchPerformanceScorer.Score([participant])[participant.ParticipantId];
+
+        result.Score.Should().Be(5.5);
+        result.TeamRank.Should().Be(1);
+        result.TeamSize.Should().Be(1);
+        result.Label.Should().BeNull();
+    }
+
+    private static MatchPerformanceScorer.Input Player(
+        bool win,
+        int kills = 5,
+        int deaths = 5,
+        int assists = 5,
+        int damage = 15000,
+        int gold = 12000,
+        int vision = 20,
+        int cs = 180) =>
+        new(
+            Guid.Empty,
+            Guid.NewGuid(),
+            TeamId: 100,
+            win,
+            kills,
+            deaths,
+            assists,
+            gold,
+            damage,
+            vision,
+            cs,
+            DurationSeconds: 1800);
+}

--- a/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/SummonerStatsServiceTests.cs
@@ -145,6 +145,11 @@ public class SummonerStatsServiceTests
         result.TotalCount.Should().Be(2);
         result.Items.Should().OnlyContain(x => x.QueueId == 420 || x.QueueType == "420");
         result.Items.Should().OnlyContain(x => x.Items.Count == 7);
+        result.Items.Should().OnlyContain(x =>
+            x.Performance.Score == 5.5 &&
+            x.Performance.TeamRank == 1 &&
+            x.Performance.TeamSize == 1 &&
+            x.Performance.Label == null);
         result.Facets!.Queues.Should().HaveCount(3);
         result.Facets.ChampionIds.Should().HaveCount(2);
 
@@ -336,6 +341,8 @@ public class SummonerStatsServiceTests
         detail.Participants[0].Runes.PrimarySelections.Should().Equal([8005, 9111]);
         detail.Participants[0].Runes.SubSelections.Should().Equal([8473]);
         detail.Participants[0].Runes.StatShards.Should().Equal([5008]);
+        detail.Participants[0].Performance.Score.Should().Be(5.5);
+        detail.Participants[0].Performance.Label.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

- Adds a deterministic team-impact scorer for every stored match participant.
- Exposes a 1–10 score, team rank, MVP/ACE label, and the underlying kill-participation, damage, gold, vision, and farm values on recent history and match-detail responses.
- Shows compact performance indicators on collapsed match cards and expanded scoreboard rows.
- Adds a recent-form readout that compares the latest five scored games with the preceding sample, with an eight-game minimum.
- Regenerates the OpenAPI contract and TypeScript client, documents the scoring formula, and versions affected cache keys.

## Why

The profile had real post-game stats but no immediate answer to how the player performed relative to their teammates. This adds an OP.GG-style signal without treating KDA as the whole story or persisting a formula-derived label that could become stale.

The score is calculated when the cached match-history response is built. It percentile-ranks each input within the participant's match and team, then weights kill participation 30%, champion damage 25%, vision 15%, gold 10%, farm 10%, and survival 10%. The top winning teammate is labeled MVP; the top losing teammate is labeled ACE.

## Validation

- Service Core: 314 tests passed
- Web API: 70 tests passed
- PostgreSQL integration: 28 tests passed
- Frontend: lint passed
- Frontend: 211 tests passed
- Frontend: production build passed
- Browser QA at 390px, 1280px, and 1440px against real live match details; no horizontal overflow or console errors