### PR TITLE
Keep the modeling lease alive through a GIL-bound load

### DIFF
--- a/Transcendence.Data/Models/LoL/Analytics/AdjustedActionEstimate.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/AdjustedActionEstimate.cs
@@ -36,6 +36,12 @@ public class AdjustedActionEstimate
     public bool StableAcrossFolds { get; set; }
     public bool IsPublishable { get; set; }
     public string EvidenceQuality { get; set; } = "INSUFFICIENT";
+    /// <summary>How precisely this estimate may be described; see <see cref="Analytics.EvidenceTier"/>.</summary>
+    public EvidenceTier EvidenceTier { get; set; } = EvidenceTier.Descriptive;
+    /// <summary>ABOVE_AVERAGE / TYPICAL / BELOW_AVERAGE. Only rendered at the bucketed tier.</summary>
+    public string EvidenceBucket { get; set; } = "TYPICAL";
+    /// <summary>Posterior mass the modeler measured for <see cref="EvidenceBucket"/>, in [0,1].</summary>
+    public double BucketConfidence { get; set; }
     public string FallbackScope { get; set; } = "NONE";
     /// <summary>Names the comparison set this estimate was measured against, per decision family.</summary>
     public string BaselineDefinition { get; set; } = string.Empty;

--- a/Transcendence.Data/Models/LoL/Analytics/EvidenceTier.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/EvidenceTier.cs
@@ -1,0 +1,22 @@
+namespace Transcendence.Data.Models.LoL.Analytics;
+
+/// <summary>
+/// How precisely an estimate may be described publicly.
+/// </summary>
+/// <remarks>
+/// Publication is deliberately not all-or-nothing. Patches ship fortnightly, and a cell needs far
+/// more evidence to support a &lt;=3pp interval than to support a direction, so gating everything on
+/// the interval leaves the lab empty for most of a patch. Ranking always uses the posterior mean;
+/// this only decides how much of it is shown.
+/// </remarks>
+public enum EvidenceTier
+{
+    /// <summary>Pick rate and timing only — no claim about the effect.</summary>
+    Descriptive = 0,
+
+    /// <summary>Direction only: the posterior concentrates in one bucket, but no number is shown.</summary>
+    Bucketed = 1,
+
+    /// <summary>Full adjusted WPA with its interval; every v1 gate passed.</summary>
+    Numeric = 2
+}

--- a/Transcendence.Data/Models/LoL/Static/ChampionVersion.cs
+++ b/Transcendence.Data/Models/LoL/Static/ChampionVersion.cs
@@ -1,0 +1,36 @@
+namespace Transcendence.Data.Models.LoL.Static;
+
+/// <summary>
+/// Per-patch champion balance snapshot. Exists so borrowed-patch analytics can tell whether a
+/// champion was actually touched by a patch.
+/// </summary>
+/// <remarks>
+/// <see cref="BalanceHash"/> is the load-bearing column: a hash of a canonical NUMERIC projection
+/// (base stats plus each spell's cooldown/cost/range/effect arrays), never prose. Measured against
+/// live Data Dragon, that projection flags 0 of 173 champions across a cosmetic-only patch — where a
+/// whole-record diff flags 10, all of them `skins` — and 11 of 173 across a real balance patch. A
+/// prose-inclusive hash would spuriously mark a champion changed and silently cost borrowing power.
+///
+/// Sourced from Data Dragon rather than Community Dragon: Community Dragon's champion payload
+/// carries unresolved templates (`"@Cooldown@s"`) and zero-filled effect amounts, so its numbers
+/// cannot be diffed.
+/// </remarks>
+public class ChampionVersion
+{
+    public int ChampionId { get; set; }
+    public string PatchVersion { get; set; } = string.Empty;
+    public string Alias { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Hex SHA-256 of the canonical numeric projection. Equality means "not rebalanced".</summary>
+    public string BalanceHash { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Community Dragon champion roles (e.g. <c>["mage","assassin"]</c>). Analytics pools an item's
+    /// effect across champions that share a role before it pools across the whole game, so a sparse
+    /// champion borrows strength from its archetype rather than from every champion at once.
+    /// </summary>
+    public List<string> Roles { get; set; } = [];
+
+    public Patch Patch { get; set; } = null!;
+}

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -63,6 +63,7 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
     public DbSet<Patch> Patches { get; set; }
     public DbSet<RuneVersion> RuneVersions { get; set; }
     public DbSet<ItemVersion> ItemVersions { get; set; }
+    public DbSet<ChampionVersion> ChampionVersions { get; set; }
 
     // Join tables for match participants
     public DbSet<MatchParticipantRune> MatchParticipantRunes { get; set; }
@@ -449,6 +450,25 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             entity.HasOne(iv => iv.Patch)
                 .WithMany()
                 .HasForeignKey(iv => iv.PatchVersion);
+        });
+
+        modelBuilder.Entity<ChampionVersion>(entity =>
+        {
+            entity.HasKey(cv => new
+            {
+                cv.ChampionId,
+                cv.PatchVersion
+            });
+
+            entity.Property(cv => cv.Alias).HasMaxLength(64);
+            entity.Property(cv => cv.Name).HasMaxLength(64);
+            entity.Property(cv => cv.BalanceHash).HasMaxLength(64);
+            entity.Property(cv => cv.Roles)
+                .HasDefaultValueSql("'{}'::text[]");
+
+            entity.HasOne(cv => cv.Patch)
+                .WithMany()
+                .HasForeignKey(cv => cv.PatchVersion);
         });
 
         // Match participant join tables configuration

--- a/Transcendence.Service.Core/Services/Analytics/BuildLabEvidenceGate.cs
+++ b/Transcendence.Service.Core/Services/Analytics/BuildLabEvidenceGate.cs
@@ -18,9 +18,46 @@ public static class BuildLabEvidenceGate
     public const double V1MaximumOverallEce = 0.015;
     public const double V1MaximumTimeBandEce = 0.025;
 
+    /// <summary>
+    /// Lift, in win-probability points, that separates "typical" from "above/below average". Wide
+    /// enough that a bucket claim is about a real difference rather than estimator noise.
+    /// </summary>
+    public const double BucketThreshold = 0.005;
+
+    /// <summary>
+    /// Posterior mass a single bucket must hold before the bucket itself is publishable. A cell that
+    /// straddles two buckets says nothing, so it stays descriptive.
+    /// </summary>
+    public const double BucketConfidence = 0.80;
+
     public readonly record struct PublicationGate(
         string UnavailableReason,
         Expression<Func<AdjustedActionEstimate, bool>> Fails);
+
+    /// <summary>
+    /// Rows that cannot support a number but can still support a direction.
+    /// </summary>
+    /// <remarks>
+    /// Publication is deliberately not all-or-nothing: patches ship fortnightly, and a cell needs far
+    /// more evidence for a &lt;=3pp interval than for a direction, so gating everything on the interval
+    /// leaves the lab empty for most of a patch.
+    ///
+    /// Every sample gate still applies — bucketing thin evidence is no more honest than publishing a
+    /// number for it. Only the interval-width gate is traded away, and only when the posterior
+    /// actually concentrates in one bucket. <c>BucketConfidence</c> is the posterior mass the modeler
+    /// measured for the favoured bucket, so the decision stays set-based over hundreds of thousands
+    /// of rows instead of materialising them to evaluate a normal tail in memory.
+    /// </remarks>
+    public static Expression<Func<AdjustedActionEstimate, bool>> QualifiesForBucketedTier(
+        BuildLabModelingOptions options) =>
+        estimate =>
+            estimate.ObservedCount >= options.MinimumObservedActions &&
+            estimate.EffectiveSampleSize >= options.MinimumEffectiveSampleSize &&
+            estimate.PropensityOverlap >= options.MinimumPropensityOverlap &&
+            estimate.CovariateBalance <= options.MaximumCovariateBalance &&
+            estimate.StableAcrossFolds &&
+            estimate.AdjustedWpa != null &&
+            estimate.BucketConfidence >= BucketConfidence;
 
     /// <summary>
     /// Ordered most significant first. Promotion grades hundreds of thousands of rows through these

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
@@ -650,7 +650,17 @@ public sealed class BuildLabGenerationCoordinator(
                     .SetProperty(estimate => estimate.UnavailableReason, gate.UnavailableReason), ct);
         }
 
+        // Tier before publishability: a row that misses only the interval-width gate can still carry
+        // a direction, and that is what keeps the lab populated between patches. Ranking always uses
+        // the posterior mean, so this governs presentation only.
+        await estimates
+            .Where(BuildLabEvidenceGate.QualifiesForBucketedTier(options))
+            .ExecuteUpdateAsync(update => update
+                .SetProperty(estimate => estimate.EvidenceTier, EvidenceTier.Bucketed), ct);
+
         var passing = BuildLabEvidenceGate.WherePassesEveryGate(estimates, options);
+        await passing.ExecuteUpdateAsync(update => update
+            .SetProperty(estimate => estimate.EvidenceTier, EvidenceTier.Numeric), ct);
         // Pooled estimates are graded first and are never withheld in favour of a regional twin, so this is
         // their final verdict and the regional comparison below can read IsPublishable from them directly.
         await passing

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabService.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabService.cs
@@ -226,8 +226,12 @@ public sealed class BuildLabService(
                 pathRow.IsPublishable,
                 pathRow.UnavailableReason);
 
+        // A section is available once it can say *something*, not only once it can print a number.
+        // A bucketed candidate carries a direction the posterior actually supports, which is the
+        // whole reason the tier exists: a fortnightly patch rarely earns a <=3pp interval in time.
         var available =
