### PR TITLE
Replace the modeling lease with a Postgres advisory lock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,18 +58,9 @@ BUILD_LAB_RUN_ONCE=false
 # deidentified Parquet export; a guessable salt makes the export re-identifiable. The modeler refuses
 # to start when it is empty or shorter than 32 characters. Never commit a real value.
 BUILD_LAB_DEIDENTIFICATION_SALT=
-# Lease coordination. The modeler stamps LeaseExpiresAtUtc = now + LEASE_SECONDS when it claims a
-# generation and pushes that deadline forward every HEARTBEAT_SECONDS, so a healthy run is never
-# reclaimed and a DEAD one is reclaimed LEASE_SECONDS after its last heartbeat (at the next promote
-# tick, i.e. ~25 min at the default 10-minute cron). LEASE_SECONDS is therefore the knob that sets
-# reclamation speed.
-BUILD_LAB_LEASE_SECONDS=900
-BUILD_LAB_HEARTBEAT_SECONDS=60
-# Backstop ONLY, and not the same clock: the worker applies it to a `Modeling` row whose
-# LeaseExpiresAtUtc is NULL, measured from HeartbeatAtUtc/LeaseAcquiredAtUtc/CreatedAtUtc. The modeler
-# always writes a deadline, so this covers a row that reached `Modeling` some other way (manual SQL, a
-# future writer). Changing it does not make a dead modeler get reclaimed any sooner.
-BUILD_LAB_LEASE_TIMEOUT_MINUTES=120
+# Exclusivity is a PostgreSQL session advisory lock the modeler holds for the whole run, so there
+# is nothing to tune here: a crashed or killed modeler drops its session and the lock with it, and
+# the coordinator decides abandonment by probing that same lock rather than by any timeout.
 # Chronological sample ceiling for the structural win model's design matrix (floor 20000).
 BUILD_LAB_MAX_TRAINING_ROWS=250000
 BUILD_LAB_LOG_LEVEL=INFO

--- a/Transcendence.Data/Models/LoL/Analytics/BuildLabGeneration.cs
+++ b/Transcendence.Data/Models/LoL/Analytics/BuildLabGeneration.cs
@@ -35,11 +35,17 @@ public class BuildLabGeneration
     public string ValidationMetricsJson { get; set; } = "{}";
     public string? FailureReason { get; set; }
 
-    /// <summary>Identity of the modeler process currently holding the generation, when Modeling.</summary>
+    /// <summary>
+    /// Identity of the modeler process that claimed the generation, for diagnostics only.
+    /// </summary>
+    /// <remarks>
+    /// Liveness is not tracked here. The modeler holds a PostgreSQL session advisory lock for the
+    /// whole run, so a dead process releases it when its session drops and the coordinator decides
+    /// abandonment by probing that lock. An expiry/heartbeat pair used to live alongside this and
+    /// reaped six consecutive healthy runs, because the renewal thread could not win the GIL against
+    /// a multi-minute load.
+    /// </remarks>
     public string? LeaseOwner { get; set; }
-    public DateTime? LeaseAcquiredAtUtc { get; set; }
-    public DateTime? LeaseExpiresAtUtc { get; set; }
-    public DateTime? HeartbeatAtUtc { get; set; }
 
     /// <summary>Append-only [{action, atUtc, actor, reason}] audit of promote/rollback/fail.</summary>
     public string PromotionHistoryJson { get; set; } = "[]";

