### PR TITLE
Commit the modeling claim so Modeling is visible during the run

### DIFF
--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -238,7 +238,13 @@ def try_acquire_modeling_lock(connection: psycopg.Connection) -> bool:
     acquired = connection.execute(
         "SELECT pg_try_advisory_lock(hashtextextended(%s, 0))", (MODELING_LOCK_KEY,)
     ).fetchone()
-    return bool(next(iter(acquired.values()))) if acquired else False
+    held = bool(next(iter(acquired.values()))) if acquired else False
+    # psycopg opens a transaction on that SELECT, which would make the subsequent claim a savepoint
+    # and hide `Modeling` from every other session until the whole run committed. A session advisory
+    # lock is not transaction-scoped, so committing here keeps the lock and lets the claim be its own
+    # durable, immediately-visible transaction.
+    connection.commit()
+    return held
 
 
 def release_modeling_lock(connection: psycopg.Connection) -> None:
@@ -282,6 +288,9 @@ def lease_generation(connection: psycopg.Connection, settings: Settings) -> dict
                 generation["Id"],
             )
             return None
+    # Publish the claim before the long run starts, so the admin surface and the reaper both see
+    # `Modeling` rather than a row that still looks unclaimed for hours.
+    connection.commit()
     return generation
 
 

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1526,3 +1526,15 @@ def test_the_coordinator_and_the_modeler_agree_on_the_lock_key():
         pytest.skip("the .NET coordinator is not present in this checkout")
     # Both hash the same string with hashtextextended; a drift here silently disables the reaper.
     assert f'"{MODELING_LOCK_KEY}"' in coordinator.read_text(encoding="utf-8")
+
+
+def test_the_claim_is_committed_before_the_long_run_starts():
+    # psycopg opens a transaction on the lock SELECT. Without an explicit commit the claim becomes a
+    # savepoint and `Modeling` stays invisible to every other session for the whole run, so the admin
+    # surface shows PendingDataset and the reaper cannot see the row at all.
+    connection = FakeConnection(rows={"pg_try_advisory_lock": [{"ok": True}]})
+
+    try_acquire_modeling_lock(connection)
+
+    assert connection.commits >= 1, "the lock SELECT's transaction must be closed"
+    assert "connection.commit()" in inspect.getsource(pipeline.lease_generation)


### PR DESCRIPTION
Follow-up to #154, fixing a regression that PR introduced.

## What went wrong

psycopg opens a transaction on the first statement, and #154 now acquires the modeling lock with a `SELECT` **before** the generation is claimed. That turned `lease_generation`'s `with connection.transaction()` into a savepoint rather than a top-level transaction, so `Status = Modeling` stayed invisible to every other session until the entire run committed — hours later.

Observed directly on prod: a generation the modeler was actively loading still read `PendingDataset`, while `pg_locks` showed one advisory lock held.

## Impact

Observability and reaper reach, not correctness:

- the admin surface showed an unclaimed row for a run in progress
- the abandoned-run reaper selects on `Status = Modeling`, so it could not see the row at all
- a long-lived open transaction also blocks DDL — which is exactly what quarantined the #154 deploy until I stopped the modeler by hand

The advisory lock still did its job: a second modeler could not double-claim.

## Fix

A session advisory lock is **not** transaction-scoped, so committing right after acquiring it keeps the lock while letting the claim be its own durable, immediately-visible transaction. Same commit after the claim itself.

Test asserts the lock helper closes its transaction and that `lease_generation` commits.

## Verification

71 modeler tests pass.