### PR TITLE
Split the modeler image into pullable layers

### DIFF
--- a/analytics/modeler/Dockerfile
+++ b/analytics/modeler/Dockerfile
@@ -1,12 +1,40 @@
 FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 WORKDIR /app
+
+# The dependency install is deliberately split across several layers, and every pyproject dependency
+# must appear in exactly one of them — test_dockerfile_layers_cover_every_declared_dependency pins
+# that, because the project itself is installed with --no-deps below.
+#
+# Why: installing the whole scientific stack as one `pip install .` produced a single 567 MB layer.
+# The prod host runs the containerd image store on spinning disk, where extracting and committing a
+# layer that large outran the pull's lease and containerd GC'd it mid-commit — `docker pull` failed
+# with "lease does not exist" and left a half-populated image that could not resolve its platform.
+# Every image that pulls cleanly on that host has a largest layer under 20 MB. Keep these groups
+# roughly balanced; do not collapse them back together.
+#
+# --no-compile keeps shipped .pyc out of the layers: PYTHONDONTWRITEBYTECODE is set and the runtime
+# uid cannot write into site-packages, so that bytecode would never be reused anyway.
+RUN pip install --no-compile "numpy>=2.1,<3"
+RUN pip install --no-compile "pandas>=2.2,<3"
+RUN pip install --no-compile "scikit-learn>=1.6,<2" "joblib>=1.4,<2"
+RUN pip install --no-compile "pyarrow>=18,<21"
+RUN pip install --no-compile "boto3>=1.35,<2" "psycopg[binary]>=3.2,<4"
+
+# numpy/scipy/pandas ship their own test suites; nothing in this image runs them.
+RUN find /usr/local/lib/python3.12/site-packages -type d -name tests -prune -exec rm -rf {} + \
+ && find /usr/local/lib/python3.12/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
+
 COPY analytics/modeler/pyproject.toml ./
 COPY analytics/modeler/src ./src
-RUN pip install --no-cache-dir .
+# --no-deps: the layers above are the install plan. A dependency added to pyproject but not to those
+# layers fails the coverage test instead of silently landing in one oversized layer.
+RUN pip install --no-compile --no-deps .
 
 ENV PYTHONPATH=/app/src
 # /artifacts is the compose mount (BUILD_LAB_ARTIFACT_DIR) and a named volume, which Docker seeds

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -1204,6 +1205,34 @@ def test_first_item_path_estimates_publish_the_timing_the_champion_page_renders(
     # Without this family the champion page's first-item card renders "—" forever.
     assert timings["FIRST_ITEM_PATH"] == pytest.approx(8.75)
     assert all(timing is not None for timing in timings.values())
+
+
+def test_dockerfile_layers_cover_every_declared_dependency():
+    root = Path(__file__).resolve().parents[1]
+    dockerfile = (root / "Dockerfile").read_text(encoding="utf-8")
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+
+    declared = re.findall(r'^\s*"([A-Za-z0-9_.-]+)(?:\[[^\]]*\])?[<>=!~]', pyproject, re.MULTILINE)
+    installed = "\n".join(
+        line for line in dockerfile.splitlines() if line.startswith("RUN pip install")
+    )
+    # The project is installed with --no-deps, so anything missing from the split layers would be
+    # absent at runtime rather than merely mis-layered.
+    assert declared, "no dependencies parsed out of pyproject.toml"
+    missing = [name for name in declared if name not in installed]
+    assert not missing, f"pyproject deps absent from the Dockerfile install layers: {missing}"
+    assert "--no-deps" in dockerfile
+
+    # One oversized layer is what broke `docker pull` on the containerd image store: keep the
+    # scientific stack spread across separate RUN layers.
+    dependency_layers = [
+        line for line in dockerfile.splitlines()
+        if line.startswith("RUN pip install") and "--no-deps" not in line
+    ]
+    assert len(dependency_layers) >= 4, dependency_layers
+    for package in ("numpy", "pandas", "scikit-learn", "pyarrow"):
+        owning = [line for line in dependency_layers if package in line]
+        assert len(owning) == 1, f"{package} must be installed in exactly one layer: {owning}"
 
 
 def test_the_image_prepares_the_artifact_volume_for_the_runtime_uid(monkeypatch):


### PR DESCRIPTION
## What was going on

`docker pull` of the modeler image failed on the prod host with `lease does not exist: not found`, then "succeeded" but left an image that could not resolve its platform, then failed again committing the attestation sub-manifest. I worked around it by pulling the amd64 manifest **by digest** and pinning the tag locally — which takes the modeler off the poll-deploy path entirely. That was treating symptoms.

**The root cause is ours.** `RUN pip install .` put the whole scientific stack in a single layer:

```
567MB  RUN /bin/sh -c pip install --no-cache-dir .     <-- modeler
 19MB  (largest layer)                                 <-- webapi, pulls fine
```

The prod host runs the **containerd image store** (`driver-type: io.containerd.snapshotter.v1`) on spinning disk. Extracting and committing a 567 MB layer outran the pull's lease, and containerd GC'd it mid-commit. Nothing to do with the registry, the attestations, or multi-arch — every image that pulls cleanly on that host has a largest layer under 20 MB.

## Changes

- Dependency install split across **five** `RUN` layers so no single layer holds the whole stack.
- `--no-compile` plus stripping vendored test suites and `__pycache__`. `PYTHONDONTWRITEBYTECODE` is set and the runtime uid cannot write into `site-packages`, so that bytecode was never reused — it was pure layer weight.
- The project installs with `--no-deps`, making the split layers the actual install plan rather than a duplicate of it.
- Two properties pinned in tests: every `pyproject` dependency must appear in the layers (with `--no-deps`, a missing one is absent at runtime, not just mis-layered), and `numpy`/`pandas`/`scikit-learn`/`pyarrow` must each live in exactly one layer.

## Verification

- 53 modeler tests pass.
- The image itself is built by CI — the local sandbox has no DNS, so `pip` cannot resolve `files.pythonhosted.org`. The `build (analytics-modeler, …)` job is the real check.

## Follow-up once published

Prod is currently pinned to a digest with `pull_policy: missing`. After this image lands, drop the pin and restore `pull_policy: always` so poll-deploy manages the modeler like every other service.