### PR TITLE
Make the Build Lab palette test deterministic

### DIFF
--- a/apps/web/components/GlobalCommandPalette.test.tsx
+++ b/apps/web/components/GlobalCommandPalette.test.tsx
@@ -129,10 +129,18 @@ describe("GlobalCommandPalette", () => {
 
     const input = await screen.findByRole("combobox", { name: "Global search input" });
     await user.type(input, "build");
+    // The point of the entry: Build Lab sits beside the library rather than replacing it. Both match
+    // "build" because each carries it in `keywords`.
     await screen.findByRole("option", { name: /Build Lab/i });
     expect(screen.getByRole("option", { name: /Build Atlas/i })).toBeTruthy();
 
-    await user.click(screen.getByRole("option", { name: /Build Lab/i }));
+    // Narrow to a single match before clicking. While two options match, cmdk re-filters as it
+    // re-renders, so a node queried before the click can already be detached when it lands — which
+    // fails on a slow runner and passes locally.
+    await user.clear(input);
+    await user.type(input, "build lab");
+    const buildLab = await screen.findByRole("option", { name: /Build Lab/i });
+    await user.click(buildLab);
     await waitFor(() => expect(router.push).toHaveBeenCalledWith("/lol/builds"));
   });
 


### PR DESCRIPTION
## Why

`GlobalCommandPalette.test.tsx > adds Build Lab beside the library once the flag is enabled` fails on CI and passes locally. It is currently blocking every PR — it failed on #147, which only touches `analytics/modeler/**`.

```
AssertionError: expected "vi.fn()" to be called with arguments: [ '/lol/builds' ]
Tests  1 failed | 282 passed (283)
```

Both `Build Lab` and `Build Atlas` carry `"builds"` in their `keywords`, so typing `"build"` leaves **two** matching options. cmdk re-filters as it re-renders, so the node queried before `user.click` can already be detached by the time the click lands, and `router.push` never receives `/lol/builds`. Locally the render settles fast enough to hide it; a slower runner does not.

## What

Keep both assertions — Build Lab appearing *beside* the library is the whole point of the case — then narrow the query to a single match before clicking.

## Verification

- 283 web tests / 55 files pass locally (ran 3× before the change to confirm it does not reproduce on this machine, which is why it reached main).

This is test-only; no production code changes.