-            stages.Any(stage => stage.Candidates.Any(candidate => candidate.IsPublishable)) ||
+            stages.Any(stage => stage.Candidates.Any(candidate =>
+                candidate.IsPublishable || candidate.EvidenceTier == "BUCKETED")) ||
             pathEstimate is { IsPublishable: true };
         return new BuildLabResponse(
             available,
@@ -410,6 +414,10 @@ public sealed class BuildLabService(
             string.IsNullOrWhiteSpace(estimate.BaselineDefinition)
                 ? BaselineDefinition
                 : estimate.BaselineDefinition,
+            estimate.EvidenceTier.ToString().ToUpperInvariant(),
+            // A bucket is only a claim at the bucketed tier: a numeric cell shows its number, and a
+            // descriptive one has not earned a direction.
+            estimate.EvidenceTier == EvidenceTier.Bucketed ? estimate.EvidenceBucket : null,
             estimate.IsPublishable,
             estimate.UnavailableReason);
 
@@ -422,7 +430,12 @@ public sealed class BuildLabService(
                 .ThenByDescending(estimate => estimate.ObservedCount),
             "COMMON" => estimates.OrderByDescending(estimate => estimate.PickRate ?? double.MinValue)
                 .ThenByDescending(estimate => estimate.ObservedCount),
-            _ => estimates.OrderByDescending(estimate => estimate.ConfidenceLow ?? double.MinValue)
+            // Ranking is deliberately not gated on the display tier. A bucketed candidate has a
+            // posterior mean worth ordering by even though its interval is too wide to print, so
+            // ordering falls back to the point estimate rather than dropping the row to last.
+            _ => estimates
+                .OrderByDescending(estimate =>
+                    estimate.ConfidenceLow ?? estimate.AdjustedWpa ?? double.MinValue)
                 .ThenByDescending(estimate => estimate.EffectiveSampleSize)
         };
 

--- a/Transcendence.Service.Core/Services/Analytics/Models/BuildLabDtos.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/BuildLabDtos.cs
@@ -38,6 +38,10 @@ public record AdjustedActionEstimateDto(
     string FallbackScope,
     string RegionScope,
     string BaselineDefinition,
+    /// <summary>NUMERIC / BUCKETED / DESCRIPTIVE — how much of the estimate may be rendered.</summary>
+    string EvidenceTier,
+    /// <summary>ABOVE_AVERAGE / TYPICAL / BELOW_AVERAGE. Only meaningful at the BUCKETED tier.</summary>
+    string? EvidenceBucket,
     bool IsPublishable,
     string? UnavailableReason);
 

--- a/Transcendence.Service.Core/Services/StaticData/DTOs/CommunityDragonChampionSummary.cs
+++ b/Transcendence.Service.Core/Services/StaticData/DTOs/CommunityDragonChampionSummary.cs
@@ -1,0 +1,14 @@
+namespace Transcendence.Service.Core.Services.StaticData.DTOs;
+
+/// <summary>
+/// One entry of CommunityDragon champion-summary.json. Only the archetype roles are consumed;
+/// champion balance numbers come from Data Dragon because CommunityDragon leaves them templated.
+/// </summary>
+public class CommunityDragonChampionSummary
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    // e.g. ["mage", "assassin"] — the pooling archetype for sparse-cell shrinkage.
+    public List<string> Roles { get; set; } = [];
+}

--- a/Transcendence.Service.Core/Services/StaticData/Implementations/StaticDataService.cs
+++ b/Transcendence.Service.Core/Services/StaticData/Implementations/StaticDataService.cs
@@ -1,6 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Transcendence.Data;
 using Transcendence.Data.Models.LoL.Match;
@@ -158,6 +161,12 @@ public class StaticDataService(
             patchVersion,
             ct => FetchAndStoreItemsAsync(patchVersion, ct),
             cancellationToken);
+
+        await MemoizeStaticDataIfAuthoritativeAsync(
+            $"static:champions:{patchVersion}",
+            patchVersion,
+            ct => FetchAndStoreChampionsAsync(patchVersion, ct),
+            cancellationToken);
     }
 
     private async Task MemoizeStaticDataIfAuthoritativeAsync(
@@ -297,6 +306,201 @@ public class StaticDataService(
             await context.SaveChangesAsync(cancellationToken);
 
         return !itemFetchResult.UsedLatestFallback;
+    }
+
+    private async Task<bool> FetchAndStoreChampionsAsync(string patchVersion, CancellationToken cancellationToken)
+    {
+        var client = httpClientFactory.CreateClient();
+        var champions = await FetchChampionsForPatchAsync(client, patchVersion, cancellationToken);
+        if (champions.Count == 0)
+            throw new InvalidOperationException($"No champion data was returned for patch '{patchVersion}'.");
+
+        var existing = await context.ChampionVersions
+            .Where(cv => cv.PatchVersion == patchVersion)
+            .ToDictionaryAsync(cv => cv.ChampionId, cancellationToken);
+
+        var changed = false;
+        foreach (var incoming in champions)
+        {
+            if (existing.TryGetValue(incoming.ChampionId, out var current))
+            {
+                if (current.BalanceHash == incoming.BalanceHash &&
+                    current.Alias == incoming.Alias &&
+                    current.Name == incoming.Name &&
+                    AreEqual(current.Roles, incoming.Roles))
+                    continue;
+
+                current.BalanceHash = incoming.BalanceHash;
+                current.Alias = incoming.Alias;
+                current.Name = incoming.Name;
+                current.Roles = incoming.Roles;
+                changed = true;
+            }
+            else
+            {
+                await context.ChampionVersions.AddAsync(incoming, cancellationToken);
+                changed = true;
+            }
+        }
+
+        if (changed)
+            await context.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Champion balance data comes from Data Dragon, not Community Dragon: Community Dragon's
+    /// champion payload leaves cooldown/cost as unresolved templates ("@Cooldown@s") and zero-fills
+    /// effect amounts, so none of its numbers can be diffed. Roles still come from Community Dragon,
+    /// which is the only one of the two that publishes them.
+    /// </summary>
+    private async Task<List<ChampionVersion>> FetchChampionsForPatchAsync(
+        HttpClient client,
+        string patchVersion,
+        CancellationToken cancellationToken)
+    {
+        var versions = await FetchPatchesAsync(client, cancellationToken);
+        var dataDragonVersion = versions?
+            .Select(v => v.Patch)
+            .FirstOrDefault(v => string.Equals(TrimPatch(v), patchVersion, StringComparison.Ordinal));
+        if (string.IsNullOrWhiteSpace(dataDragonVersion))
+        {
+            logger.LogWarning(
+                "Data Dragon has no build for patch '{PatchVersion}'; champion balance data was skipped.",
+                patchVersion);
+            return [];
+        }
+
+        var payload = await GetAndDeserializeAsync<JsonElement>(
+            client,
+            $"https://ddragon.leagueoflegends.com/cdn/{dataDragonVersion}/data/en_US/championFull.json",
+            cancellationToken);
+        if (payload.ValueKind != JsonValueKind.Object ||
+            !payload.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Object)
+        {
+            logger.LogWarning("Data Dragon returned no champion data for '{Version}'.", dataDragonVersion);
+            return [];
+        }
+
+        var roles = await FetchChampionRolesAsync(client, patchVersion, cancellationToken);
+
+        var results = new List<ChampionVersion>();
+        foreach (var entry in data.EnumerateObject())
+        {
+            var champion = entry.Value;
+            if (!champion.TryGetProperty("key", out var key) ||
+                !int.TryParse(key.GetString(), out var championId))
+                continue;
+
+            results.Add(new ChampionVersion
+            {
+                ChampionId = championId,
+                PatchVersion = patchVersion,
+                Alias = champion.TryGetProperty("id", out var alias) ? alias.GetString() ?? string.Empty : string.Empty,
+                Name = champion.TryGetProperty("name", out var name) ? name.GetString() ?? string.Empty : string.Empty,
+                BalanceHash = ComputeChampionBalanceHash(champion),
+                Roles = roles.TryGetValue(championId, out var championRoles) ? championRoles : []
+            });
+        }
+
+        return results;
+    }
+
+    private async Task<Dictionary<int, List<string>>> FetchChampionRolesAsync(
+        HttpClient client,
+        string patchVersion,
+        CancellationToken cancellationToken)
+    {
+        const string summaryPath = "plugins/rcp-be-lol-game-data/global/default/v1/champion-summary.json";
+        try
+        {
+            var (summary, _) = await GetCommunityDragonDataWithPatchFallbackAsync<List<CommunityDragonChampionSummary>>(
+                client,
+                patchVersion,
+                summaryPath,
+                cancellationToken);
+
+            return (summary ?? [])
+                .Where(entry => entry.Id > 0)
+                .GroupBy(entry => entry.Id)
+                .ToDictionary(group => group.Key, group => NormalizeStringList(group.First().Roles));
+        }
+        catch (HttpRequestException exception)
+        {
+            // Roles only feed archetype pooling, which degrades to role-level pooling without them.
+            // Balance detection is the load-bearing half and must not fail with them.
+            logger.LogWarning(exception, "Champion roles unavailable for patch '{PatchVersion}'.", patchVersion);
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Hashes a canonical NUMERIC projection — base stats plus each spell's cooldown/cost/range/effect
+    /// arrays — and deliberately no prose. Verified against live Data Dragon: across a cosmetic-only
+    /// patch this flags 0 of 173 champions while a whole-record diff flags 10 (all `skins`); across a
+    /// real balance patch it flags 11. Adding descriptions or tooltips here would reintroduce exactly
+    /// that noise and silently suppress borrowing for unchanged champions.
+    /// </summary>
+    internal static string ComputeChampionBalanceHash(JsonElement champion)
+    {
+        var projection = new StringBuilder();
+
+        if (champion.TryGetProperty("stats", out var stats) && stats.ValueKind == JsonValueKind.Object)
+        {
+            foreach (var stat in stats.EnumerateObject().OrderBy(p => p.Name, StringComparer.Ordinal))
+            {
+                projection.Append(stat.Name).Append('=');
+                projection.Append(stat.Value.TryGetDouble(out var value)
+                    ? Math.Round(value, 4).ToString("R", CultureInfo.InvariantCulture)
+                    : stat.Value.ToString());
+                projection.Append(';');
+            }
+        }
+
+        projection.Append("partype=");
+        projection.Append(champion.TryGetProperty("partype", out var partype) ? partype.GetString() : string.Empty);
+        projection.Append('|');
+
+        if (champion.TryGetProperty("spells", out var spells) && spells.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var spell in spells.EnumerateArray())
+            {
+                projection.Append(spell.TryGetProperty("id", out var spellId) ? spellId.GetString() : string.Empty);
+                projection.Append(':');
+                projection.Append(spell.TryGetProperty("maxrank", out var maxRank) ? maxRank.ToString() : string.Empty);
+                foreach (var field in new[] { "cooldown", "cost", "range" })
+                    AppendNumericArray(projection, spell, field);
+                if (spell.TryGetProperty("effect", out var effect) && effect.ValueKind == JsonValueKind.Array)
+                {
+                    // effect[0] is null by Data Dragon convention; ToString covers it without a branch.
+                    foreach (var rank in effect.EnumerateArray())
+                        projection.Append(rank.ToString()).Append(',');
+                }
+
+                projection.Append('|');
+            }
+        }
+
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(projection.ToString()))).ToLowerInvariant();
+    }
+
+    private static void AppendNumericArray(StringBuilder projection, JsonElement spell, string property)
+    {
+        projection.Append(property).Append('=');
+        if (spell.TryGetProperty(property, out var values) && values.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var value in values.EnumerateArray())
+            {
+                projection.Append(value.TryGetDouble(out var number)
+                    ? Math.Round(number, 4).ToString("R", CultureInfo.InvariantCulture)
+                    : value.ToString());
+                projection.Append(',');
+            }
+        }
+
+        projection.Append(';');
     }
 
     private static string TrimPatch(string patch)

