### PR TITLE
Keep crawlers off the Build Lab soft-404 while the flag is off

### DIFF
--- a/apps/web/app/robots.test.ts
+++ b/apps/web/app/robots.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import robots from "./robots";
+
+const connection = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("next/server", () => ({ connection }));
+
+afterEach(() => {
+  connection.mockClear();
+  vi.unstubAllEnvs();
+});
+
+describe("robots", () => {
+  it("keeps crawlers off the Build Lab soft-404 while the flag is off", async () => {
+    vi.stubEnv("TRN_FEATURE_BUILD_LAB", "false");
+
+    const rules = (await robots()).rules as { disallow: string[] };
+
+    // The routes call notFound(), but `cacheComponents` commits the prerendered shell first, so a
+    // disabled deployment answers 200 with not-found content. That must not get indexed.
+    expect(rules.disallow).toContain("/lol/builds");
+  });
+
+  it("allows the Build Lab once the flag is on but never the share links", async () => {
+    vi.stubEnv("TRN_FEATURE_BUILD_LAB", "true");
+
+    const rules = (await robots()).rules as { disallow: string[] };
+
+    expect(rules.disallow).not.toContain("/lol/builds");
+    // A share link is a capability URL: revoking it cannot un-index it.
+    expect(rules.disallow).toContain("/lol/builds/shared/");
+  });
+
+  it("keeps the pre-existing private surfaces disallowed in both flag states", async () => {
+    for (const flag of ["false", "true"]) {
+      vi.stubEnv("TRN_FEATURE_BUILD_LAB", flag);
+
+      const rules = (await robots()).rules as { disallow: string[] };
+
+      expect(rules.disallow).toEqual(
+        expect.arrayContaining(["/admin/", "/api/", "/favorites", "/login"])
+      );
+    }
+  });
+});

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,16 +1,29 @@
 import type { MetadataRoute } from "next";
 
+import { analyticsFeatureFlags } from "@/lib/analyticsFeatureFlags";
 import { getPublicSiteOrigin } from "@/lib/env";
 
-export default function robots(): MetadataRoute.Robots {
+export default async function robots(): Promise<MetadataRoute.Robots> {
   const origin = getPublicSiteOrigin();
+  // The Build Lab routes call notFound() when the rollout flag is off, but `cacheComponents`
+  // commits the prerendered shell before that runs, so a disabled deployment answers 200 with
+  // not-found content. Keep crawlers off the soft-404 until the flag is on rather than letting
+  // them index it.
+  const { buildLab } = await analyticsFeatureFlags();
   return {
     rules: {
       userAgent: "*",
       allow: "/",
       // Shared-build links are capability URLs: revoking one cannot un-index it, so they must
       // never be crawled in the first place.
-      disallow: ["/admin/", "/api/", "/favorites", "/login", "/lol/builds/shared/"]
+      disallow: [
+        "/admin/",
+        "/api/",
+        "/favorites",
+        "/login",
+        "/lol/builds/shared/",
+        ...(buildLab ? [] : ["/lol/builds"])
+      ]
     },
     sitemap: `${origin}/sitemap.xml`,
     host: origin


### PR DESCRIPTION
## Why

The Build Lab routes call `notFound()` when `TRN_FEATURE_BUILD_LAB` is off, but under `nextConfig.cacheComponents` the prerendered shell commits a `200` before the dynamic flag read runs. So a disabled deployment answers **HTTP 200 with not-found content**.

Verified against production:

| Path | Status | Body |
|---|---|---|
| `/lol/builds` | 200 | not-found UI |
| `/lol/builds/103` | 200 | not-found UI |
| `/definitely-not-a-real-page` | 404 | not-found UI |

So the soft-404 is specific to the flag-gated routes, not a site-wide problem.

## Why this fix and not a status-code fix

- `export const dynamic = "force-dynamic"` is **rejected** under `cacheComponents` (`Route segment config "dynamic" is not compatible with nextConfig.cacheComponents`). I tried it; the build fails.
- Gating in middleware would set a correct 404, but adds a request-path hop for every route on the site to fix a window that closes the moment the flag flips.

The flag-gating itself is already correct — `analyticsFeatureFlags()` uses `connection()`, so the read genuinely happens per-request and a container restart can flip it. The only wrong thing was that crawlers could index the soft-404.

## What

- `/lol/builds` is disallowed in `robots.txt` while the feature is off, and allowed once it is on.
- Shared-build capability URLs stay disallowed in **both** states.
- `/robots.txt` becomes a dynamic route, which is correct: it now depends on runtime container env rather than build-time constants.
- Three tests pin both flag states and the pre-existing private surfaces.

## Verification

- 283 web tests / 55 files pass
- lint clean, `tsc --noEmit` clean
- `next build` succeeds; `/robots.txt` correctly reports as `ƒ (Dynamic)`