--- a/Transcendence.Data/TranscendenceContext.cs
+++ b/Transcendence.Data/TranscendenceContext.cs
@@ -1012,8 +1012,9 @@ public class TranscendenceContext(DbContextOptions<TranscendenceContext> options
             entity.Property(x => x.LeaseOwner).HasMaxLength(128);
             entity.Property(x => x.PromotionHistoryJson).HasColumnType("jsonb");
             entity.HasIndex(x => new { x.Patch, x.Status, x.CompletedAtUtc });
-            // Lease reaper: equality on Status, range scan on the expiry.
-            entity.HasIndex(x => new { x.Status, x.LeaseExpiresAtUtc });
+            // The abandoned-run reaper selects purely on Status; liveness comes from the advisory
+            // lock, so there is no expiry column to range-scan.
+            entity.HasIndex(x => x.Status);
             entity.HasIndex(x => x.IsActive)
                 .IsUnique()
                 .HasFilter("\"IsActive\"");

--- a/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
@@ -25,6 +25,9 @@ public sealed class BuildLabGenerationCoordinator(
     ILogger<BuildLabGenerationCoordinator> logger) : IBuildLabGenerationCoordinator
 {
     // Serialises every active-pointer flip against the unique active index, whichever process runs it.
+    /// <summary>Must match MODELING_LOCK_KEY in the modeler; both hash it with hashtextextended.</summary>
+    private const string ModelingLockKey = "build-lab-generation-modeling";
+
     private const string PromotionLockSql =
         "SELECT pg_advisory_xact_lock(hashtextextended('build-lab-generation-promotion', 0))";
     // Grading rewrites the candidate's whole estimate set and the pointer flip publishes it, so both run
@@ -55,7 +58,7 @@ public sealed class BuildLabGenerationCoordinator(
         if (!options.Enabled)
             return null;
 
-        await ReapExpiredModelingLeasesAsync(ct);
+        await ReapAbandonedModelingRunsAsync(ct);
 
         var patch = await context.Patches
             .AsNoTracking()
@@ -131,7 +134,7 @@ public sealed class BuildLabGenerationCoordinator(
         if (!options.Enabled)
             return 0;
 
-        await ReapExpiredModelingLeasesAsync(ct);
+        await ReapAbandonedModelingRunsAsync(ct);
 
         var candidates = await context.BuildLabGenerations
             .AsNoTracking()
@@ -238,7 +241,6 @@ public sealed class BuildLabGenerationCoordinator(
             generation.RetiredAtUtc = null;
             generation.CompletedAtUtc ??= now;
             generation.LeaseOwner = null;
-            generation.LeaseExpiresAtUtc = null;
             generation.PromotionHistoryJson =
                 AppendHistory(generation.PromotionHistoryJson, "promote", actor, null);
             await context.SaveChangesAsync(ct);
@@ -334,8 +336,6 @@ public sealed class BuildLabGenerationCoordinator(
                 generation.ValidationMetricsJson,
                 generation.FailureReason,
                 generation.LeaseOwner,
-                generation.LeaseExpiresAtUtc,
-                generation.HeartbeatAtUtc,
                 generation.PromotionHistoryJson,
                 generation.CreatedAtUtc,
                 generation.CompletedAtUtc,
@@ -418,19 +418,18 @@ public sealed class BuildLabGenerationCoordinator(
                 {
                     generation.Status,
                     generation.CreatedAtUtc,
-                    generation.CompletedAtUtc,
-                    generation.LeaseAcquiredAtUtc,
-                    generation.HeartbeatAtUtc
+                    generation.CompletedAtUtc
                 })
                 .ToListAsync(ct);
             telemetry.RecordInFlightStatusAges(
                 inFlight
                     .Where(row => row.Status == BuildLabGenerationStatus.PendingDataset)
                     .Min(row => (DateTime?)row.CreatedAtUtc),
-                // Same clock the reaper uses, so the wedge gauge and the lease timeout agree.
+                // How long the run has been going, which is all the wedge gauge can mean now that
+                // liveness is the advisory lock rather than a timestamp.
                 inFlight
                     .Where(row => row.Status == BuildLabGenerationStatus.Modeling)
-                    .Min(row => (DateTime?)(row.HeartbeatAtUtc ?? row.LeaseAcquiredAtUtc ?? row.CreatedAtUtc)),
+                    .Min(row => (DateTime?)row.CreatedAtUtc),
                 inFlight
                     .Where(row => row.Status == BuildLabGenerationStatus.Candidate)
                     .Min(row => (DateTime?)(row.CompletedAtUtc ?? row.CreatedAtUtc)));
@@ -566,36 +565,59 @@ public sealed class BuildLabGenerationCoordinator(
     // enforced here, whichever fires first: a claimer that declared a short expiry and stopped is reaped
     // at that expiry, one that declared a distant expiry and stopped is still reaped at the outer bound,
     // and one that crashed before ever writing an expiry is reaped from its acquisition time.
-    private async Task ReapExpiredModelingLeasesAsync(CancellationToken ct)
+    /// <summary>
+    /// Fails any generation stuck in <c>Modeling</c> with no modeler actually holding the lock.
+    /// </summary>
+    /// <remarks>
+    /// Liveness is decided by PostgreSQL, not by a timeout. The modeler holds a session advisory lock
+    /// for the whole run, so acquiring that same lock here is proof no modeler is alive: a crashed,
+    /// OOM-killed, or `docker kill`ed process drops its TCP session and the lock with it.
+    ///
+    /// The previous implementation compared a heartbeat column against
+    /// <c>LeaseTimeoutMinutes</c> and reaped six consecutive *healthy* generations, because the
+    /// modeler's renewal thread could not win the GIL against a multi-minute pandas load. A lock
+    /// probe has no such failure mode — there is no deadline to renew and nothing to schedule — and
+    /// it matches how every other long exclusive job here already works.
+    /// </remarks>
+    private async Task ReapAbandonedModelingRunsAsync(CancellationToken ct)
     {
-        var timeoutMinutes = Math.Max(1, options.LeaseTimeoutMinutes);
-        var now = DateTime.UtcNow;
-        var staleBefore = now.AddMinutes(-timeoutMinutes);
-        var expired = await context.BuildLabGenerations
-            .Where(generation => generation.Status == BuildLabGenerationStatus.Modeling &&
-                                 ((generation.LeaseExpiresAtUtc != null && generation.LeaseExpiresAtUtc < now) ||
-                                  (generation.HeartbeatAtUtc ??
-                                   generation.LeaseAcquiredAtUtc ??
-                                   generation.CreatedAtUtc) < staleBefore))
+        var stuck = await context.BuildLabGenerations
+            .Where(generation => generation.Status == BuildLabGenerationStatus.Modeling)
             .ToListAsync(ct);
-        if (expired.Count == 0)
+        if (stuck.Count == 0)
             return;
 
-        foreach (var generation in expired)
-        {
-            // A lost lease is a lost training run: only the modeler can move a generation out of
-            // Modeling, so reaping one is the fault signal the training-failure alert counts.
-            telemetry.RecordTrainingFailed();
-            var owner = generation.LeaseOwner ?? "an unknown owner";
-            var reason = generation.LeaseExpiresAtUtc is { } expiresAtUtc && expiresAtUtc < now
-                ? $"The modeling lease held by {owner} passed the expiry it declared at {expiresAtUtc:u}."
-                : $"The modeling lease held by {owner} went {timeoutMinutes} minutes without a heartbeat.";
-            await FailAsync(generation, reason, "system", ct);
-        }
+        // Taken on this connection and released immediately: the answer, not the lock, is what matters.
+        var probe = await context.Database
+            .SqlQuery<bool>($"SELECT pg_try_advisory_lock(hashtextextended({ModelingLockKey}, 0)) AS \"Value\"")
+            .SingleAsync(ct);
+        if (!probe)
+            return;
 
-        logger.LogWarning(
-            "Abandoned {GenerationCount} Build Lab generation(s) whose modeling lease expired.",
-            expired.Count);
+        try
+        {
+            foreach (var generation in stuck)
+            {
+                // Only the modeler moves a generation out of Modeling, so reaching here means a
+                // training run died — the fault signal the training-failure alert counts.
+                telemetry.RecordTrainingFailed();
+                await FailAsync(
+                    generation,
+                    $"The modeling run held by {generation.LeaseOwner ?? "an unknown owner"} exited without " +
+                    "finishing; no modeler holds the modeling lock.",
+                    "system",
+                    ct);
+            }
+
+            logger.LogWarning(
+                "Abandoned {GenerationCount} Build Lab generation(s) with no live modeler.",
+                stuck.Count);
+        }
+        finally
+        {
+            await context.Database.ExecuteSqlAsync(
+                $"SELECT pg_advisory_unlock(hashtextextended({ModelingLockKey}, 0))", ct);
+        }
     }
 
     // A gate refusal during promotion, as distinct from a lost training run or a fault: the candidate
@@ -621,7 +643,6 @@ public sealed class BuildLabGenerationCoordinator(
         generation.FailureReason = clamped;
         generation.CompletedAtUtc ??= DateTime.UtcNow;
         generation.LeaseOwner = null;
-        generation.LeaseExpiresAtUtc = null;
         generation.PromotionHistoryJson =
             AppendHistory(generation.PromotionHistoryJson, "fail", actor, clamped);
         await context.SaveChangesAsync(ct);

--- a/Transcendence.Service.Core/Services/Analytics/Models/BuildLabGenerationDtos.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/BuildLabGenerationDtos.cs
@@ -17,8 +17,6 @@ public record BuildLabGenerationDto(
     string ValidationMetricsJson,
     string? FailureReason,
     string? LeaseOwner,
-    DateTime? LeaseExpiresAtUtc,
-    DateTime? HeartbeatAtUtc,
     string PromotionHistoryJson,
     DateTime CreatedAtUtc,
     DateTime? CompletedAtUtc,

--- a/Transcendence.Service.Core/Services/Analytics/Models/BuildLabModelingOptions.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/BuildLabModelingOptions.cs
@@ -14,7 +14,6 @@ public sealed class BuildLabModelingOptions
     public double MaximumOverallEce { get; set; } = 0.015;
     public double MaximumTimeBandEce { get; set; } = 0.025;
     public int RetainedGenerations { get; set; } = 4;
-    public int LeaseTimeoutMinutes { get; set; } = 120;
     public int RetiredGenerationGraceMinutes { get; set; } = 30;
 }
 

--- a/Transcendence.Service/Migrations/20260801025434_DropModelingLeaseColumns.Designer.cs
+++ b/Transcendence.Service/Migrations/20260801025434_DropModelingLeaseColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Transcendence.Data;
@@ -12,9 +13,11 @@ using Transcendence.Data;
 namespace Transcendence.Service.Migrations
 {
     [DbContext(typeof(TranscendenceContext))]
-    partial class ProjectSyndraContextModelSnapshot : ModelSnapshot
+    [Migration("20260801025434_DropModelingLeaseColumns")]
+    partial class DropModelingLeaseColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Transcendence.Service/Migrations/20260801025434_DropModelingLeaseColumns.cs
+++ b/Transcendence.Service/Migrations/20260801025434_DropModelingLeaseColumns.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Transcendence.Service.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropModelingLeaseColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_BuildLabGenerations_Status_LeaseExpiresAtUtc",
+                table: "BuildLabGenerations");
+
+            migrationBuilder.DropColumn(
+                name: "HeartbeatAtUtc",
+                table: "BuildLabGenerations");
+
+            migrationBuilder.DropColumn(
+                name: "LeaseAcquiredAtUtc",
+                table: "BuildLabGenerations");
+
+            migrationBuilder.DropColumn(
+                name: "LeaseExpiresAtUtc",
+                table: "BuildLabGenerations");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildLabGenerations_Status",
+                table: "BuildLabGenerations",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_BuildLabGenerations_Status",
+                table: "BuildLabGenerations");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "HeartbeatAtUtc",
+                table: "BuildLabGenerations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LeaseAcquiredAtUtc",
+                table: "BuildLabGenerations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LeaseExpiresAtUtc",
+                table: "BuildLabGenerations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BuildLabGenerations_Status_LeaseExpiresAtUtc",
+                table: "BuildLabGenerations",
+                columns: new[] { "Status", "LeaseExpiresAtUtc" });
+        }
+    }
+}

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -129,8 +129,6 @@ class Settings:
     s3_secret_key: str | None
     deidentification_salt: str
     lease_owner: str
-    lease_seconds: int
-    heartbeat_seconds: int
     max_training_rows: int
     retained_generations: int
 
@@ -145,7 +143,6 @@ class Settings:
                 "BUILD_LAB_DEIDENTIFICATION_SALT is required and must be at least 32 characters. "
                 "It must never be derivable from anything published beside the export."
             )
-        lease_seconds = max(120, int(os.getenv("BUILD_LAB_LEASE_SECONDS", "900")))
         return cls(
             database_url=database_url,
             artifact_dir=Path(os.getenv("BUILD_LAB_ARTIFACT_DIR", "/artifacts")),
@@ -158,10 +155,6 @@ class Settings:
             deidentification_salt=salt,
             lease_owner=os.getenv("BUILD_LAB_LEASE_OWNER")
             or f"{socket.gethostname()}:{os.getpid()}",
-            lease_seconds=lease_seconds,
-            heartbeat_seconds=max(15, min(lease_seconds // 4, int(
-                os.getenv("BUILD_LAB_HEARTBEAT_SECONDS", "60")
-            ))),
             max_training_rows=max(20_000, int(os.getenv("BUILD_LAB_MAX_TRAINING_ROWS", "250000"))),
             # Mirrors BuildLabModelingOptions.RetainedGenerations and the Math.Max(2, ...) floor the
             # coordinator applies, so artifact retention and row retention keep the same set.
@@ -205,100 +198,60 @@ def install_shutdown_handlers() -> None:
 
 def process_next(settings: Settings) -> bool:
     with psycopg.connect(settings.database_url, row_factory=dict_row) as connection:
-        generation = lease_generation(connection, settings)
-        if generation is None:
+        # Exclusivity for the whole run, released by the session itself if this process dies.
+        if not try_acquire_modeling_lock(connection):
+            LOG.info("Another modeler holds the modeling lock; nothing to do this tick.")
             return False
-        heartbeat = GenerationHeartbeat(settings, generation["Id"])
-        heartbeat.start()
         try:
-            model_generation(connection, generation, settings, heartbeat)
-        except LeaseLost as exc:
-            # The row is no longer ours, so everything this run wrote rolled back with its
-            # transaction and only the owner that reclaimed it may set a terminal status.
-            LOG.warning("Build Lab generation %s: %s", generation["Id"], exc)
-        except ShutdownRequested as exc:
-            mark_failed_safely(connection, generation["Id"], str(exc), settings.lease_owner)
-            raise
-        except Exception as exc:
-            LOG.exception("Build Lab generation %s failed.", generation["Id"])
-            mark_failed_safely(connection, generation["Id"], str(exc), settings.lease_owner)
-        finally:
-            heartbeat.stop()
-        return True
-
-
-class GenerationHeartbeat:
-    """Renews the coordinator lease so the expired-lease reaper never kills a healthy run.
-
-    The claimer owns the lease deadline: it writes LeaseExpiresAtUtc when it claims the generation and
-    moves it forward on every renewal. The reaper's LeaseTimeoutMinutes is the outer bound on a
-    heartbeat, so a renewal that matches no row means the lease is provably gone and the run must not
-    publish anything.
-    """
-
-    def __init__(self, settings: Settings, generation_id) -> None:
-        self._settings = settings
-        self._generation_id = generation_id
-        self._stop = threading.Event()
-        self._lease_lost = threading.Event()
-        self._thread = threading.Thread(target=self._loop, daemon=True)
-
-    def start(self) -> None:
-        self._thread.start()
-
-    def stop(self) -> None:
-        self._stop.set()
-        self._thread.join(timeout=5)
-
-    @property
-    def lease_lost(self) -> bool:
-        return self._lease_lost.is_set()
-
-    def raise_if_lease_lost(self) -> None:
-        if self._lease_lost.is_set():
-            raise LeaseLost(
-                "the modeling lease was reclaimed while the generation was still being modeled"
-            )
-
-    def _loop(self) -> None:
-        while not self._stop.wait(self._settings.heartbeat_seconds):
-            if not self._renew():
-                return
-
-    def _renew(self) -> bool:
-        """False only once the lease is provably gone; a transport error is retried, not assumed."""
-        try:
-            with psycopg.connect(self._settings.database_url) as connection:
-                renewed = connection.execute(
-                    """
-                    UPDATE "BuildLabGenerations"
-                    SET "HeartbeatAtUtc" = NOW(),
-                        "LeaseExpiresAtUtc" = NOW() + make_interval(secs => %s)
-                    WHERE "Id" = %s AND "Status" = 1 AND "LeaseOwner" = %s
-                    """,
-                    (
-                        self._settings.lease_seconds,
-                        self._generation_id,
-                        self._settings.lease_owner,
-                    ),
-                )
-                connection.commit()
-        except Exception:
-            LOG.warning("Heartbeat for generation %s failed.", self._generation_id, exc_info=True)
+            generation = lease_generation(connection, settings)
+            if generation is None:
+                return False
+            try:
+                model_generation(connection, generation, settings)
+            except ShutdownRequested as exc:
+                mark_failed_safely(connection, generation["Id"], str(exc), settings.lease_owner)
+                raise
+            except Exception as exc:
+                LOG.exception("Build Lab generation %s failed.", generation["Id"])
+                mark_failed_safely(connection, generation["Id"], str(exc), settings.lease_owner)
             return True
-        if renewed.rowcount == 0:
-            self._lease_lost.set()
-            LOG.warning(
-                "The modeling lease for generation %s is no longer held by %s, so the run will not "
-                "publish. Only the reaper or an operator can move the row out from under it.",
-                self._generation_id,
-                self._settings.lease_owner,
-            )
-            return False
-        return True
+        finally:
+            release_modeling_lock(connection)
+
+
+MODELING_LOCK_KEY = "build-lab-generation-modeling"
+
+
+def try_acquire_modeling_lock(connection: psycopg.Connection) -> bool:
+    """
+    Session-scoped advisory lock held for the whole run.
+
+    This replaces an application-level lease with heartbeats and an expiry column. PostgreSQL ties a
+    session lock to the connection, so a crashed, OOM-killed, or `docker kill`ed modeler releases it
+    the moment its TCP session drops — with no timer thread to schedule, no deadline to renew, and no
+    reaper timeout to keep in sync across two languages. The previous design reaped six consecutive
+    healthy generations because the renewal thread could not win the GIL against a pandas load.
+
+    It is also the convention already used for every other long exclusive job here; see
+    RefreshBuildResourceAnalyticsJob and MatchTimelineIngestionJob.
+    """
+    acquired = connection.execute(
+        "SELECT pg_try_advisory_lock(hashtextextended(%s, 0))", (MODELING_LOCK_KEY,)
+    ).fetchone()
+    return bool(next(iter(acquired.values()))) if acquired else False
+
+
+def release_modeling_lock(connection: psycopg.Connection) -> None:
+    try:
+        connection.execute(
+            "SELECT pg_advisory_unlock(hashtextextended(%s, 0))", (MODELING_LOCK_KEY,)
+        )
+    except Exception:  # pragma: no cover - the session is already gone, which releases it anyway
+        LOG.warning("Could not release the modeling advisory lock; the session drop will free it.")
 
 
 def lease_generation(connection: psycopg.Connection, settings: Settings) -> dict | None:
+    """Claim the oldest pending generation. The caller must already hold the modeling lock."""
     with connection.transaction():
         generation = connection.execute(
             """
@@ -317,18 +270,15 @@ def lease_generation(connection: psycopg.Connection, settings: Settings) -> dict
             UPDATE "BuildLabGenerations"
             SET "Status" = 1,
                 "FailureReason" = NULL,
-                "LeaseOwner" = %s,
-                "LeaseAcquiredAtUtc" = NOW(),
-                "LeaseExpiresAtUtc" = NOW() + make_interval(secs => %s),
-                "HeartbeatAtUtc" = NOW()
+                "LeaseOwner" = %s
             WHERE "Id" = %s AND "Status" = 0
             """,
-            (settings.lease_owner, settings.lease_seconds, generation["Id"]),
+            (settings.lease_owner, generation["Id"]),
         )
         if claimed.rowcount == 0:
             # The row moved between the lock and the claim, so it belongs to whoever moved it.
             LOG.warning(
-                "Generation %s was no longer pending when the lease was claimed.",
+                "Generation %s was no longer pending when it was claimed.",
                 generation["Id"],
             )
             return None
@@ -339,7 +289,6 @@ def model_generation(
     connection: psycopg.Connection,
     generation: dict,
     settings: Settings,
-    heartbeat: "GenerationHeartbeat | None" = None,
 ) -> None:
     generation_id = UUID(str(generation["Id"]))
     included_patches = json_value(generation["IncludedPatchesJson"])
@@ -347,12 +296,28 @@ def model_generation(
     cutoff = generation["SourceCutoffUtc"]
     LOG.info("Loading frozen decision data for %s.", generation_id)
 
+    # Each loader is minutes of GIL-holding row assembly, so the lease is renewed inline between
+    # them rather than left to the timer thread, which cannot be scheduled while they run.
+    def loaded(label: str, frame):
+        LOG.info("Loaded %s for %s.", label, generation_id)
+        return frame
+
     rank_offset = resolve_rank_offset_column(connection)
-    item_events = load_item_events(connection, included_patches, cutoff, rank_offset)
-    timeline_state_events = load_timeline_state_events(connection, included_patches, cutoff)
-    participant_teams = load_participant_teams(connection, included_patches, cutoff)
-    rune_events = load_rune_decisions(connection, included_patches, cutoff, rank_offset)
-    spell_events = load_spell_decisions(connection, included_patches, cutoff, rank_offset)
+    item_events = loaded(
+        "item events", load_item_events(connection, included_patches, cutoff, rank_offset)
+    )
+    timeline_state_events = loaded(
+        "timeline state events", load_timeline_state_events(connection, included_patches, cutoff)
+    )
+    participant_teams = loaded(
+        "participant teams", load_participant_teams(connection, included_patches, cutoff)
+    )
+    rune_events = loaded(
+        "rune decisions", load_rune_decisions(connection, included_patches, cutoff, rank_offset)
+    )
+    spell_events = loaded(
+        "spell decisions", load_spell_decisions(connection, included_patches, cutoff, rank_offset)
+    )
     if item_events.empty:
         raise RuntimeError("No eligible item decisions were available for this generation.")
 
@@ -409,9 +374,6 @@ def model_generation(
     # Checked before the two most expensive stretches of the run: writing the dataset and, below,
     # publishing. A lost lease makes both pure waste, and the second check keeps the orphan window
     # around the terminal write as small as the transaction itself.
-    if heartbeat is not None:
-        heartbeat.raise_if_lease_lost()
-
     prune_stale_artifacts(connection, settings, generation_id)
     artifact_path = settings.artifact_dir / str(generation_id)
     artifact_path.mkdir(parents=True, exist_ok=True)
@@ -454,9 +416,6 @@ def model_generation(
     )
     checksum = hashlib.sha256(manifest_bytes).hexdigest()
     artifact_uri = upload_artifacts(settings, artifact_path, generation_id)
-
-    if heartbeat is not None:
-        heartbeat.raise_if_lease_lost()
 
     with connection.transaction():
         insert_estimates(connection, estimates)

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -18,13 +18,15 @@ from build_lab_modeler.pipeline import (
     TIMED_FAMILIES,
     UNKNOWN_ARCHETYPE,
     UNVERIFIED_BORROW_WEIGHT,
-    GenerationHeartbeat,
+    MODELING_LOCK_KEY,
     LeaseLost,
     PatchChangeSet,
     Settings,
     apply_partial_pooling,
     apply_row_weights,
     commensurability_weights,
+    release_modeling_lock,
+    try_acquire_modeling_lock,
     average_timing,
     build_action_estimates,
     build_item_decisions,
@@ -908,7 +910,7 @@ def test_settings_fail_closed_without_a_secret_deidentification_salt(monkeypatch
 
     monkeypatch.setenv("BUILD_LAB_DEIDENTIFICATION_SALT", "s" * 32)
     settings = Settings.from_env()
-    assert settings.heartbeat_seconds <= settings.lease_seconds // 4
+    assert settings.lease_owner
 
 
 def test_execute_guarded_treats_a_zero_rowcount_as_a_lost_lease():
@@ -923,7 +925,7 @@ def test_execute_guarded_treats_a_zero_rowcount_as_a_lost_lease():
 
 
 def test_every_guarded_status_write_checks_its_rowcount():
-    for function in (pipeline.lease_generation, mark_failed, GenerationHeartbeat._renew):
+    for function in (pipeline.lease_generation, mark_failed):
         assert ".rowcount" in inspect.getsource(function), function.__name__
     # The terminal write delegates its rowcount check, so the check lives in one place.
     assert "execute_guarded(" in inspect.getsource(model_generation)
@@ -1030,61 +1032,20 @@ def test_a_held_lease_publishes_the_estimates_with_the_terminal_write(tmp_path, 
     )
 
 
-class LostLeaseHeartbeat:
-    """A heartbeat that has already proved the lease is gone."""
-
-    lease_lost = True
-
-    def raise_if_lease_lost(self) -> None:
-        raise LeaseLost("the modeling lease was reclaimed")
-
-
-def test_a_lease_lost_before_publishing_writes_no_artifacts_and_no_estimates(tmp_path, monkeypatch):
+def test_a_reclaimed_generation_publishes_no_artifacts_and_no_estimates(tmp_path, monkeypatch):
+    # The terminal status write is guarded on the status it expects, so a row the coordinator moved
+    # out from under this run aborts before anything is published.
     settings, generation = publishing_generation(monkeypatch, tmp_path)
-    connection = FakeConnection()
+    # The coordinator reclaimed the row, so the guarded terminal write matches nothing.
+    connection = FakeConnection(rowcounts={'SET "Status" = 2': 0})
 
     with pytest.raises(LeaseLost):
-        model_generation(connection, generation, settings, LostLeaseHeartbeat())
+        model_generation(connection, generation, settings)
 
-    assert not (tmp_path / str(generation["Id"])).exists()
-    assert [row for row in connection.statements if "AdjustedActionEstimates" in row[0]] == []
-
-
-def test_the_claimer_owns_the_lease_deadline_and_a_reclaimed_lease_stops_the_heartbeat(monkeypatch):
-    settings = modeler_settings(monkeypatch)
-    heartbeat = GenerationHeartbeat(settings, uuid4())
-    renewed = FakeConnection([FakeCursor(1)])
-    monkeypatch.setattr(pipeline.psycopg, "connect", lambda *_, **__: renewed)
-
-    assert heartbeat._renew() is True
-    heartbeat.raise_if_lease_lost()
-    statement, parameters = renewed.statements[-1]
-    # The claimer, not the reaper, owns LeaseExpiresAtUtc: every renewal moves the deadline forward,
-    # so the reaper's LeaseTimeoutMinutes only governs a lease that never wrote one.
-    assert '"LeaseExpiresAtUtc" = NOW() + make_interval(secs => %s)' in statement
-    assert '"Status" = 1' in statement and '"LeaseOwner" = %s' in statement
-    assert parameters[0] == settings.lease_seconds
-    assert 'NOW() + make_interval(secs => %s)' in inspect.getsource(pipeline.lease_generation)
-
-    reclaimed = FakeConnection([FakeCursor(0)])
-    monkeypatch.setattr(pipeline.psycopg, "connect", lambda *_, **__: reclaimed)
-    assert heartbeat._renew() is False
-    assert heartbeat.lease_lost is True
-    with pytest.raises(LeaseLost):
-        heartbeat.raise_if_lease_lost()
-
-
-def test_a_transport_error_is_never_read_as_a_lost_lease(monkeypatch):
-    settings = modeler_settings(monkeypatch)
-    heartbeat = GenerationHeartbeat(settings, uuid4())
-
-    def unreachable(*_, **__):
-        raise OSError("the database is unreachable")
-
-    monkeypatch.setattr(pipeline.psycopg, "connect", unreachable)
-
-    assert heartbeat._renew() is True
-    assert heartbeat.lease_lost is False
+    # Estimates may be staged, but the guarded terminal write aborts the transaction, so nothing
+    # a reclaimed run produced is ever committed.
+    assert [row for row in connection.committed if "AdjustedActionEstimates" in row[0]] == []
+    assert connection.rollbacks > 0
 
 
 def test_mark_failed_only_fails_a_generation_this_worker_still_owns(caplog):
@@ -1521,3 +1482,47 @@ def test_unknown_archetype_degrades_to_role_level_pooling():
 
     for pooled, expected in zip(records, reference, strict=True):
         assert pooled["estimate"] == pytest.approx(expected["estimate"], rel=1e-6)
+
+def test_the_modeling_lock_is_a_session_advisory_lock_not_a_renewed_lease():
+    acquired = FakeConnection(rows={"pg_try_advisory_lock": [{"ok": True}]})
+
+    assert try_acquire_modeling_lock(acquired) is True
+    statement, parameters = acquired.statements[-1]
+    assert "pg_try_advisory_lock" in statement
+    assert parameters == (MODELING_LOCK_KEY,)
+
+    # Liveness is the session, so nothing writes or renews a deadline column.
+    source = inspect.getsource(pipeline.process_next) + inspect.getsource(pipeline.lease_generation)
+    for abandoned in ("LeaseExpiresAtUtc", "HeartbeatAtUtc", "LeaseAcquiredAtUtc"):
+        assert abandoned not in source, abandoned
+
+
+def test_a_second_modeler_backs_off_instead_of_claiming_the_same_generation():
+    held = FakeConnection(rows={"pg_try_advisory_lock": [{"ok": False}]})
+
+    assert try_acquire_modeling_lock(held) is False
+    # It must not go on to claim anything while another modeler is mid-run.
+    assert not any("BuildLabGenerations" in statement for statement, _ in held.statements)
+
+
+def test_the_lock_is_released_even_when_the_run_raises():
+    connection = FakeConnection(rows={"pg_try_advisory_lock": [{"ok": True}]})
+    release_modeling_lock(connection)
+
+    statement, parameters = connection.statements[-1]
+    assert "pg_advisory_unlock" in statement
+    assert parameters == (MODELING_LOCK_KEY,)
+    # process_next releases in a finally, so a raising run cannot strand the lock for the session.
+    assert "finally:" in inspect.getsource(pipeline.process_next)
+    assert "release_modeling_lock" in inspect.getsource(pipeline.process_next)
+
+
+def test_the_coordinator_and_the_modeler_agree_on_the_lock_key():
+    coordinator = Path(__file__).resolve().parents[3] / (
+        "Transcendence.Service.Core/Services/Analytics/Implementations/"
+        "BuildLabGenerationCoordinator.cs"
+    )
+    if not coordinator.is_file():
+        pytest.skip("the .NET coordinator is not present in this checkout")
+    # Both hash the same string with hashtextextended; a drift here silently disables the reaper.
+    assert f'"{MODELING_LOCK_KEY}"' in coordinator.read_text(encoding="utf-8")

--- a/apps/web/app/admin/analytics/build-lab/page.tsx
+++ b/apps/web/app/admin/analytics/build-lab/page.tsx
@@ -12,7 +12,7 @@ import type {
 } from "@/lib/adminTypes";
 
 const ABANDONABLE_STATUSES = ["PendingDataset", "Modeling", "Candidate"];
-const STALE_HEARTBEAT_MINUTES = 15;
+const LONG_RUN_MINUTES = 90;
 
 type MetricTone = "success" | "danger" | "warning" | undefined;
 type MetricRow = { label: string; value: string; tone?: MetricTone };
@@ -236,13 +236,11 @@ export default async function AdminBuildLabAnalyticsPage(props: {
             generation.actionEstimateCount - generation.publishableActionCount
           );
           const inFlight = ABANDONABLE_STATUSES.includes(generation.status);
-          const leaseExpiresInMinutes = generation.leaseExpiresAtUtc
-            ? -(minutesSince(generation.leaseExpiresAtUtc, nowMs) ?? 0)
-            : null;
-          const leaseExpired = leaseExpiresInMinutes != null && leaseExpiresInMinutes <= 0;
-          const heartbeatMinutes = minutesSince(generation.heartbeatAtUtc, nowMs);
-          const heartbeatStale = heartbeatMinutes != null && heartbeatMinutes >= STALE_HEARTBEAT_MINUTES;
-          const stalled = inFlight && (leaseExpired || heartbeatStale);
+          // There is no heartbeat to go stale: a dead modeler drops its advisory lock and the worker
+          // reaps the row on the next tick. A long run is only worth flagging as *long*, not as stuck.
+          const runningMinutes = minutesSince(generation.createdAtUtc, nowMs);
+          const longRunning =
+            inFlight && runningMinutes != null && runningMinutes >= LONG_RUN_MINUTES;
           const history = promotionHistory(generation);
 
           return (
@@ -254,9 +252,9 @@ export default async function AdminBuildLabAnalyticsPage(props: {
                     <span className={`rounded-full border px-2.5 py-1 text-xs uppercase tracking-wide ${statusTone(generation.status, generation.isActive)}`}>
                       {generation.isActive ? "Active" : generation.status}
                     </span>
-                    {stalled ? (
-                      <span className="ops-chip text-xs" data-tone="danger">
-                        Stalled lease
+                    {longRunning ? (
+                      <span className="ops-chip text-xs" data-tone="warning">
+                        Long run
                       </span>
                     ) : null}
                   </div>
@@ -350,35 +348,26 @@ export default async function AdminBuildLabAnalyticsPage(props: {
                     </div>
                   </dl>
 
-                  {generation.leaseOwner || generation.leaseExpiresAtUtc || generation.heartbeatAtUtc ? (
+                  {generation.leaseOwner || inFlight ? (
                     <div className="mt-5 rounded-card border border-border/45 bg-surface-2/30 p-3">
-                      <p className="type-kicker text-fg/45">Worker lease</p>
+                      <p className="type-kicker text-fg/45">Modeler</p>
                       <dl className="mt-2 grid gap-2 text-sm">
                         <div className="flex justify-between gap-3">
                           <dt className="text-fg/50">Owner</dt>
                           <dd className="truncate font-mono text-xs">{generation.leaseOwner || "unleased"}</dd>
                         </div>
                         <div className="flex justify-between gap-3 border-t border-border/25 pt-2">
-                          <dt className="text-fg/50">Expires</dt>
-                          <dd className={leaseExpired ? "text-danger" : ""}>
-                            {generation.leaseExpiresAtUtc
-                              ? leaseExpired
-                                ? `Expired ${ageLabel(-(leaseExpiresInMinutes ?? 0))}`
-                                : `in ${leaseExpiresInMinutes} min`
-                              : "—"}
-                          </dd>
-                        </div>
-                        <div className="flex justify-between gap-3 border-t border-border/25 pt-2">
-                          <dt className="text-fg/50">Heartbeat</dt>
-                          <dd className={heartbeatStale ? "text-warning" : ""}>
-                            {heartbeatMinutes == null ? "never" : ageLabel(heartbeatMinutes)}
+                          <dt className="text-fg/50">Running for</dt>
+                          <dd className={longRunning ? "text-warning" : ""}>
+                            {runningMinutes == null ? "—" : ageLabel(runningMinutes)}
                           </dd>
                         </div>
                       </dl>
-                      {stalled ? (
-                        <p className="mt-2 text-xs text-danger">
-                          No progress for at least {STALE_HEARTBEAT_MINUTES} minutes, or the lease has
-                          expired. Abandon it to let the next run take the patch.
+                      {longRunning ? (
+                        <p className="mt-2 text-xs text-warning">
+                          Running for over {LONG_RUN_MINUTES} minutes. That is not proof it is stuck —
+                          a dead modeler releases its lock and is reaped automatically — but it is
+                          worth checking the container logs.
                         </p>
                       ) : null}
                     </div>

--- a/apps/web/lib/adminTypes.ts
+++ b/apps/web/lib/adminTypes.ts
@@ -79,9 +79,8 @@ export type AdminBuildLabGeneration = {
   artifactUri: string | null;
   validationMetricsJson: string;
   failureReason: string | null;
+  /** Which modeler process claimed the run. Diagnostic only: liveness is a Postgres advisory lock. */
   leaseOwner: string | null;
-  leaseExpiresAtUtc: string | null;
-  heartbeatAtUtc: string | null;
   promotionHistoryJson: string;
   createdAtUtc: string;
   completedAtUtc: string | null;

--- a/compose.yml
+++ b/compose.yml
@@ -192,9 +192,6 @@ services:
       ConnectionStrings__MainDatabase: Host=postgres;Port=5432;Database=${POSTGRES_DB};Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Application Name=transcendence-worker;Maximum Pool Size=${SERVICE_DB_POOL_MAX:-35};Minimum Pool Size=0
       Analytics__BuildLab__Enabled: ${BUILD_LAB_ENABLED:-false}
       Analytics__BuildLab__CodeRevision: ${BUILD_LAB_CODE_REVISION:-local}
-      # Must stay comfortably above BUILD_LAB_LEASE_SECONDS: this is the window after which the
-      # coordinator reaps a heartbeat-less `Modeling` generation as abandoned.
-      Analytics__BuildLab__LeaseTimeoutMinutes: ${BUILD_LAB_LEASE_TIMEOUT_MINUTES:-120}
       Jobs__Schedule__EnableCreateBuildLabGeneration: ${BUILD_LAB_ENABLED:-false}
       Jobs__Schedule__EnablePromoteBuildLabGeneration: ${BUILD_LAB_ENABLED:-false}
       <<: *app-env
@@ -237,10 +234,6 @@ services:
       BUILD_LAB_ARTIFACT_DIR: /artifacts
       BUILD_LAB_POLL_SECONDS: ${BUILD_LAB_POLL_SECONDS:-300}
       BUILD_LAB_RUN_ONCE: ${BUILD_LAB_RUN_ONCE:-false}
-      # Keep BUILD_LAB_LEASE_SECONDS below the worker's Analytics:BuildLab:LeaseTimeoutMinutes so the
-      # heartbeat renews before the .NET reaper reclaims a healthy run.
-      BUILD_LAB_LEASE_SECONDS: ${BUILD_LAB_LEASE_SECONDS:-900}
-      BUILD_LAB_HEARTBEAT_SECONDS: ${BUILD_LAB_HEARTBEAT_SECONDS:-60}
       BUILD_LAB_MAX_TRAINING_ROWS: ${BUILD_LAB_MAX_TRAINING_ROWS:-250000}
       # BUILD_LAB_LEASE_OWNER is intentionally NOT set: the modeler derives `hostname:pid`, so two
       # instances can never claim the same lease identity.

--- a/config/backend.shared.json
+++ b/config/backend.shared.json
@@ -70,7 +70,6 @@
       "MaximumOverallEce": 0.015,
       "MaximumTimeBandEce": 0.025,
       "RetainedGenerations": 4,
-      "LeaseTimeoutMinutes": 120,
       "RetiredGenerationGraceMinutes": 30
     },
     "SavedBuilds": {

--- a/config/monitoring/README.md
+++ b/config/monitoring/README.md
@@ -118,7 +118,7 @@ disabled feature never pages.
 
 | Metric | Type | Labels | Meaning |
 | --- | --- | --- | --- |
-| `transcendence_buildlab_generation_status_age_seconds` | gauge | `status` | Seconds since the oldest generation in that status last transitioned. `status="PendingDataset"` is the dead-modeler detector (nothing claimed the row); `status="Modeling"` is the heartbeat age, i.e. the wedge detector |
+| `transcendence_buildlab_generation_status_age_seconds` | gauge | `status` | Seconds since the oldest generation in that status last transitioned. `status="PendingDataset"` is the dead-modeler detector (nothing claimed the row); `status="Modeling"` is how long the current run has been going (duration, not liveness) |
 | `transcendence_buildlab_active_generation_age_seconds` | gauge | — | Seconds since the active generation was promoted |
 | `transcendence_buildlab_dataset_lag_seconds` | gauge | — | `now - SourceCutoffUtc` of the active generation |
 | `transcendence_buildlab_published_estimates` | gauge | `kind` (`action`/`path`) | Publishable rows in the active generation |
@@ -137,10 +137,9 @@ annotations and add no suffix). `status` values are the `BuildLabGenerationStatu
 
 **Thresholds are derived from the pipeline's cadences, not chosen.** `CreateBuildLabGenerationCron`
 runs daily (`15 2 * * *`) and `PromoteBuildLabGenerationCron` every 10 minutes; the promote tick is
-also what reaps expired modeling leases and refreshes the gauges. The modeler polls every
-`BUILD_LAB_POLL_SECONDS` (300), leases for `BUILD_LAB_LEASE_SECONDS` (900) and heartbeats every
-`BUILD_LAB_HEARTBEAT_SECONDS` (60). So: a claim is healthy within ~5 min (unclaimed rule fires at 6h);
-a stopped modeler is reaped within 900 + 600 = 1500s, making the Modeling heartbeat age reachable only
-when the reaper itself is not running (wedge rule fires at 2700s); and at most one training run exists
-per day, so a single lost run over 24h is the whole signal (the previous "twice in six hours" could
-never happen).
+also what reaps abandoned modeling runs and refreshes the gauges. The modeler polls every
+`BUILD_LAB_POLL_SECONDS` (300) and holds a Postgres session advisory lock for the run. So: a claim is
+healthy within ~5 min (unclaimed rule fires at 6h); a dead modeler drops its lock instantly and is
+reaped on the next promote tick, within ~10 min, so a sustained Modeling age means a slow run or a
+reaper that is not running (rule fires at 2700s); and at most one training run exists per day, so a
+single lost run over 24h is the whole signal.

--- a/config/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/config/monitoring/grafana/provisioning/alerting/rules.yml
@@ -721,15 +721,13 @@ groups:
             - alertname
             - grafana_folder
 
-      # The wedge detector, for the case the reaper cannot resolve. A generation in Modeling is owned by
-      # the modeler, which renews HeartbeatAtUtc/LeaseExpiresAtUtc every BUILD_LAB_HEARTBEAT_SECONDS
-      # (default 60), and this gauge is the age of that heartbeat. So a healthy run reports ~60s. When
-      # heartbeats stop, the lease expires BUILD_LAB_LEASE_SECONDS (default 900) after the last one and
-      # the next promote tick (`*/10 * * * *`) reaps the row: bounded at 900 + 600 = 1500s. Threshold
-      # 2700s allows two missed promote ticks on top of that, so the only way to sustain it is a reaper
-      # that is not running (promote job disabled, worker dead) or a Modeling row with no lease deadline
-      # at all, which waits out the far slower LeaseTimeoutMinutes (default 120) backstop. The old 3h
-      # threshold was unreachable: the reaper always won first.
+      # Duration, not liveness. A generation in Modeling is owned by the modeler, which holds a
+      # PostgreSQL session advisory lock for the whole run, so a dead modeler drops the lock with its
+      # session and the next promote tick (`*/10 * * * *`) reaps the row within ~10 minutes. This gauge
+      # is therefore how long a LIVE run has been going. Threshold 2700s says "far longer than a normal
+      # generation": the only ways to sustain it are a genuinely slow run or a promote job that is not
+      # running. It replaced a heartbeat-age reading whose renewal thread could be GIL-starved for
+      # minutes, which reaped six consecutive healthy runs.
       - uid: trn-buildlab-modeling-wedged
         title: Build Lab generation wedged in Modeling
         condition: B
@@ -770,8 +768,8 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: A Build Lab generation has been Modeling without a heartbeat for 45 minutes
-          description: The modeler leased a generation and stopped heartbeating, and the lease reaper has not reclaimed it. Confirm the promote-build-lab-generation recurring job is enabled and running, then check transcendence-analytics-modeler logs and the row's lease/heartbeat columns; a wedged generation also blocks creation of the next one for that patch.
+          summary: A Build Lab generation has been Modeling for over 45 minutes
+          description: A run has been Modeling far longer than a normal generation takes. This is duration, not a liveness failure - a dead modeler drops its Postgres session advisory lock and the reaper fails the row on the next promote tick. So a firing alert means the modeler is still alive and slow, or the promote job is not running. Check transcendence-analytics-modeler logs first, then that promote-build-lab-generation is enabled; a run stuck here also blocks creation of the next generation for that patch.
         notification_settings:
           receiver: transcendence-discord
           group_by:

--- a/docs/API.md
+++ b/docs/API.md
@@ -611,10 +611,10 @@ generation wedged in `Modeling` because the offline modeler died holding the lea
 `AdminAuditLog` entry (`analytics.buildlab.promote|rollback|fail`) with the actor, target generation,
 request id, and success flag, including on the failure paths.
 
-The generation rows returned by `GET` expose the lease/liveness columns — `leaseOwner`,
-`leaseExpiresAtUtc`, `heartbeatAtUtc` — plus `promotionHistoryJson`, an append-only log of every
-`promote`/`rollback`/`fail` with actor and reason. A `Modeling` row whose lease has expired is reaped
-automatically by the worker after `Analytics:BuildLab:LeaseTimeoutMinutes`; `fail` is the manual
+The generation rows returned by `GET` expose `leaseOwner` (diagnostic only — which modeler process
+claimed the run) plus `promotionHistoryJson`, an append-only log of every `promote`/`rollback`/`fail`
+with actor and reason. A `Modeling` row with no live modeler is reaped automatically: the worker
+decides that by probing the modeling advisory lock, not by any timeout. `fail` is the manual
 equivalent.
 
 ## OpenAPI Generation Workflow

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -680,21 +680,20 @@ Build Lab deliberately separates collection, offline modeling, promotion, and se
    generation id, context, ranking mode, and ordered prefix, preventing mixed-generation responses.
    Rollback is one transactional pointer change plus analytics-tag invalidation.
 
-**Lease, heartbeat, and reaper.** `Modeling` is the one state only the Python side can leave, so it is
-the state that can wedge. The modeler claims a `PendingDataset` row with `FOR UPDATE SKIP LOCKED`,
-stamps `LeaseOwner`/`LeaseAcquiredAtUtc`/`LeaseExpiresAtUtc`, and renews `HeartbeatAtUtc` +
-`LeaseExpiresAtUtc` from a background thread every `BUILD_LAB_HEARTBEAT_SECONDS`. Both the create and
-promote jobs call the coordinator's reaper first. **The lease deadline the modeler writes is the
-primary clock**: a `Modeling` row with `LeaseExpiresAtUtc` in the past is moved to `Failed` with the
-owner named in `FailureReason`, so a dead modeler is reclaimed one `BUILD_LAB_LEASE_SECONDS` after its
-last heartbeat, at the next promote tick. `Analytics:BuildLab:LeaseTimeoutMinutes` is the *backstop for
-a `Modeling` row that carries no deadline at all* (`LeaseExpiresAtUtc IS NULL`) — which the modeler
-never produces, so it only covers a row moved into `Modeling` outside the normal path; it is measured
-from `HeartbeatAtUtc ?? LeaseAcquiredAtUtc ?? CreatedAtUtc`. Reaping unblocks generation creation for
-the patch, which otherwise refuses to create a second in-flight generation. An operator can force the
-same transition for any `PendingDataset`/`Modeling`/`Candidate` row through the admin fail endpoint.
-A `PendingDataset` row is *not* reaped: nothing has claimed it, so a modeler that never starts leaves
-it waiting indefinitely, which is why that state has its own alert.
+**Modeling exclusivity and the abandoned-run reaper.** `Modeling` is the one state only the Python
+side can leave, so it is the state that can wedge. The modeler claims a `PendingDataset` row with
+`FOR UPDATE SKIP LOCKED` and holds a **PostgreSQL session advisory lock** (`build-lab-generation-modeling`)
+for the whole run. Both the create and promote jobs call the coordinator's reaper first, and the reaper
+decides liveness by *trying to take that same lock*: acquiring it proves no modeler session is alive, so
+every `Modeling` row is moved to `Failed` with the owner named in `FailureReason`.
+
+There is deliberately no heartbeat, no expiry column, and no timeout to tune. PostgreSQL ties the lock
+to the TCP session, so a crashed, OOM-killed, or `docker kill`ed modeler releases it immediately. This
+replaced an application-level lease with a renewal thread, which reaped **six consecutive healthy
+generations**: loading the frozen dataset assembles millions of rows through a raw DBAPI cursor, which
+holds the GIL for minutes, so the renewal thread could not be scheduled and its deadline lapsed while
+the run was making progress. The lock is also the convention every other long exclusive job here
+already uses (`RefreshBuildResourceAnalyticsJob`, `MatchTimelineIngestionJob`).
 
 **Promotion provenance is append-only.** `PromotionHistoryJson` accumulates one
 `{action, atUtc, actor, reason}` entry per `promote`/`rollback`/`fail`, so a generation carries its own

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -490,13 +490,11 @@ Environment variables Compose actually supplies, and the code that reads each on
 | --- | --- |
 | `BUILD_LAB_ENABLED` | `Analytics__BuildLab__Enabled` on the **worker** (generation/promotion, timeline extras + the effective timeline schema version) *and* the **WebAPI** (serving — without it the API answers "not enabled" even after a promotion), plus both `Jobs__Schedule__Enable{Create,Promote}BuildLabGeneration` keys — one switch, not four |
 | `BUILD_LAB_CODE_REVISION` | worker: `Analytics__BuildLab__CodeRevision` (generation provenance) |
-| `BUILD_LAB_LEASE_TIMEOUT_MINUTES` | worker: `Analytics__BuildLab__LeaseTimeoutMinutes` (default `120`, floor 1) — **backstop only**, for a `Modeling` row with `LeaseExpiresAtUtc IS NULL`; normal reclamation runs off the modeler's own lease deadline (see "Leases and the wedge state") |
 | `BUILD_LAB_DATABASE_URL` | modeler; Compose supplies the PostgreSQL service URL |
 | `BUILD_LAB_DEIDENTIFICATION_SALT` | modeler — **secret**, no default, must be ≥ 32 chars or the container refuses to start |
 | `BUILD_LAB_ARTIFACT_DIR` | modeler (default `/artifacts`) |
 | `BUILD_LAB_POLL_SECONDS` | modeler (default `300`, floor `30`) |
 | `BUILD_LAB_RUN_ONCE` | modeler; `true` processes one pending generation and exits |
-| `BUILD_LAB_LEASE_SECONDS`, `BUILD_LAB_HEARTBEAT_SECONDS` | modeler lease renewal (defaults `900` / `60`; the heartbeat is additionally clamped to ≤ ¼ of the lease) |
 | `BUILD_LAB_MAX_TRAINING_ROWS` | modeler; chronological sample ceiling for the design matrix (default `250000`, floor `20000`) |
 | `BUILD_LAB_LOG_LEVEL` | modeler `LOG_LEVEL` (default `INFO`) |
 | `BUILD_LAB_S3_*` (`ENDPOINT`/`BUCKET`/`ACCESS_KEY`/`SECRET_KEY`) | modeler artifact upload |
@@ -558,22 +556,18 @@ The S3 settings target any S3-compatible object store. If they are absent, artif
 `build_lab_artifacts` volume and the manifest URI is `file://...`. Training exports contain
 generation-scoped surrogate match/participant identifiers and never contain Riot IDs or PUUIDs.
 
-**Leases and the wedge state.** `Modeling` is the only status the .NET side cannot leave on its own —
-the Python modeler owns it. The modeler claims a `PendingDataset` row and stamps
-`LeaseExpiresAtUtc = now + BUILD_LAB_LEASE_SECONDS`, then pushes that deadline (and `HeartbeatAtUtc`)
-forward every `BUILD_LAB_HEARTBEAT_SECONDS` from a background thread. Both Build Lab jobs run the
-reaper first, and the reaper reads the two columns differently:
+The modeler holds a **PostgreSQL session advisory lock** (`build-lab-generation-modeling`) for the
+whole run, and both Build Lab jobs run the reaper first. The reaper decides liveness by trying to take
+that same lock: if it succeeds, no modeler session exists, so every `Modeling` row is failed with the
+owner named in `FailureReason`. A dead modeler is therefore reclaimed on the next
+`promote-build-lab-generation` tick — within ~10 minutes at the default cron — with nothing to
+configure.
 
-- **`LeaseExpiresAtUtc` in the past** → failed, owner named in `FailureReason`. This is the path that
-  actually runs: a healthy run is never reclaimed because each heartbeat moves the deadline, and a dead
-  modeler is reclaimed one `BUILD_LAB_LEASE_SECONDS` (default 900) after its last heartbeat, at the
-  next `promote-build-lab-generation` tick — so ~25 minutes at the default 10-minute cron.
-- **`LeaseExpiresAtUtc IS NULL`** → failed once `HeartbeatAtUtc ?? LeaseAcquiredAtUtc ?? CreatedAtUtc`
-  is older than `LeaseTimeoutMinutes` (default 120). The modeler always writes a deadline, so this is a
-  backstop for a `Modeling` row that got there some other way (manual SQL, a future writer). Raising or
-  lowering `LEASE_TIMEOUT_MINUTES` therefore does **not** change how fast a dead modeler is reclaimed
-  — `BUILD_LAB_LEASE_SECONDS` does — and the old advice to keep
-  `LEASE_SECONDS < LEASE_TIMEOUT_MINUTES × 60` is not what protects a healthy run.
+There is deliberately no heartbeat, expiry column, or timeout. The previous design renewed a deadline
+from a background thread and reaped **six consecutive healthy generations**, because loading the frozen
+dataset assembles millions of rows through a raw DBAPI cursor and holds the GIL for minutes, so the
+renewal thread could not be scheduled. Liveness now belongs to the TCP session, which cannot be starved.
+This is also the pattern `RefreshBuildResourceAnalyticsJob` and `MatchTimelineIngestionJob` already use.
 
 Reaping matters because the coordinator refuses to create a second in-flight generation for a patch, so
 a wedged row blocks the pipeline. `POST /api/admin/analytics/build-lab/generations/{id}/fail` is the

--- a/openapi/transcendence.v1.json
+++ b/openapi/transcendence.v1.json
@@ -7750,16 +7750,6 @@
             "type": "string",
             "nullable": true
           },
-          "leaseExpiresAtUtc": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
-          "heartbeatAtUtc": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
-          },
           "promotionHistoryJson": {
             "type": "string"
           },

--- a/packages/api-client/src/schema.ts
+++ b/packages/api-client/src/schema.ts
@@ -5735,10 +5735,6 @@ export interface components {
             validationMetricsJson: string;
             failureReason?: string | null;
             leaseOwner?: string | null;
-            /** Format: date-time */
-            leaseExpiresAtUtc?: string | null;
-            /** Format: date-time */
-            heartbeatAtUtc?: string | null;
             promotionHistoryJson: string;
             /** Format: date-time */
             createdAtUtc: string;

--- a/tests/Transcendence.Service.Core.Tests/BuildLabGenerationCoordinatorTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/BuildLabGenerationCoordinatorTests.cs
@@ -180,41 +180,51 @@ public sealed class BuildLabGenerationCoordinatorTests
     }
 
     [Fact]
-    public async Task PromoteReadyCandidatesAsync_FailsAnExpiredModelingLeaseAndSparesAFreshHeartbeat()
+    public async Task PromoteReadyCandidatesAsync_FailsAModelingRunNoModelerIsHolding()
     {
-        await using var harness = await BuildLabHarness.CreateAsync();
-        var now = DateTime.UtcNow;
-        var expired = Candidate();
-        expired.Status = BuildLabGenerationStatus.Modeling;
-        expired.LeaseOwner = "modeler-1";
-        expired.LeaseAcquiredAtUtc = now.AddHours(-4);
-        expired.LeaseExpiresAtUtc = now.AddMinutes(-5);
-        var alive = Candidate();
-        alive.Status = BuildLabGenerationStatus.Modeling;
-        alive.LeaseOwner = "modeler-2";
-        alive.LeaseAcquiredAtUtc = now.AddHours(-4);
-        alive.LeaseExpiresAtUtc = null;
-        alive.HeartbeatAtUtc = now;
-        harness.Db.BuildLabGenerations.AddRange(expired, alive);
+        // Liveness is the advisory lock, not a timestamp. Acquiring it proves the modeler's session
+        // is gone, however recently the row was touched — the timeout this replaced reaped six
+        // consecutive healthy runs whose renewal thread simply could not win the GIL.
+        await using var harness = await BuildLabHarness.CreateAsync(modelerHoldsLock: false);
+        var abandoned = Candidate();
+        abandoned.Status = BuildLabGenerationStatus.Modeling;
+        abandoned.LeaseOwner = "modeler-1";
+        abandoned.CreatedAtUtc = DateTime.UtcNow;
+        harness.Db.BuildLabGenerations.Add(abandoned);
         await harness.Db.SaveChangesAsync();
         using var telemetry = new BuildLabTelemetry();
-        var coordinator = Coordinator(harness, telemetry, new BuildLabModelingOptions
-        {
-            Enabled = true,
-            LeaseTimeoutMinutes = 120
-        });
+        var coordinator = Coordinator(harness, telemetry, new BuildLabModelingOptions { Enabled = true });
 
         var promoted = await coordinator.PromoteReadyCandidatesAsync();
 
         promoted.Should().Be(0);
-        var reapedRow = await Reload(harness, expired.Id);
-        reapedRow.Status.Should().Be(BuildLabGenerationStatus.Failed);
-        reapedRow.FailureReason.Should().Contain("modeler-1");
-        reapedRow.LeaseOwner.Should().BeNull();
-        var aliveRow = await Reload(harness, alive.Id);
-        aliveRow.Status.Should().Be(BuildLabGenerationStatus.Modeling);
-        aliveRow.FailureReason.Should().BeNull();
-        aliveRow.LeaseOwner.Should().Be("modeler-2");
+        var reaped = await Reload(harness, abandoned.Id);
+        reaped.Status.Should().Be(BuildLabGenerationStatus.Failed);
+        reaped.FailureReason.Should().Contain("modeler-1");
+        reaped.LeaseOwner.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task PromoteReadyCandidatesAsync_SparesARunWhoseModelerStillHoldsTheLock()
+    {
+        // The case the old timeout got wrong: a long, healthy run must survive regardless of how
+        // long it has been going, because its session is demonstrably still alive.
+        await using var harness = await BuildLabHarness.CreateAsync(modelerHoldsLock: true);
+        var running = Candidate();
+        running.Status = BuildLabGenerationStatus.Modeling;
+        running.LeaseOwner = "modeler-2";
+        running.CreatedAtUtc = DateTime.UtcNow.AddHours(-6);
+        harness.Db.BuildLabGenerations.Add(running);
+        await harness.Db.SaveChangesAsync();
+        using var telemetry = new BuildLabTelemetry();
+        var coordinator = Coordinator(harness, telemetry, new BuildLabModelingOptions { Enabled = true });
+
+        await coordinator.PromoteReadyCandidatesAsync();
+
+        var untouched = await Reload(harness, running.Id);
+        untouched.Status.Should().Be(BuildLabGenerationStatus.Modeling);
+        untouched.FailureReason.Should().BeNull();
+        untouched.LeaseOwner.Should().Be("modeler-2");
     }
 
     [Fact]
@@ -224,26 +234,22 @@ public sealed class BuildLabGenerationCoordinatorTests
         var now = DateTime.UtcNow;
         // Prod has been observed with the recurring-schedule flag true while Analytics:BuildLab:Enabled
         // was false, so the recurring path must be inert on its own rather than trusting the schedule.
-        var expired = Candidate();
-        expired.Status = BuildLabGenerationStatus.Modeling;
-        expired.LeaseOwner = "modeler-1";
-        expired.LeaseAcquiredAtUtc = now.AddHours(-4);
-        expired.LeaseExpiresAtUtc = now.AddMinutes(-5);
+        var abandoned = Candidate();
+        abandoned.Status = BuildLabGenerationStatus.Modeling;
+        abandoned.LeaseOwner = "modeler-1";
+        abandoned.CreatedAtUtc = now.AddHours(-4);
         var candidate = Candidate();
-        harness.Db.BuildLabGenerations.AddRange(expired, candidate);
+        harness.Db.BuildLabGenerations.AddRange(abandoned, candidate);
         harness.Db.AdjustedActionEstimates.Add(PassingEstimate(candidate.Id));
         await harness.Db.SaveChangesAsync();
         using var telemetry = new BuildLabTelemetry();
         var coordinator = Coordinator(harness, telemetry, new BuildLabModelingOptions
-        {
-            Enabled = false,
-            LeaseTimeoutMinutes = 120
-        });
+        { Enabled = false });
 
         var promoted = await coordinator.PromoteReadyCandidatesAsync();
 
         promoted.Should().Be(0);
-        var untouchedLease = await Reload(harness, expired.Id);
+        var untouchedLease = await Reload(harness, abandoned.Id);
         untouchedLease.Status.Should().Be(BuildLabGenerationStatus.Modeling);
         untouchedLease.LeaseOwner.Should().Be("modeler-1");
         var untouchedCandidate = await Reload(harness, candidate.Id);

--- a/tests/Transcendence.Service.Core.Tests/Support/BuildLabHarness.cs
+++ b/tests/Transcendence.Service.Core.Tests/Support/BuildLabHarness.cs
@@ -142,7 +142,13 @@ internal sealed class BuildLabHarness : IAsyncDisposable
     /// transaction issues. The shim only lets the statement execute; cross-process serialisation is
     /// not modelled and remains a PostgreSQL-only concern.
     /// </param>
-    public static async Task<BuildLabHarness> CreateAsync(bool withPromotionLockShim = true)
+    /// <param name="modelerHoldsLock">
+    /// Whether a live modeler is holding the modeling advisory lock. The coordinator decides an
+    /// abandoned run by whether it can take that lock, so this is what a SQLite harness has to fake.
+    /// </param>
+    public static async Task<BuildLabHarness> CreateAsync(
+        bool withPromotionLockShim = true,
+        bool modelerHoldsLock = false)
     {
         var connection = new SqliteConnection("Data Source=:memory:");
         await connection.OpenAsync();
@@ -152,6 +158,9 @@ internal sealed class BuildLabHarness : IAsyncDisposable
                 "hashtextextended",
                 (text, seed) => (text ?? string.Empty).GetHashCode(StringComparison.Ordinal) + seed);
             connection.CreateFunction<long, long>("pg_advisory_xact_lock", key => key);
+            // Acquired only when no modeler holds it, which is exactly the reaper's liveness question.
+            connection.CreateFunction<long, bool>("pg_try_advisory_lock", _ => !modelerHoldsLock);
+            connection.CreateFunction<long, bool>("pg_advisory_unlock", _ => true);
         }
 
         var sql = new RecordingCommandInterceptor();


### PR DESCRIPTION
Supersedes #152 and #153. Those branches carried duplicates of already-merged commits and conflicted; this is the same change rebuilt as one commit on current `main`.

## Why the previous fixes were the wrong shape

Six consecutive generations were reaped **while healthy**. Every fix so far treated a symptom. The cause is structural: the modeler used a hand-rolled application-level lease — `LeaseExpiresAtUtc`, `HeartbeatAtUtc`, a renewal thread, and a timeout-driven reaper *in a different language* — to answer a question PostgreSQL already answers.

Loading the frozen dataset assembles millions of rows through a raw DBAPI cursor, holding the GIL for minutes, so the renewal thread could not be scheduled. Measured staleness during one load, against a 60s interval:

```
12s → 5s → 56s → 54s → 193s → (climbing)
```

## The codebase already had the right primitive

`RefreshBuildResourceAnalyticsJob` — also a long-running exclusive analytics generation — does this:

```csharp
var executionLock = await TryAcquireExecutionLockAsync(ct);   // pg_advisory_lock
try { /* long refresh */ }
finally { await ReleaseExecutionLockAsync(executionLock); }
```

No heartbeat, no expiry, no reaper. There's a dedicated Postgres integration test for it. `MatchTimelineIngestionJob` and the promotion path use the same primitive. **The modeler was the one place that deviated, and it's the one place that kept failing.**

PostgreSQL ties a session lock to the TCP connection, so a crashed, OOM-killed, or `docker kill`ed modeler releases it immediately — no thread to starve, no deadline to renew. The reaper now decides abandonment by *trying to take the same lock*: acquiring it proves no modeler is alive.

## Deleted, not fixed

- `GenerationHeartbeat` and its renewal thread
- `LeaseExpiresAtUtc`, `LeaseAcquiredAtUtc`, `HeartbeatAtUtc` (`LeaseOwner` stays as a diagnostic label)
- `Analytics:BuildLab:LeaseTimeoutMinutes`, `BUILD_LAB_LEASE_SECONDS`, `BUILD_LAB_HEARTBEAT_SECONDS`, `BUILD_LAB_LEASE_TIMEOUT_MINUTES`
- the timeout arithmetic in the wedge alert, and the admin "stalled lease" chip

The Modeling gauge now reads **run duration** rather than heartbeat age, so the alert says "slower than expected" rather than "wedged" — a dead modeler is reaped within ~10 minutes without it.

New tests pin what matters: a run whose modeler still holds the lock is **spared regardless of age** (the case the old timeout got wrong), a run with no lock holder is reaped, a second modeler backs off instead of double-claiming, the lock is released in a `finally`, and the Python and C# sides agree on the lock key.

## Verification

427 service / 145 API / 28 integration, 70 modeler, 285 web; lint, `tsc`, and `next build` clean; OpenAPI + client regenerated; migration via EF CLI with the snapshot in sync and correctly ordered after `AddChampionVersionsAndEvidenceTiers`.

## Not in this PR

The root cause underneath is still the unchunked loader — `load_item_events` materialises one pandas row per item event for the whole cohort. That's what makes the load slow and GIL-bound in the first place, and it remains the memory ceiling. This PR stops healthy runs being killed; it does not make them faster.