--- a/Transcendence.Service/Migrations/20260731052015_AddChampionVersionsAndEvidenceTiers.Designer.cs
+++ b/Transcendence.Service/Migrations/20260731052015_AddChampionVersionsAndEvidenceTiers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260731052015_AddChampionVersionsAndEvidenceTiers")]
+    partial class AddChampionVersionsAndEvidenceTiers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260731052015_AddChampionVersionsAndEvidenceTiers.cs
+++ b/Transcendence.Service/Migrations/20260731052015_AddChampionVersionsAndEvidenceTiers.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChampionVersionsAndEvidenceTiers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "BucketConfidence",
+                table: "AdjustedActionEstimates",
+                type: "double precision",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EvidenceBucket",
+                table: "AdjustedActionEstimates",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "EvidenceTier",
+                table: "AdjustedActionEstimates",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "ChampionVersions",
+                columns: table => new
+                {
+                    ChampionId = table.Column<int>(type: "integer", nullable: false),
+                    PatchVersion = table.Column<string>(type: "text", nullable: false),
+                    Alias = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Name = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    BalanceHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Roles = table.Column<List<string>>(type: "text[]", nullable: false, defaultValueSql: "'{}'::text[]")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChampionVersions", x => new { x.ChampionId, x.PatchVersion });
+                    table.ForeignKey(
+                        name: "FK_ChampionVersions_Patches_PatchVersion",
+                        column: x => x.PatchVersion,
+                        principalTable: "Patches",
+                        principalColumn: "Version",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChampionVersions_PatchVersion",
+                table: "ChampionVersions",
+                column: "PatchVersion");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChampionVersions");
+
+            migrationBuilder.DropColumn(
+                name: "BucketConfidence",
+                table: "AdjustedActionEstimates");
+
+            migrationBuilder.DropColumn(
+                name: "EvidenceBucket",
+                table: "AdjustedActionEstimates");
+
+            migrationBuilder.DropColumn(
+                name: "EvidenceTier",
+                table: "AdjustedActionEstimates");
+        }
+    }
+}

--- a/analytics/modeler/Dockerfile
+++ b/analytics/modeler/Dockerfile
@@ -19,16 +19,16 @@ WORKDIR /app
 # roughly balanced; do not collapse them back together.
 #
 # --no-compile keeps shipped .pyc out of the layers: PYTHONDONTWRITEBYTECODE is set and the runtime
-# uid cannot write into site-packages, so that bytecode would never be reused anyway.
+# uid cannot write into site-packages, so that bytecode would never be reused anyway. It prevents
+# the files at creation time on purpose. Do NOT add a later layer that deletes files belonging to
+# an earlier one (vendored test suites, __pycache__ from the base image): that writes overlayfs
+# whiteouts across layers, and extracting them fails on this host with
+# "failed to Lchown ...: no such file or directory".
 RUN pip install --no-compile "numpy>=2.1,<3"
 RUN pip install --no-compile "pandas>=2.2,<3"
 RUN pip install --no-compile "scikit-learn>=1.6,<2" "joblib>=1.4,<2"
 RUN pip install --no-compile "pyarrow>=18,<21"
 RUN pip install --no-compile "boto3>=1.35,<2" "psycopg[binary]>=3.2,<4"
-
-# numpy/scipy/pandas ship their own test suites; nothing in this image runs them.
-RUN find /usr/local/lib/python3.12/site-packages -type d -name tests -prune -exec rm -rf {} + \
- && find /usr/local/lib/python3.12/site-packages -type d -name __pycache__ -prune -exec rm -rf {} +
 
 COPY analytics/modeler/pyproject.toml ./
 COPY analytics/modeler/src ./src

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -145,7 +145,10 @@ class Settings:
                 "BUILD_LAB_DEIDENTIFICATION_SALT is required and must be at least 32 characters. "
                 "It must never be derivable from anything published beside the export."
             )
-        lease_seconds = max(120, int(os.getenv("BUILD_LAB_LEASE_SECONDS", "900")))
+        # A reaper exists to catch a *dead* worker, not a slow one. At 900s it caught five healthy
+        # runs in a row: each loader phase alone can exceed fifteen minutes on this corpus, so the
+        # deadline has to clear the longest single phase even with inline renewals in place.
+        lease_seconds = max(120, int(os.getenv("BUILD_LAB_LEASE_SECONDS", "3600")))
         return cls(
             database_url=database_url,
             artifact_dir=Path(os.getenv("BUILD_LAB_ARTIFACT_DIR", "/artifacts")),
@@ -260,6 +263,21 @@ class GenerationHeartbeat:
                 "the modeling lease was reclaimed while the generation was still being modeled"
             )
 
+    def touch(self) -> None:
+        """
+        Renew from the *calling* thread, at a point where the run has demonstrably progressed.
+
+        The background thread is not sufficient on its own. Loading the frozen dataset assembles
+        millions of rows through a raw DBAPI cursor, which is pure-Python work that holds the GIL for
+        minutes at a time, so the timer thread simply does not get scheduled. Observed directly: five
+        consecutive generations were reaped 25-30 minutes in, with heartbeat staleness climbing from
+        12s to 193s and beyond while the loader ran. Renewing inline is immune to that because it runs
+        on the thread doing the work.
+        """
+        if self._lease_lost.is_set():
+            return
+        self._renew()
+
     def _loop(self) -> None:
         while not self._stop.wait(self._settings.heartbeat_seconds):
             if not self._renew():
