### PR TITLE
Prevent competing app deployers

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -77,6 +77,8 @@ services:
       context: .
       dockerfile: apps/web/Dockerfile
     container_name: transcendence-web
+    labels:
+      wud.watch: "false"
     restart: unless-stopped
     cpus: "${WEB_CPUS:-2.0}"
     mem_limit: "${WEB_MEMORY_LIMIT:-1g}"
@@ -120,6 +122,8 @@ services:
       context: .
       dockerfile: Transcendence.WebAPI/Dockerfile
     container_name: transcendence-webapi
+    labels:
+      wud.watch: "false"
     restart: unless-stopped
     cpus: "${WEBAPI_CPUS:-4.0}"
     mem_limit: "${WEBAPI_MEMORY_LIMIT:-2g}"
@@ -170,6 +174,8 @@ services:
       context: .
       dockerfile: Transcendence.Service/Dockerfile
     container_name: transcendence-service
+    labels:
+      wud.watch: "false"
     restart: unless-stopped
     cpus: "${SERVICE_CPUS:-8.0}"
     mem_limit: "${SERVICE_MEMORY_LIMIT:-6g}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -326,7 +326,8 @@ recreated with `--pull never`. The failed digest remains quarantined until `:mai
 failure aborts later components in that poll cycle. PostgreSQL and Redis are never recreated by the poller.
 
 **wud is retired for the app containers** (wud 8.2.2 silently failed to resolve the GHCR digest for
-these packages); it may still linger in the stack but does not deploy `web`/`webapi`/`service`.
+these packages); it may still linger in the stack for sidecars, but Compose pins `wud.watch=false`
+on `web`, `webapi`, and `service` so it cannot race the systemd poller during a release.
 Hot-table index migrations remain the exception and must be applied out-of-band before deployment
 (see DEVELOPMENT.md); the CI `migration-apply` job additionally applies the full chain to ephemeral
 PostgreSQL on every PR.

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -64,9 +64,9 @@ The automatic rollback protects single-service replacement failures. Break-glass
 pin a service to an immutable `:sha-<short>` tag in the compose file and `compose up -d` it (see
 `docs/ARCHITECTURE.md` "Deployment & rollback").
 
-> If wud's app-container watching is ever wanted back, note it is unreliable here; this
-> poller is the source of truth. wud still works fine for the public Docker Hub
-> sidecars (portainer/dozzle/grafana/prometheus).
+> The app Compose services explicitly set `wud.watch=false`; keep that exclusion in place because
+> this poller is the app release source of truth and two independent recreators can race each other.
+> wud may continue watching public Docker Hub sidecars (portainer/dozzle/grafana/prometheus).
 
 ## `install-matchup-performance-db.sql` — online matchup source preparation
 


### PR DESCRIPTION
## What changed

- Add `wud.watch=false` to the web, WebAPI, and worker Compose services.
- Document the systemd digest poller as the sole app release mechanism while retaining wud for sidecars.

## Why

During the PR #142 production rollout, wud detected the same new GHCR images as the systemd poller and independently removed/recreated the worker and API. The two deployers raced, leaving Compose with a partially renamed worker container. The poller aborted later services as designed, but the app services need an explicit watcher exclusion so this cannot recur.

## Production impact

The exclusion has already been applied to the production Portainer Compose definition. The worker, API, and web containers were recreated sequentially with the label present and all passed health checks. This PR brings source control back in sync with production.

## Validation

- `docker compose -f compose.yml config -q`
- `bash -n scripts/ops/poll-deploy.sh`
- `git diff --check`
- Live production labels verified as `wud.watch=false` on all three app containers
- Manual poller run completed successfully with no changes
- Public API readiness and web health endpoints pass