### PR TITLE
Guard the recurring Build Lab promote job on Enabled

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
@@ -125,6 +125,12 @@ public sealed class BuildLabGenerationCoordinator(
 
     public async Task<int> PromoteReadyCandidatesAsync(CancellationToken ct = default)
     {
+        // The recurring schedule flag and Analytics:BuildLab:Enabled are separate keys and prod has
+        // been observed with them diverged, so the recurring path guards on Enabled itself. The
+        // operator-driven PromoteCandidateAsync deliberately stays reachable for shadow validation.
+        if (!options.Enabled)
+            return 0;
+
         await ReapExpiredModelingLeasesAsync(ct);
 
         var candidates = await context.BuildLabGenerations

--- a/tests/Transcendence.Service.Core.Tests/BuildLabGenerationCoordinatorTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/BuildLabGenerationCoordinatorTests.cs
@@ -218,6 +218,40 @@ public sealed class BuildLabGenerationCoordinatorTests
     }
 
     [Fact]
+    public async Task PromoteReadyCandidatesAsync_WhenDisabled_NeitherReapsNorPromotes()
+    {
+        await using var harness = await BuildLabHarness.CreateAsync();
+        var now = DateTime.UtcNow;
+        // Prod has been observed with the recurring-schedule flag true while Analytics:BuildLab:Enabled
+        // was false, so the recurring path must be inert on its own rather than trusting the schedule.
+        var expired = Candidate();
+        expired.Status = BuildLabGenerationStatus.Modeling;
+        expired.LeaseOwner = "modeler-1";
+        expired.LeaseAcquiredAtUtc = now.AddHours(-4);
+        expired.LeaseExpiresAtUtc = now.AddMinutes(-5);
+        var candidate = Candidate();
+        harness.Db.BuildLabGenerations.AddRange(expired, candidate);
+        harness.Db.AdjustedActionEstimates.Add(PassingEstimate(candidate.Id));
+        await harness.Db.SaveChangesAsync();
+        using var telemetry = new BuildLabTelemetry();
+        var coordinator = Coordinator(harness, telemetry, new BuildLabModelingOptions
+        {
+            Enabled = false,
+            LeaseTimeoutMinutes = 120
+        });
+
+        var promoted = await coordinator.PromoteReadyCandidatesAsync();
+
+        promoted.Should().Be(0);
+        var untouchedLease = await Reload(harness, expired.Id);
+        untouchedLease.Status.Should().Be(BuildLabGenerationStatus.Modeling);
+        untouchedLease.LeaseOwner.Should().Be("modeler-1");
+        var untouchedCandidate = await Reload(harness, candidate.Id);
+        untouchedCandidate.Status.Should().Be(BuildLabGenerationStatus.Candidate);
+        untouchedCandidate.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task PromoteReadyCandidatesAsync_ContinuesPastOneCandidatesFailure()
     {
         // The harness deliberately withholds the SQLite shim for the PostgreSQL advisory-lock statement


### PR DESCRIPTION
## Why

The recurring promote job called `ReapExpiredModelingLeasesAsync` before any feature check, so it ran every 10 minutes regardless of `Analytics:BuildLab:Enabled`. That was left as a deliberate asymmetry, on the assumption that the schedule flag and the feature flag move together.

Production disproves the assumption. The deployed worker currently reports:

```
Jobs__Schedule__EnableCreateBuildLabGeneration=true
Jobs__Schedule__EnablePromoteBuildLabGeneration=true
Analytics__BuildLab__Enabled=false
```

`compose.yml` derives all three from `${BUILD_LAB_ENABLED:-false}`, but the Portainer stack's environment does not — so the schedule flags and the feature flag have diverged in the live stack. The reap `UPDATE` and candidate `SELECT` were executing on a deployment where the feature is off.

## What

- `PromoteReadyCandidatesAsync` returns early when `options.Enabled` is false.
- `PromoteCandidateAsync` (the operator/admin path) is untouched, so a manual shadow-validation promote is still reachable with the feature off.
- One regression test pins that a disabled deployment neither reaps an expired lease nor promotes a ready candidate.

## Verification

- `dotnet build` — 0 warnings, 0 errors
- 416 service / 145 API / 28 integration tests pass, 0 skipped

## Follow-up not in this PR

The underlying config drift is in the Portainer stack, not the repo. Worth reconciling the stack's environment with `compose.yml` so the schedule flags derive from `BUILD_LAB_ENABLED` again.