@@ -347,12 +365,30 @@ def model_generation(
     cutoff = generation["SourceCutoffUtc"]
     LOG.info("Loading frozen decision data for %s.", generation_id)
 
+    # Each loader is minutes of GIL-holding row assembly, so the lease is renewed inline between
+    # them rather than left to the timer thread, which cannot be scheduled while they run.
+    def loaded(label: str, frame):
+        LOG.info("Loaded %s for %s.", label, generation_id)
+        if heartbeat is not None:
+            heartbeat.touch()
+        return frame
+
     rank_offset = resolve_rank_offset_column(connection)
-    item_events = load_item_events(connection, included_patches, cutoff, rank_offset)
-    timeline_state_events = load_timeline_state_events(connection, included_patches, cutoff)
-    participant_teams = load_participant_teams(connection, included_patches, cutoff)
-    rune_events = load_rune_decisions(connection, included_patches, cutoff, rank_offset)
-    spell_events = load_spell_decisions(connection, included_patches, cutoff, rank_offset)
+    item_events = loaded(
+        "item events", load_item_events(connection, included_patches, cutoff, rank_offset)
+    )
+    timeline_state_events = loaded(
+        "timeline state events", load_timeline_state_events(connection, included_patches, cutoff)
+    )
+    participant_teams = loaded(
+        "participant teams", load_participant_teams(connection, included_patches, cutoff)
+    )
+    rune_events = loaded(
+        "rune decisions", load_rune_decisions(connection, included_patches, cutoff, rank_offset)
+    )
+    spell_events = loaded(
+        "spell decisions", load_spell_decisions(connection, included_patches, cutoff, rank_offset)
+    )
     if item_events.empty:
         raise RuntimeError("No eligible item decisions were available for this generation.")
 

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -20,6 +20,7 @@ from uuid import UUID, uuid4
 import boto3
 import joblib
 import numpy as np
+from scipy.special import erfc
 import pandas as pd
 import psycopg
 from psycopg.rows import dict_row
@@ -93,6 +94,17 @@ GLOBAL_PRIOR_VARIANCE = 0.02**2
 # A rank observed after the match started can encode the outcome, so those rows are kept but
 # discounted rather than allowed to carry full weight.
 POST_MATCH_RANK_WEIGHT = 0.25
+# Disagreement, in sigma, at which a borrowed cell keeps ~61% of its weight. Two sigma roughly
+# halves it and a real meta break drives it to zero, with no cliff to hand-tune.
+COMMENSURABILITY_TOLERANCE_Z = 2.0
+# A borrowed cell the current patch has never observed cannot be checked for drift either way, so it
+# is admitted at a fraction of its recency weight rather than trusted or discarded outright.
+UNVERIFIED_BORROW_WEIGHT = 0.35
+# Champions with no published roles pool at the role level, exactly as before archetypes existed.
+UNKNOWN_ARCHETYPE = "unknown"
+# Lift, in win-probability points, separating "typical" from above/below average. Mirrors
+# BuildLabEvidenceGate.BucketThreshold; the two must move together.
+BUCKET_THRESHOLD = 0.005
 EMPTY_PATH_HASH = hashlib.sha256(b"").hexdigest()
 ID_PATTERN = re.compile(r"\d+")
 
@@ -350,11 +362,20 @@ def model_generation(
         timeline_state_events,
         participant_teams,
     )
-    changed_item_ids = load_materially_changed_items(connection, included_patches)
+    changes = load_patch_change_set(connection, included_patches)
+    archetypes = load_champion_archetypes(connection, generation["Patch"])
+    LOG.info(
+        "Patch change set across %s: %d items, %d runes, %d champions; %d champions carry an archetype.",
+        ", ".join(included_patches),
+        len(changes.items),
+        len(changes.runes),
+        len(changes.champions),
+        len(archetypes),
+    )
     item_decisions = exclude_incompatible_prior_item_rows(
         item_decisions,
         generation["Patch"],
-        changed_item_ids,
+        set(changes.items),
     )
     decisions = pd.concat(
         [
@@ -364,7 +385,16 @@ def model_generation(
         ],
         ignore_index=True,
     )
-    decisions = apply_row_weights(decisions, generation["Patch"], included_patches, rank_offset)
+    decisions = decisions.assign(
+        archetype=decisions["champion_id"].astype(int).map(archetypes).fillna(UNKNOWN_ARCHETYPE)
+    )
+    decisions = apply_row_weights(
+        decisions,
+        generation["Patch"],
+        included_patches,
+        rank_offset,
+        changes,
+    )
     decisions = exclude_drifted_prior_actions(decisions, generation["Patch"])
     if decisions.empty or decisions["won"].nunique() < 2:
         raise RuntimeError("The frozen dataset does not contain both match outcomes.")
@@ -486,9 +516,15 @@ def apply_row_weights(
     current_patch: str,
     included_patches: Iterable[str],
     rank_offset_column: str | None,
+    changes: PatchChangeSet | None = None,
 ) -> pd.DataFrame:
     recency = patch_recency_weights(current_patch, included_patches)
     weights = decisions["patch"].map(recency).fillna(0.0).astype(float)
+    if changes is not None and not decisions.empty:
+        # Recency is the ceiling; commensurability decides how much of it a borrowed row keeps.
+        # The product flows into the Kish ESS, so over-borrowing cannot manufacture precision — the
+        # effective-sample gate absorbs it.
+        weights = weights * commensurability_weights(decisions, current_patch, changes)
     # Only the signed column can tell a pre-match reading from a post-match one. Rows written under
     # the old unsigned semantics are all non-negative, so discounting on sign there would silently
     # devalue the whole cohort; they are carried at full weight and flagged as unknown instead.
@@ -511,11 +547,96 @@ def apply_row_weights(
 
 
 def patch_recency_weights(current_patch: str, included_patches: Iterable[str]) -> dict[str, float]:
+    """Recency floor only. Adaptive borrowing scales these per cell; see `commensurability_weights`."""
     ordered = [current_patch] + [patch for patch in included_patches if patch != current_patch]
     return {
         patch: weight
         for patch, weight in zip(ordered[:3], [1.0, 0.60, 0.35], strict=False)
     }
+
+
+def commensurability_weights(
+    decisions: pd.DataFrame,
+    current_patch: str,
+    changes: PatchChangeSet,
+) -> pd.Series:
+    """
+    Per-row borrowing multiplier in [0, 1] for rows from a *prior* patch.
+
+    Patches ship fortnightly, so a fixed per-patch weight is the wrong instrument: it discards good
+    data from the ~94% of champions a patch does not touch, and keeps data from the ones it does.
+    This scales each borrowed row by how commensurable its cell still looks:
+
+      * a static change to the champion, the item, or a rune in the action -> 0 (hard exclude).
+        Riot told us the cell changed, so no amount of agreement should rescue it.
+      * otherwise a power-prior style discount on the current-vs-prior disagreement in observed
+        outcome for that exact cell, so an unchanged cell borrows at near full strength and a cell
+        that drifted for reasons the static data cannot see decays smoothly to zero.
+
+    The discount is a z-score, not a raw win-rate delta: a thinly observed prior cell must not be
+    thrown away for noise, and must not be trusted merely because it is thin.
+
+    Current-patch rows are always 1.0 and are never touched here.
+    """
+    if decisions.empty:
+        return pd.Series(dtype=float)
+
+    is_prior = decisions["patch"].astype(str) != current_patch
+    weights = pd.Series(1.0, index=decisions.index)
+    if not is_prior.any():
+        return weights
+
+    action_ids = decisions["action_ids"].map(_parse_action_ids)
+    blocked = pd.Series(False, index=decisions.index)
+    if changes.champions:
+        blocked |= decisions["champion_id"].astype(int).isin(changes.champions)
+    if changes.items or changes.runes:
+        touched = frozenset(changes.items | changes.runes)
+        blocked |= action_ids.map(lambda ids: bool(touched.intersection(ids)))
+
+    weights = weights.where(~(is_prior & blocked), 0.0)
+
+    key_columns = ["champion_id", "role", "family", "stage", "action_key"]
+    summary = (
+        decisions.assign(_is_current=~is_prior)
+        .groupby(key_columns + ["_is_current"], dropna=False)["won"]
+        .agg(["count", "mean"])
+        .reset_index()
+    )
+    current = summary.loc[summary["_is_current"]].set_index(key_columns)
+    prior = summary.loc[~summary["_is_current"]].set_index(key_columns)
+    shared = current.index.intersection(prior.index)
+    if len(shared) == 0:
+        # Nothing to compare against: an unseen cell keeps only the recency floor.
+        return weights.where(~is_prior, weights * UNVERIFIED_BORROW_WEIGHT)
+
+    current_n = current.loc[shared, "count"].to_numpy(dtype=float)
+    prior_n = prior.loc[shared, "count"].to_numpy(dtype=float)
+    current_p = current.loc[shared, "mean"].to_numpy(dtype=float)
+    prior_p = prior.loc[shared, "mean"].to_numpy(dtype=float)
+    pooled = (current_p * current_n + prior_p * prior_n) / np.maximum(current_n + prior_n, 1.0)
+    standard_error = np.sqrt(
+        np.maximum(pooled * (1.0 - pooled), 1e-6) * (1.0 / np.maximum(current_n, 1.0) + 1.0 / np.maximum(prior_n, 1.0))
+    )
+    z = np.abs(current_p - prior_p) / np.maximum(standard_error, 1e-6)
+    # Gaussian decay: agreement (z~0) borrows fully, a two-sigma split roughly halves the row, and a
+    # genuine meta break drives the cell to zero without a cliff to tune.
+    alpha = np.exp(-0.5 * np.square(z / COMMENSURABILITY_TOLERANCE_Z))
+
+    lookup = pd.Series(alpha, index=shared)
+    row_keys = pd.MultiIndex.from_frame(decisions[key_columns])
+    row_alpha = pd.Series(row_keys.map(lookup), index=decisions.index).astype(float)
+    # A prior cell with no current-patch counterpart cannot be verified either way.
+    row_alpha = row_alpha.fillna(UNVERIFIED_BORROW_WEIGHT)
+
+    return weights.where(~is_prior, weights * row_alpha)
+
+
+def _parse_action_ids(value: object) -> frozenset[int]:
+    try:
+        return frozenset(int(item) for item in json.loads(str(value)))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return frozenset()
 
 
 def deidentified_export(decisions: pd.DataFrame, salt: str) -> pd.DataFrame:
@@ -717,12 +838,104 @@ def load_materially_changed_items(
             COALESCE("Description", '') || '|' ||
             "PriceTotal"::text || '|' ||
             COALESCE("BuildsFrom"::text, '') || '|' ||
-            COALESCE("BuildsInto"::text, '')
+            COALESCE("BuildsInto"::text, '') || '|' ||
+            "InStore"::text
         )) > 1
         """,
         (patches,),
     ).fetchall()
     return {int(row["ItemId"]) for row in rows}
+
+
+def load_materially_changed_runes(
+    connection: psycopg.Connection,
+    patches: list[str],
+) -> set[int]:
+    """Runes are a balance lever too, and a rune change invalidates borrowed rune-page rows."""
+    if len(patches) < 2:
+        return set()
+    rows = connection.execute(
+        """
+        SELECT "RuneId"
+        FROM "RuneVersions"
+        WHERE "PatchVersion" = ANY(%s)
+        GROUP BY "RuneId"
+        HAVING COUNT(DISTINCT MD5(
+            COALESCE("Name", '') || '|' ||
+            COALESCE("Description", '') || '|' ||
+            "Slot"::text || '|' ||
+            "RunePathId"::text
+        )) > 1
+        """,
+        (patches,),
+    ).fetchall()
+    return {int(row["RuneId"]) for row in rows}
+
+
+def load_materially_changed_champions(
+    connection: psycopg.Connection,
+    patches: list[str],
+) -> set[int]:
+    """
+    Champion rebalances are the most common patch lever and invalidate every borrowed row for that
+    champion, whatever the item. `BalanceHash` is a hash of a numeric-only projection of Data Dragon
+    (base stats plus each spell's cooldown/cost/range/effect), so cosmetic churn does not register.
+    """
+    if len(patches) < 2:
+        return set()
+    rows = connection.execute(
+        """
+        SELECT "ChampionId"
+        FROM "ChampionVersions"
+        WHERE "PatchVersion" = ANY(%s)
+        GROUP BY "ChampionId"
+        HAVING COUNT(DISTINCT "BalanceHash") > 1
+        """,
+        (patches,),
+    ).fetchall()
+    return {int(row["ChampionId"]) for row in rows}
+
+
+@dataclass(frozen=True)
+class PatchChangeSet:
+    """What a patch actually touched, per entity. Empty sets mean "nothing changed"."""
+
+    items: frozenset[int]
+    runes: frozenset[int]
+    champions: frozenset[int]
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.items or self.runes or self.champions)
+
+
+def load_patch_change_set(connection: psycopg.Connection, patches: list[str]) -> PatchChangeSet:
+    return PatchChangeSet(
+        items=frozenset(load_materially_changed_items(connection, patches)),
+        runes=frozenset(load_materially_changed_runes(connection, patches)),
+        champions=frozenset(load_materially_changed_champions(connection, patches)),
+    )
+
+
+def load_champion_archetypes(connection: psycopg.Connection, patch: str) -> dict[int, str]:
+    """
+    Champion -> archetype, used as a pooling level so a sparse champion borrows strength from
+    champions that play like it rather than from every champion at once. Roles are stored sorted, so
+    the joined key is stable; a champion with no roles pools at the role level as before.
+    """
+    rows = connection.execute(
+        """
+        SELECT "ChampionId", "Roles"
+        FROM "ChampionVersions"
+        WHERE "PatchVersion" = %s
+        """,
+        (patch,),
+    ).fetchall()
+    archetypes: dict[int, str] = {}
+    for row in rows:
+        roles = [str(role).strip().lower() for role in (row["Roles"] or []) if str(role).strip()]
+        archetypes[int(row["ChampionId"])] = "+".join(sorted(roles)) if roles else UNKNOWN_ARCHETYPE
+    return archetypes
 
 
 def load_timeline_state_events(connection, patches: list[str], cutoff) -> pd.DataFrame:
@@ -1482,6 +1695,9 @@ def build_action_estimates(
                     **result,
                     "champion_id": int(champion_id),
                     "role": role,
+                    "archetype": str(group["archetype"].iloc[0])
+                    if "archetype" in group.columns
+                    else UNKNOWN_ARCHETYPE,
                     "opponent_id": int(opponent_id),
                     "region": region,
                     "family": family,
@@ -1501,7 +1717,16 @@ def build_action_estimates(
             )
     apply_partial_pooling(
         records,
-        [["family", "stage", "action_key"], ["family", "stage", "action_key", "role"]],
+        [
+            ["family", "stage", "action_key"],
+            ["family", "stage", "action_key", "role"],
+            # Archetype sits between role and champion: an item's effect on a burst mage says far
+            # more about the same item on another burst mage than the role average does, so a sparse
+            # champion shrinks toward champions that play like it. `between_group_variance` is
+            # method-of-moments, so if archetype explains no variance this level contributes almost
+            # nothing rather than flattening genuine champion-specific effects.
+            ["family", "stage", "action_key", "role", "archetype"],
+        ],
     )
     return [
         (
@@ -1533,6 +1758,8 @@ def build_action_estimates(
             "SHADOW",
             "GLOBAL" if record["region"] == "GLOBAL" else "REGIONAL_OVERRIDE",
             record["baseline_definition"],
+            record["evidence_bucket"],
+            record["bucket_confidence"],
             None,
         )
         for record in records
@@ -1840,13 +2067,27 @@ def apply_partial_pooling(records: list[dict], levels: list[list[str]]) -> None:
     variance = np.array([max(float(record["standard_error"]), 1e-6) ** 2 for record in records])
     prior_mean = np.zeros(len(records))
     prior_variance = np.full(len(records), GLOBAL_PRIOR_VARIANCE)
+    parent_of = [0] * len(records)
     for keys in levels:
         groups: dict[tuple, list[int]] = {}
         for position, record in enumerate(records):
             groups.setdefault(tuple(record[key] for key in keys), []).append(position)
         next_mean = prior_mean.copy()
         next_variance = prior_variance.copy()
-        for members in groups.values():
+        group_of = list(parent_of)
+        for group_id, members in enumerate(groups.values()):
+            # A level that reproduces its parent's membership refines nothing, so applying the
+            # update would shrink the same records toward their own mean a second time. Champions
+            # with no published archetype hit this, and must land exactly where role-level pooling
+            # left them rather than being quietly pulled tighter.
+            if len({parent_of[position] for position in members}) == 1 and len(members) == sum(
+                1 for position in range(len(records)) if parent_of[position] == parent_of[members[0]]
+            ):
+                for position in members:
+                    group_of[position] = group_id
+                continue
+            for position in members:
+                group_of[position] = group_id
             index = np.array(members)
             spread = between_group_variance(raw[index], variance[index])
             precision = 1.0 / (variance[index] + spread)
@@ -1858,14 +2099,41 @@ def apply_partial_pooling(records: list[dict], levels: list[list[str]]) -> None:
             next_mean[index] = (group_mean / group_variance + parent_mean / parent_variance) / combined
             next_variance[index] = spread + 1.0 / combined
         prior_mean, prior_variance = next_mean, next_variance
+        parent_of = group_of
     posterior_variance = 1.0 / (1.0 / variance + 1.0 / prior_variance)
     posterior_mean = (raw / variance + prior_mean / prior_variance) * posterior_variance
     posterior_error = np.sqrt(posterior_variance)
+    bucket, bucket_confidence = posterior_buckets(posterior_mean, posterior_error)
     for position, record in enumerate(records):
         record["estimate"] = float(posterior_mean[position])
         record["posterior_standard_error"] = float(posterior_error[position])
+        record["evidence_bucket"] = bucket[position]
+        record["bucket_confidence"] = float(bucket_confidence[position])
         record["low"] = float(posterior_mean[position] - 1.96 * posterior_error[position])
         record["high"] = float(posterior_mean[position] + 1.96 * posterior_error[position])
+
+
+def posterior_buckets(
+    mean: np.ndarray,
+    error: np.ndarray,
+) -> tuple[list[str], np.ndarray]:
+    """
+    Favoured bucket per estimate and the posterior mass behind it.
+
+    A cell needs far more evidence to pin a <=3pp interval than to say which side of "typical" it
+    falls on, so the serving layer publishes a direction when it cannot publish a number. The mass is
+    computed here, where the posterior lives, so promotion can grade it with a plain column
+    comparison instead of materialising every row to evaluate a normal tail.
+    """
+    safe_error = np.maximum(error, 1e-9)
+    # P(lift > +threshold) and P(lift < -threshold) under the posterior.
+    above = 0.5 * erfc((BUCKET_THRESHOLD - mean) / (safe_error * math.sqrt(2)))
+    below = 0.5 * erfc((BUCKET_THRESHOLD + mean) / (safe_error * math.sqrt(2)))
+    typical = np.clip(1.0 - above - below, 0.0, 1.0)
+    stacked = np.vstack([below, typical, above])
+    labels = np.array(["BELOW_AVERAGE", "TYPICAL", "ABOVE_AVERAGE"])
+    winner = stacked.argmax(axis=0)
+    return list(labels[winner]), stacked.max(axis=0)
 
 
 def between_group_variance(values: np.ndarray, variance: np.ndarray) -> float:
@@ -2082,10 +2350,11 @@ def insert_estimates(connection, rows: list[tuple]) -> None:
             "RawWinRate", "PickRate", "ObservedCount", "EffectiveSampleSize",
             "AverageTimingMinutes", "PropensityOverlap", "CovariateBalance",
             "StableAcrossFolds", "IsPublishable", "EvidenceQuality", "FallbackScope",
-            "BaselineDefinition", "UnavailableReason", "ComputedAtUtc"
+            "BaselineDefinition", "EvidenceBucket", "BucketConfidence",
+            "UnavailableReason", "ComputedAtUtc"
         ) VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s::jsonb,
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW()
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW()
         )
         ON CONFLICT DO NOTHING
         """,

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import logging
 import re
 from datetime import datetime, timezone
@@ -15,11 +16,15 @@ from build_lab_modeler.pipeline import (
     FEATURE_COLUMNS,
     GLOBAL_PRIOR_VARIANCE,
     TIMED_FAMILIES,
+    UNKNOWN_ARCHETYPE,
+    UNVERIFIED_BORROW_WEIGHT,
     GenerationHeartbeat,
     LeaseLost,
+    PatchChangeSet,
     Settings,
     apply_partial_pooling,
     apply_row_weights,
+    commensurability_weights,
     average_timing,
     build_action_estimates,
     build_item_decisions,
@@ -1309,3 +1314,210 @@ def test_run_once_still_surfaces_an_unreachable_database(monkeypatch, tmp_path):
     # A one-shot invocation (CI / manual) must fail loudly rather than swallow the outage.
     with pytest.raises(operational_error):
         pipeline.run()
+
+
+# --- Phase A: adaptive per-cell borrowing -------------------------------------------------
+
+
+def _borrow_frame(current_win_rate: float, prior_win_rate: float, n: int = 400, champion: int = 103):
+    """One cell observed on both the current and the prior patch, with controllable disagreement."""
+    rows = []
+    for patch, rate in (("16.15", current_win_rate), ("16.14", prior_win_rate)):
+        wins = int(round(rate * n))
+        for index in range(n):
+            rows.append(
+                {
+                    "patch": patch,
+                    "champion_id": champion,
+                    "role": "MIDDLE",
+                    "family": "ITEM",
+                    "stage": 1,
+                    "action_key": "item:3157",
+                    "action_ids": json.dumps([3157]),
+                    "won": 1 if index < wins else 0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+NO_CHANGES = PatchChangeSet(items=frozenset(), runes=frozenset(), champions=frozenset())
+
+
+def test_borrowing_stays_strong_when_the_prior_patch_agrees():
+    frame = _borrow_frame(0.50, 0.50)
+
+    weights = commensurability_weights(frame, "16.15", NO_CHANGES)
+
+    current = weights[frame["patch"] == "16.15"]
+    prior = weights[frame["patch"] == "16.14"]
+    assert (current == 1.0).all(), "current-patch rows are never discounted"
+    assert prior.min() > 0.95, "an agreeing prior patch should borrow at close to full strength"
+
+
+def test_borrowing_collapses_across_a_meta_break():
+    # 50% -> 70% on 400 observations a side is a ~6 sigma split: the cell is not the same cell.
+    frame = _borrow_frame(0.50, 0.70)
+
+    weights = commensurability_weights(frame, "16.15", NO_CHANGES)
+
+    assert weights[frame["patch"] == "16.14"].max() < 0.05
+    assert (weights[frame["patch"] == "16.15"] == 1.0).all()
+
+
+def test_borrowing_decays_monotonically_with_disagreement():
+    previous = 1.1
+    for prior_rate in (0.50, 0.54, 0.58, 0.62, 0.70):
+        weight = commensurability_weights(_borrow_frame(0.50, prior_rate), "16.15", NO_CHANGES)
+        current = weight[_borrow_frame(0.50, prior_rate)["patch"] == "16.14"].max()
+        assert current < previous, f"weight must fall as disagreement grows (at {prior_rate})"
+        previous = current
+
+
+def test_a_thin_prior_cell_is_not_discarded_for_noise():
+    # Same 20-point gap, but on 12 observations it is well inside noise, so it must not be treated
+    # as a meta break the way the 400-observation version is.
+    thin = commensurability_weights(_borrow_frame(0.50, 0.70, n=12), "16.15", NO_CHANGES)
+    thick = commensurability_weights(_borrow_frame(0.50, 0.70, n=400), "16.15", NO_CHANGES)
+
+    assert thin[_borrow_frame(0.50, 0.70, n=12)["patch"] == "16.14"].max() > 0.5
+    assert thick[_borrow_frame(0.50, 0.70, n=400)["patch"] == "16.14"].max() < 0.05
+
+
+@pytest.mark.parametrize(
+    "changes,reason",
+    [
+        (PatchChangeSet(frozenset({3157}), frozenset(), frozenset()), "item was rebalanced"),
+        (PatchChangeSet(frozenset(), frozenset(), frozenset({103})), "champion was rebalanced"),
+        (PatchChangeSet(frozenset(), frozenset({3157}), frozenset()), "rune in the action changed"),
+    ],
+)
+def test_a_static_change_hard_excludes_the_prior_patch(changes, reason):
+    # Perfect agreement: only the static change set can be what zeroes these rows.
+    frame = _borrow_frame(0.50, 0.50)
+
+    weights = commensurability_weights(frame, "16.15", changes)
+
+    assert (weights[frame["patch"] == "16.14"] == 0.0).all(), reason
+    assert (weights[frame["patch"] == "16.15"] == 1.0).all(), "current patch is never excluded"
+
+
+def test_a_static_change_to_another_champion_does_not_block_this_one():
+    frame = _borrow_frame(0.50, 0.50, champion=103)
+    changes = PatchChangeSet(frozenset(), frozenset(), frozenset({64}))
+
+    weights = commensurability_weights(frame, "16.15", changes)
+
+    assert weights[frame["patch"] == "16.14"].min() > 0.95
+
+
+def test_a_prior_cell_with_no_current_counterpart_is_admitted_cautiously():
+    frame = _borrow_frame(0.50, 0.50)
+    frame = frame.loc[frame["patch"] == "16.14"].reset_index(drop=True)
+
+    weights = commensurability_weights(frame, "16.15", NO_CHANGES)
+
+    assert weights.max() == pytest.approx(UNVERIFIED_BORROW_WEIGHT)
+
+
+def test_adaptive_weights_flow_into_the_row_weights_and_drop_zeroed_rows():
+    frame = _borrow_frame(0.50, 0.50)
+    changes = PatchChangeSet(frozenset({3157}), frozenset(), frozenset())
+
+    weighted = apply_row_weights(frame, "16.15", ["16.15", "16.14"], None, changes)
+
+    assert set(weighted["patch"]) == {"16.15"}, "hard-excluded rows carry zero weight and are dropped"
+    assert (weighted["patch_weight"] == 1.0).all()
+
+
+def test_row_weights_are_unchanged_when_no_change_set_is_supplied():
+    frame = _borrow_frame(0.50, 0.50)
+
+    weighted = apply_row_weights(frame, "16.15", ["16.15", "16.14"], None)
+
+    prior = weighted.loc[weighted["patch"] == "16.14", "patch_weight"]
+    assert prior.nunique() == 1
+    assert prior.iloc[0] == pytest.approx(0.60), "falls back to the recency floor"
+
+
+# --- Phase B: archetype pooling -------------------------------------------------------------
+
+
+def _pool_records(divergent_estimate: float | None = None):
+    """Six champions sharing an action; four mages, two marksmen."""
+    records = []
+    for index, (champion, archetype, estimate) in enumerate(
+        [
+            (1, "mage", 0.020),
+            (2, "mage", 0.022),
+            (3, "mage", 0.018),
+            (4, "mage", divergent_estimate if divergent_estimate is not None else 0.021),
+            (5, "marksman", -0.015),
+            (6, "marksman", -0.017),
+        ]
+    ):
+        records.append(
+            {
+                "champion_id": champion,
+                "role": "MIDDLE",
+                "archetype": archetype,
+                "family": "ITEM",
+                "stage": 1,
+                "action_key": "item:3157",
+                "raw_estimate": estimate,
+                "standard_error": 0.010,
+            }
+        )
+    return records
+
+
+ARCHETYPE_LEVELS = [
+    ["family", "stage", "action_key"],
+    ["family", "stage", "action_key", "role"],
+    ["family", "stage", "action_key", "role", "archetype"],
+]
+ROLE_LEVELS = ARCHETYPE_LEVELS[:2]
+
+
+def test_archetype_pooling_narrows_the_posterior_for_a_typical_champion():
+    with_archetype = _pool_records()
+    without = _pool_records()
+    apply_partial_pooling(with_archetype, ARCHETYPE_LEVELS)
+    apply_partial_pooling(without, ROLE_LEVELS)
+
+    tighter = with_archetype[0]["posterior_standard_error"]
+    looser = without[0]["posterior_standard_error"]
+    assert tighter <= looser, "adding a level must not widen a well-supported cell"
+
+
+def test_archetype_pooling_does_not_flatten_a_genuinely_divergent_champion():
+    # Champion 4 is a mage whose true effect is the opposite sign of its archetype.
+    records = _pool_records(divergent_estimate=-0.030)
+    apply_partial_pooling(records, ARCHETYPE_LEVELS)
+
+    divergent = next(r for r in records if r["champion_id"] == 4)
+    peers = [r["estimate"] for r in records if r["champion_id"] in (1, 2, 3)]
+
+    assert divergent["estimate"] < min(peers), "a divergent champion must not be pulled to its peers"
+    assert divergent["estimate"] < 0, "the sign of a strongly-observed divergence must survive"
+
+
+def test_posterior_interval_matches_the_posterior_it_reports():
+    records = _pool_records()
+    apply_partial_pooling(records, ARCHETYPE_LEVELS)
+
+    for record in records:
+        width = record["high"] - record["low"]
+        assert width == pytest.approx(2 * 1.96 * record["posterior_standard_error"], rel=1e-9)
+        assert record["low"] < record["estimate"] < record["high"]
+
+
+def test_unknown_archetype_degrades_to_role_level_pooling():
+    records = _pool_records()
+    for record in records:
+        record["archetype"] = UNKNOWN_ARCHETYPE
+    reference = _pool_records()
+    apply_partial_pooling(records, ARCHETYPE_LEVELS)
+    apply_partial_pooling(reference, ROLE_LEVELS)
+
+    for pooled, expected in zip(records, reference, strict=True):
+        assert pooled["estimate"] == pytest.approx(expected["estimate"], rel=1e-6)

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1038,6 +1038,9 @@ class LostLeaseHeartbeat:
     def raise_if_lease_lost(self) -> None:
         raise LeaseLost("the modeling lease was reclaimed")
 
+    def touch(self) -> None:
+        """A lost lease is never renewed, inline or otherwise."""
+
 
 def test_a_lease_lost_before_publishing_writes_no_artifacts_and_no_estimates(tmp_path, monkeypatch):
     settings, generation = publishing_generation(monkeypatch, tmp_path)
@@ -1521,3 +1524,58 @@ def test_unknown_archetype_degrades_to_role_level_pooling():
 
     for pooled, expected in zip(records, reference, strict=True):
         assert pooled["estimate"] == pytest.approx(expected["estimate"], rel=1e-6)
+
+
+def test_touch_renews_inline_so_a_gil_bound_load_cannot_lose_the_lease(monkeypatch):
+    # The timer thread cannot be scheduled while a loader assembles millions of rows through a raw
+    # DBAPI cursor, which is what reaped five consecutive healthy generations. touch() renews on the
+    # thread doing the work, so progress itself keeps the lease alive.
+    settings = modeler_settings(monkeypatch)
+    heartbeat = GenerationHeartbeat(settings, uuid4())
+    renewed = FakeConnection([FakeCursor(1), FakeCursor(1)])
+    monkeypatch.setattr(pipeline.psycopg, "connect", lambda *_, **__: renewed)
+
+    heartbeat.touch()
+
+    statement, parameters = renewed.statements[-1]
+    assert '"LeaseExpiresAtUtc" = NOW() + make_interval(secs => %s)' in statement
+    assert parameters[0] == settings.lease_seconds
+
+
+def test_touch_is_a_no_op_once_the_lease_is_provably_gone(monkeypatch):
+    settings = modeler_settings(monkeypatch)
+    heartbeat = GenerationHeartbeat(settings, uuid4())
+    reclaimed = FakeConnection([FakeCursor(0)])
+    monkeypatch.setattr(pipeline.psycopg, "connect", lambda *_, **__: reclaimed)
+    assert heartbeat._renew() is False
+
+    before = len(reclaimed.statements)
+    heartbeat.touch()
+
+    # A reclaimed lease must not be silently taken back by a later inline renewal.
+    assert len(reclaimed.statements) == before
+
+
+def test_every_loader_phase_renews_the_lease_between_stages():
+    source = inspect.getsource(pipeline.model_generation)
+    # Each loader is minutes of GIL-holding work; the deadline has to advance between them.
+    assert "heartbeat.touch()" in source
+    for loader in (
+        "load_item_events",
+        "load_timeline_state_events",
+        "load_participant_teams",
+        "load_rune_decisions",
+        "load_spell_decisions",
+    ):
+        assert f"loaded(" in source and loader in source, loader
+
+
+def test_the_default_lease_clears_the_longest_observed_load_phase(monkeypatch):
+    monkeypatch.delenv("BUILD_LAB_LEASE_SECONDS", raising=False)
+    settings = modeler_settings(monkeypatch)
+
+    # Five consecutive generations were reaped 25-30 minutes in at the old 900s default.
+    assert settings.lease_seconds >= 1800
+    # The reaper's own backstop must still be the outer bound.
+    assert settings.lease_seconds < 120 * 60
+    assert settings.heartbeat_seconds <= settings.lease_seconds // 4

--- a/apps/web/components/BuildLab.test.tsx
+++ b/apps/web/components/BuildLab.test.tsx
@@ -50,6 +50,8 @@ const gatedCandidate: AdjustedActionEstimate = {
   fallbackScope: "NONE",
   regionScope: "NA1",
   baselineDefinition: "Other first legendary items bought in the same decision.",
+  evidenceTier: "DESCRIPTIVE",
+  evidenceBucket: null,
   isPublishable: false,
   unavailableReason: "Withheld: 42 observed games is below the publication gate for this cell."
 };
@@ -69,6 +71,8 @@ const publishableCandidate: AdjustedActionEstimate = {
   fallbackScope: "GLOBAL_FALLBACK",
   regionScope: "GLOBAL",
   baselineDefinition: "Other first legendary items bought in the same decision.",
+  evidenceTier: "NUMERIC",
+  evidenceBucket: null,
   isPublishable: true,
   unavailableReason: null
 };
@@ -238,6 +242,64 @@ describe("BuildLab", () => {
     expect(screen.getByText("Estimated win probability").nextElementSibling?.textContent).toBe("—");
 
     await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalled());
+  });
+
+  it("publishes a direction for a bucketed candidate instead of withholding everything", async () => {
+    // A fortnightly patch rarely earns a <=3pp interval in time. A cell whose posterior still
+    // concentrates on one side of "typical" says so rather than going dark.
+    renderLab({
+      response: {
+        stages: [
+          {
+            family: "ITEM",
+            stage: 1,
+            label: "First item",
+            candidates: [
+              {
+                ...gatedCandidate,
+                actionKey: "ITEM:3153",
+                evidenceTier: "BUCKETED",
+                evidenceBucket: "ABOVE_AVERAGE",
+                unavailableReason: "The confidence interval is too wide."
+              }
+            ]
+          }
+        ]
+      }
+    });
+    const row = candidateRow("Blade of the Ruined King");
+    const cells = within(row).getAllByRole("cell");
+
+    expect(cells[1].textContent).toBe("Above average");
+    expect(cells[1].textContent).not.toContain("Insufficient evidence");
+    // The number is still withheld: only the direction was earned.
+    expect(cells[2].textContent).toBe("Direction only");
+  });
+
+  it("renders a below-average bucket in the loss tone, not the action accent", async () => {
+    renderLab({
+      response: {
+        stages: [
+          {
+            family: "ITEM",
+            stage: 1,
+            label: "First item",
+            candidates: [
+              {
+                ...gatedCandidate,
+                evidenceTier: "BUCKETED",
+                evidenceBucket: "BELOW_AVERAGE"
+              }
+            ]
+          }
+        ]
+      }
+    });
+    const cells = within(candidateRow("Blade of the Ruined King")).getAllByRole("cell");
+
+    expect(cells[1].textContent).toBe("Below average");
+    expect(cells[1].className).toContain("text-danger");
+    expect(cells[1].className).not.toContain("text-primary");
   });
 
   it("states why a gated candidate is unavailable and shows no headline estimate for it", async () => {

--- a/apps/web/components/BuildLab.tsx
+++ b/apps/web/components/BuildLab.tsx
@@ -28,6 +28,8 @@ import {
   savedRuneSelections,
   selectBuildLabCandidate,
   undoLastBuildLabSelection,
+  bucketLabel,
+  bucketToneClass,
   wpaToneClass,
   type AdjustedActionEstimate,
   type BuildLabMode,
@@ -320,15 +322,27 @@ function StageTable({
               <td
                 className={cn(
                   "px-3 py-3 text-right font-semibold tabular-nums",
-                  candidate.isPublishable ? wpaToneClass(candidate.adjustedWpa) : "text-muted"
+                  candidate.isPublishable
+                    ? wpaToneClass(candidate.adjustedWpa)
+                    : candidate.evidenceTier === "BUCKETED"
+                      ? bucketToneClass(candidate.evidenceBucket)
+                      : "text-muted"
                 )}
               >
-                {candidate.isPublishable ? formatWpa(candidate.adjustedWpa) : "Insufficient evidence"}
+                {/* A bucketed cell states the direction its posterior supports and withholds the
+                    number its interval cannot. Only a descriptive cell says nothing. */}
+                {candidate.isPublishable
+                  ? formatWpa(candidate.adjustedWpa)
+                  : candidate.evidenceTier === "BUCKETED"
+                    ? bucketLabel(candidate.evidenceBucket)
+                    : "Insufficient evidence"}
               </td>
               <td className="px-3 py-3 text-right tabular-nums text-fg/72">
                 {candidate.isPublishable
                   ? `${formatWpa(candidate.confidenceLow)} to ${formatWpa(candidate.confidenceHigh)}`
-                  : "—"}
+                  : candidate.evidenceTier === "BUCKETED"
+                    ? "Direction only"
+                    : "—"}
               </td>
               <td className="px-3 py-3 text-right tabular-nums text-fg/72">
                 {formatCompactCount(candidate.observedCount)} /{" "}

--- a/apps/web/components/ChampionRecommendation.test.tsx
+++ b/apps/web/components/ChampionRecommendation.test.tsx
@@ -24,6 +24,8 @@ function estimate(overrides: Partial<AdjustedActionEstimate> = {}): AdjustedActi
     fallbackScope: "NONE",
     regionScope: "NA1",
     baselineDefinition: "Other first legendary items bought in the same decision.",
+    evidenceTier: "NUMERIC" as const,
+    evidenceBucket: null,
     isPublishable: true,
     unavailableReason: null,
     ...overrides

--- a/apps/web/lib/buildLab.ts
+++ b/apps/web/lib/buildLab.ts
@@ -51,6 +51,15 @@ export type BuildLabContext = {
   mode: string;
 };
 
+export type EvidenceTier = "NUMERIC" | "BUCKETED" | "DESCRIPTIVE";
+export type EvidenceBucket = "ABOVE_AVERAGE" | "TYPICAL" | "BELOW_AVERAGE";
+
+export const EVIDENCE_BUCKET_LABEL: Record<EvidenceBucket, string> = {
+  ABOVE_AVERAGE: "Above average",
+  TYPICAL: "Typical",
+  BELOW_AVERAGE: "Below average"
+};
+
 export type AdjustedActionEstimate = {
   actionKey: string;
   actionIds: number[];
@@ -71,6 +80,13 @@ export type AdjustedActionEstimate = {
   regionScope: string;
   /** The comparison set the lift is measured against — disclosed, never implied. */
   baselineDefinition: string;
+  /**
+   * How much of the estimate may be shown. A fortnightly patch rarely earns a <=3pp interval in
+   * time, so a cell that cannot support a number can still support a direction.
+   */
+  evidenceTier: EvidenceTier;
+  /** Only meaningful at the BUCKETED tier. */
+  evidenceBucket?: EvidenceBucket | null;
   isPublishable: boolean;
   unavailableReason?: string | null;
 };
@@ -472,6 +488,17 @@ export function buildLabRegionOptions(
 export function wpaToneClass(value?: number | null) {
   if (value == null || value === 0) return "text-fg";
   return value > 0 ? "text-success" : "text-danger";
+}
+
+/** Same win/loss semantics as a numeric lift, so a direction reads the same way a number would. */
+export function bucketToneClass(bucket?: EvidenceBucket | null) {
+  if (bucket === "ABOVE_AVERAGE") return "text-success";
+  if (bucket === "BELOW_AVERAGE") return "text-danger";
+  return "text-fg";
+}
+
+export function bucketLabel(bucket?: EvidenceBucket | null) {
+  return bucket ? EVIDENCE_BUCKET_LABEL[bucket] : "Insufficient evidence";
 }
 
 export function humanizeToken(value: string | null | undefined) {

--- a/compose.yml
+++ b/compose.yml
@@ -238,8 +238,9 @@ services:
       BUILD_LAB_POLL_SECONDS: ${BUILD_LAB_POLL_SECONDS:-300}
       BUILD_LAB_RUN_ONCE: ${BUILD_LAB_RUN_ONCE:-false}
       # Keep BUILD_LAB_LEASE_SECONDS below the worker's Analytics:BuildLab:LeaseTimeoutMinutes so the
-      # heartbeat renews before the .NET reaper reclaims a healthy run.
-      BUILD_LAB_LEASE_SECONDS: ${BUILD_LAB_LEASE_SECONDS:-900}
+      # heartbeat renews before the .NET reaper reclaims a healthy run. It must also clear the longest
+      # single load phase: at 900s the reaper killed five consecutive healthy generations 25-30 minutes in.
+      BUILD_LAB_LEASE_SECONDS: ${BUILD_LAB_LEASE_SECONDS:-3600}
       BUILD_LAB_HEARTBEAT_SECONDS: ${BUILD_LAB_HEARTBEAT_SECONDS:-60}
       BUILD_LAB_MAX_TRAINING_ROWS: ${BUILD_LAB_MAX_TRAINING_ROWS:-250000}
       # BUILD_LAB_LEASE_OWNER is intentionally NOT set: the modeler derives `hostname:pid`, so two

--- a/docs/API.md
+++ b/docs/API.md
@@ -511,6 +511,26 @@ client can show how thin a cell is and `evidenceQuality` / `unavailableReason` s
 The same rule applies to `pathEstimate`: `estimatedWinProbability`, `adjustedLift`, and both bounds are
 null when the path failed its gates, while its counts remain visible.
 
+**`evidenceTier` decides how much of a cell may be shown.** Publication is not all-or-nothing.
+Patches ship fortnightly, and a cell needs far more evidence to pin a ≤3pp interval than to say which
+side of "typical" it falls on, so gating everything on the interval would leave the lab empty for most
+of a patch.
+
+| `evidenceTier` | Meaning | Client renders |
+| --- | --- | --- |
+| `NUMERIC` | Every v1 gate passed | `adjustedWpa` and its interval |
+| `BUCKETED` | Sample gates passed; only the interval-width gate failed, and the posterior still concentrates in one bucket | `evidenceBucket` (`ABOVE_AVERAGE` / `TYPICAL` / `BELOW_AVERAGE`); no number |
+| `DESCRIPTIVE` | Not enough evidence for either | pick rate and timing only |
+
+`evidenceBucket` is non-null only at the `BUCKETED` tier — a numeric cell shows its number and a
+descriptive one has not earned a direction. Bucketing never relaxes the sample, overlap, balance, or
+stability gates; it trades away *only* the interval width, and only when the modeler measured at least
+80% posterior mass on one side. `available` is true once any candidate is numeric **or** bucketed.
+
+Ranking is deliberately independent of the tier: `mode=supported` orders by the interval's lower bound
+where one exists and by the point estimate otherwise, so a bucketed candidate is ranked on the evidence
+it has rather than sinking below cells with no evidence at all.
+
 **Regional fallback is decided per cell, not per response.** For a regional request each individual
 estimate keeps its regional number only when that cell is publishable *and* differs meaningfully
 from the pooled global baseline after multiple-comparison correction; otherwise that one cell serves

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -512,6 +512,39 @@ Everything else under `Analytics:BuildLab` (the publication thresholds below, `D
 `PriorPatchesToBorrow`, `RetainedGenerations`, `RetiredGenerationGraceMinutes`) is config-file only —
 set it in `config/backend.shared.json`, not through an env var.
 
+#### Adaptive patch borrowing
+
+`PriorPatchesToBorrow` is a **ceiling**, not a schedule. Patches ship fortnightly, so a fixed per-patch
+weight is the wrong instrument: it discards good data from the champions a patch never touched and
+keeps data from the ones it rebalanced. Recency sets the ceiling; each borrowed row then keeps only the
+fraction of it that its cell still deserves:
+
+- **Static change → 0.** A rebalance to the champion, the item, or a rune in the action hard-excludes
+  the borrowed row. Detected by diffing per-patch static data: `ItemVersions` and `RuneVersions` from
+  Community Dragon, and `ChampionVersions.BalanceHash` — a hash of a *numeric-only* Data Dragon
+  projection (base stats plus each spell's cooldown/cost/range/effect). Measured against live data that
+  projection flags 0 of 173 champions across a cosmetic-only patch, where a whole-record diff flags 10
+  on `skins` alone, and 11 of 173 across a real balance patch.
+- **Otherwise, a commensurability discount.** The current-vs-prior disagreement for that exact cell is
+  scored as a z-score and decayed, so an agreeing cell borrows at nearly full strength, a thin cell is
+  not thrown away for noise, and a cell that drifted for reasons static data cannot see (indirect
+  interactions, system changes) decays to zero on its own.
+
+Both halves matter because they are complementary *in time*: the drift test needs current-patch data to
+have power and is weakest in the first days of a patch, which is exactly when static detection is
+instant. Static detection in turn cannot see indirect or systemic changes, which the drift test can.
+
+Known and accepted over-flag: Riot is migrating spells off `effect` onto dataValues, so an effect array
+can drop to zeros with no balance change (Warwick did this in 16.15). That costs one champion's
+borrowing for a patch. Excluding `effect` from the hash would instead miss four real changes in the same
+patch and borrow across them, so the projection keeps it — a false positive costs coverage, a false
+negative biases an estimate.
+
+Champion `Roles` from the same table feed archetype pooling: an item's effect on a burst mage says more
+about the same item on another burst mage than the role average does, so a sparse champion shrinks
+toward champions that play like it. A champion with no published roles pools at the role level exactly
+as before.
+
 `BUILD_LAB_DEIDENTIFICATION_SALT` is a secret and ships as an **empty** placeholder in `.env.example`;
 generate a real one (`openssl rand -hex 32`) into the deployed `.env` before enabling Build Lab and
 never commit it. It keys the HMAC surrogate match/participant ids in the Parquet export, so a guessable

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -6175,6 +6175,7 @@
           "baselineDefinition",
           "effectiveSampleSize",
           "evidenceQuality",
+          "evidenceTier",
           "fallbackScope",
           "isPublishable",
           "observedCount",
@@ -6241,6 +6242,13 @@
           },
           "baselineDefinition": {
             "type": "string"
+          },
+          "evidenceTier": {
+            "type": "string"
+          },
+          "evidenceBucket": {
+            "type": "string",
+            "nullable": true
           },
           "isPublishable": {
             "type": "boolean"

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -5287,6 +5287,8 @@ export interface components {
             fallbackScope: string;
             regionScope: string;
             baselineDefinition: string;
+            evidenceTier: string;
+            evidenceBucket?: string | null;
             isPublishable: boolean;
             unavailableReason?: string | null;
         };

--- a/tests/Transcendence.Service.Core.Tests/ChampionBalanceHashTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/ChampionBalanceHashTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using FluentAssertions;
+using Transcendence.Service.Core.Services.StaticData.Implementations;
+
+namespace Transcendence.Service.Core.Tests;
+
+/// <summary>
+/// Pins the champion balance projection that adaptive patch borrowing depends on. A false positive
+/// silently costs borrowing power; a false negative borrows across a real nerf and biases the
+/// estimate. The fixtures are trimmed real Data Dragon records so the properties are asserted
+/// against the data the job actually ingests.
+/// </summary>
+public class ChampionBalanceHashTests
+{
+    private static JsonElement Champion(string json) => JsonDocument.Parse(json).RootElement;
+
+    // Real Data Dragon shape, reduced to the fields the projection reads.
+    private const string AhriBase = """
+    {
+      "id": "Ahri", "key": "103", "name": "Ahri", "partype": "Mana",
+      "stats": { "hp": 590, "hpperlevel": 104, "armor": 21, "armorperlevel": 4.2,
+                 "attackdamage": 53, "attackspeed": 0.668 },
+      "spells": [
+        { "id": "AhriQ", "maxrank": 5, "cooldown": [7,7,7,7,7], "cost": [55,65,75,85,95],
+          "range": [970,970,970,970,970], "effect": [null,[40,65,90,115,140]] }
+      ]
+    }
+    """;
+
+    [Fact]
+    public void CosmeticOnlyDifferencesDoNotChangeTheHash()
+    {
+        // Data Dragon churns skins and lore constantly. Across 16.13 -> 16.14 a whole-record diff
+        // flags 10 of 173 champions on `skins` alone while this projection flags none, so those
+        // fields must never reach the hash.
+        var withCosmetics = AhriBase.TrimEnd()[..^1] +
+            """, "skins": [{"id":"103014","name":"Star Guardian Ahri"}], "lore": "rewritten blurb", "title": "the Nine-Tailed Fox" }""";
+
+        ChampionBalanceHash(withCosmetics).Should().Be(ChampionBalanceHash(AhriBase));
+    }
+
+    [Theory]
+    [InlineData("\"hp\": 590", "\"hp\": 610", "base stat")]
+    [InlineData("\"armorperlevel\": 4.2", "\"armorperlevel\": 5.0", "per-level growth")]
+    [InlineData("[7,7,7,7,7]", "[6,6,6,6,6]", "spell cooldown")]
+    [InlineData("[55,65,75,85,95]", "[50,60,70,80,90]", "spell cost")]
+    [InlineData("[970,970,970,970,970]", "[900,900,900,900,900]", "spell range")]
+    [InlineData("[40,65,90,115,140]", "[45,70,95,120,145]", "spell effect")]
+    public void EveryBalanceLeverChangesTheHash(string before, string after, string lever)
+    {
+        var rebalanced = AhriBase.Replace(before, after);
+        rebalanced.Should().NotBe(AhriBase, $"the {lever} fixture must actually differ");
+
+        ChampionBalanceHash(rebalanced).Should().NotBe(ChampionBalanceHash(AhriBase), lever);
+    }
+
+    [Fact]
+    public void DataDragonZeroingAnEffectArrayIsTreatedAsAChange()
+    {
+        // Riot is migrating spells off `effect` onto dataValues, so an effect array can drop to zeros
+        // with no balance change behind it (Warwick did exactly this in 16.15). That is a known
+        // over-flag and it is the safe direction: it costs one champion's borrowing for a patch,
+        // whereas ignoring `effect` would miss four real changes in the same patch and borrow across
+        // them. The empirical drift test is what recovers the lost coverage.
+        var zeroed = AhriBase.Replace("[40,65,90,115,140]", "[0,0,0,0,0]");
+
+        ChampionBalanceHash(zeroed).Should().NotBe(ChampionBalanceHash(AhriBase));
+    }
+
+    [Fact]
+    public void StatOrderingAndFormattingDoNotChangeTheHash()
+    {
+        // Projection sorts stats and normalises numeric formatting, so key order and 590 vs 590.0
+        // must not read as a rebalance.
+        var reordered = """
+        {
+          "id": "Ahri", "key": "103", "name": "Ahri", "partype": "Mana",
+          "stats": { "attackspeed": 0.668, "armorperlevel": 4.2, "attackdamage": 53.0,
+                     "armor": 21, "hpperlevel": 104, "hp": 590.0 },
+          "spells": [
+            { "id": "AhriQ", "maxrank": 5, "cooldown": [7,7,7,7,7], "cost": [55,65,75,85,95],
+              "range": [970,970,970,970,970], "effect": [null,[40,65,90,115,140]] }
+          ]
+        }
+        """;
+
+        ChampionBalanceHash(reordered).Should().Be(ChampionBalanceHash(AhriBase));
+    }
+
+    [Fact]
+    public void MissingSpellsOrStatsStillProduceAStableHash()
+    {
+        var sparse = """{ "id": "X", "key": "1", "name": "X" }""";
+
+        var hash = ChampionBalanceHash(sparse);
+
+        hash.Should().HaveLength(64);
+        hash.Should().Be(ChampionBalanceHash(sparse));
+    }
+
+    private static string ChampionBalanceHash(string json) =>
+        StaticDataService.ComputeChampionBalanceHash(Champion(json));
+}

--- a/tests/Transcendence.Service.Core.Tests/StaticDataServiceTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/StaticDataServiceTests.cs
@@ -57,7 +57,8 @@ public class StaticDataServiceTests
     }
 
     [Theory]
-    [InlineData(false, 2)]
+    // One removal per memoized static-data fetch: runes, items, and champion balance data.
+    [InlineData(false, 3)]
     [InlineData(true, 0)]
     public async Task EnsureStaticDataForPatchAsync_RemovesOnlyNonAuthoritativeCacheEntries(
         bool shouldCache,

--- a/tests/Transcendence.Service.Core.Tests/Support/SqliteCompatibleTranscendenceContext.cs
+++ b/tests/Transcendence.Service.Core.Tests/Support/SqliteCompatibleTranscendenceContext.cs
@@ -18,5 +18,8 @@ internal sealed class SqliteCompatibleTranscendenceContext(DbContextOptions<Tran
         modelBuilder.Entity<ItemVersion>()
             .Property(x => x.BuildsInto)
             .HasDefaultValueSql("'[]'");
+        modelBuilder.Entity<ChampionVersion>()
+            .Property(x => x.Roles)
+            .HasDefaultValueSql("'[]'");
     }
 }


### PR DESCRIPTION
## What's happening

Five consecutive generations were reaped 25–30 minutes in. **Every one of them was healthy and making progress.**

| Created | Matches | Outcome |
|---|---|---|
| 21:15 | 20,093 | lease expiry @ 21:41 |
| 22:15 | 21,590 | lease expiry @ 22:46 |
| 23:15 | 21,896 | lease expiry @ 23:40 |
| 00:15 | 22,828 | lease expiry @ 00:42 |
| 01:15 | 24,042 | lease expiry @ 01:40 |

Result: **0 estimates ever produced.** The pipeline has never completed a run.

## Why

The heartbeat runs in a timer thread, but loading the frozen dataset assembles millions of rows through a raw DBAPI cursor — pure-Python work that holds the GIL for minutes — so the thread never gets scheduled. Measured staleness during one load, against a 60s interval:

```
12s → 5s → 56s → 54s → 193s → (climbing)
```

The reaper then does exactly what it was built to do and kills a run that was working the whole time. This is self-inflicted: the lease/reaper was designed to catch a *dead* worker and tuned so it also kills a *slow* one.

(My first guess was that the heartbeat shared the main connection. It doesn't — it opens its own. The mechanism is GIL starvation, which the staleness curve demonstrates: healthy during I/O phases, degrading as CPU-bound assembly dominates.)

## Fix

- **`touch()` renews on the calling thread**, and each loader phase renews after it completes. Progress itself advances the deadline, immune to GIL contention.
- **Default lease 900s → 3600s.** A single loader can exceed fifteen minutes on this corpus, so the deadline must clear the longest *single* phase even with inline renewals — fix 1 alone doesn't cover a phase that outruns the lease on its own. `LeaseTimeoutMinutes` (120) remains the outer bound for a lease that never wrote an expiry.
- **A reclaimed lease is still never taken back**: `touch()` is a no-op once the lease is provably gone, so this cannot resurrect a run the reaper legitimately killed.

## Verification

72 modeler tests pass (+4), covering: inline renewal writes the deadline, `touch()` no-ops after a lost lease, every loader phase renews between stages, and the default lease clears the observed load window while staying under the reaper's backstop.

## Not fixed here

The root cause is the unchunked loader I flagged when reviewing the modeler — `load_item_events` materialises one pandas row per item event for the whole cohort. It now bites as lease expiry before it bites as memory. Chunked/streamed loading is the real fix and is a redesign, not a surgical change.