### PR TITLE
Drop the cross-layer cleanup from the modeler image

### DIFF
--- a/analytics/modeler/Dockerfile
+++ b/analytics/modeler/Dockerfile
@@ -19,16 +19,16 @@ WORKDIR /app
 # roughly balanced; do not collapse them back together.
 #
 # --no-compile keeps shipped .pyc out of the layers: PYTHONDONTWRITEBYTECODE is set and the runtime
-# uid cannot write into site-packages, so that bytecode would never be reused anyway.
+# uid cannot write into site-packages, so that bytecode would never be reused anyway. It prevents
+# the files at creation time on purpose. Do NOT add a later layer that deletes files belonging to
+# an earlier one (vendored test suites, __pycache__ from the base image): that writes overlayfs
+# whiteouts across layers, and extracting them fails on this host with
+# "failed to Lchown ...: no such file or directory".
 RUN pip install --no-compile "numpy>=2.1,<3"
 RUN pip install --no-compile "pandas>=2.2,<3"
 RUN pip install --no-compile "scikit-learn>=1.6,<2" "joblib>=1.4,<2"
 RUN pip install --no-compile "pyarrow>=18,<21"
 RUN pip install --no-compile "boto3>=1.35,<2" "psycopg[binary]>=3.2,<4"
-
-# numpy/scipy/pandas ship their own test suites; nothing in this image runs them.
-RUN find /usr/local/lib/python3.12/site-packages -type d -name tests -prune -exec rm -rf {} + \
- && find /usr/local/lib/python3.12/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
 
 COPY analytics/modeler/pyproject.toml ./
 COPY analytics/modeler/src ./src


### PR DESCRIPTION
## Why

#147 split the dependency install and fixed the oversized-layer pull failure. But the cleanup layer it added alongside introduced a different failure:

```
failed to extract layer ... failed to Lchown
".../site-packages/pip/_internal/cli" for UID 0, GID 0: no such file or directory
```

That `RUN` deleted vendored test suites and `__pycache__` belonging to **earlier layers** — including pip's, which comes from the base image. Removing a previous layer's files writes overlayfs **whiteouts across layers**, and extracting those whiteouts fails on the prod host's containerd/overlayfs snapshotter.

## What

Remove the cleanup layer. `--no-compile` already prevents the bytecode from being created at all, which needs no whiteouts. The vendored test suites stay — they are worth far less than a pullable image.

The comment now records the constraint so this is not reintroduced: **do not add a layer that deletes files belonging to an earlier one.**

## Verification

- 53 modeler tests pass.
- The layer split and the dependency-coverage tests from #147 are unchanged.
- Real check is the prod pull, which I will run against the published image.