### PR TITLE
Run the modeler to completion instead of as a daemon

### DIFF
--- a/analytics/modeler/src/build_lab_modeler/__main__.py
+++ b/analytics/modeler/src/build_lab_modeler/__main__.py
@@ -1,4 +1,15 @@
-from .pipeline import run
+import sys
+
+from .pipeline import RunOutcome, run
+
+# The exit code is the only thing a oneshot scheduler sees, so map the outcome onto it rather than
+# always exiting 0. `idle` and `completed` are both successful ticks; a generation that failed its
+# gates or blew up must surface as a unit failure, visible without reading the database.
+EXIT_CODES = {
+    RunOutcome.IDLE: 0,
+    RunOutcome.COMPLETED: 0,
+    RunOutcome.FAILED: 1,
+}
 
 if __name__ == "__main__":
-    run()
+    sys.exit(EXIT_CODES[run()])

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import hashlib
 import hmac
 import json
@@ -113,6 +114,20 @@ class ShutdownRequested(RuntimeError):
     """Raised from the SIGTERM/SIGINT handler so an in-flight generation is marked failed."""
 
 
+class RunOutcome(enum.Enum):
+    """
+    What one invocation actually did, so a run-to-completion process can exit meaningfully.
+
+    A oneshot is scheduled and observed by systemd, which only sees the exit code: a generation that
+    failed its gates must not look the same as a tick with nothing to do, or a broken pipeline reports
+    success forever.
+    """
+
+    IDLE = "idle"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
 class LeaseLost(RuntimeError):
     """Raised when a guarded write matches no row, so this process no longer owns the generation."""
 
@@ -162,22 +177,22 @@ class Settings:
         )
 
 
-def run() -> None:
+def run() -> RunOutcome:
     settings = Settings.from_env()
     settings.artifact_dir.mkdir(parents=True, exist_ok=True)
     install_shutdown_handlers()
     while True:
         try:
-            processed = process_next(settings)
+            outcome = process_next(settings)
             if settings.run_once:
-                return
-            if not processed:
+                return outcome
+            if outcome is RunOutcome.IDLE:
                 # The signal handler raises here too, so a container stop during the idle poll exits
                 # cleanly instead of unwinding as an unhandled error.
                 time.sleep(settings.poll_seconds)
         except ShutdownRequested:
             LOG.info("Shutdown requested; the modeler is stopping.")
-            return
+            return RunOutcome.IDLE
         except psycopg.OperationalError as exc:
             # The database is unreachable or restarting. Any lease taken before the drop is left for
             # the .NET reaper to expire, so retry on the normal cadence rather than letting the
@@ -196,16 +211,16 @@ def install_shutdown_handlers() -> None:
         signal.signal(received, handle)
 
 
-def process_next(settings: Settings) -> bool:
+def process_next(settings: Settings) -> RunOutcome:
     with psycopg.connect(settings.database_url, row_factory=dict_row) as connection:
         # Exclusivity for the whole run, released by the session itself if this process dies.
         if not try_acquire_modeling_lock(connection):
             LOG.info("Another modeler holds the modeling lock; nothing to do this tick.")
-            return False
+            return RunOutcome.IDLE
         try:
             generation = lease_generation(connection, settings)
             if generation is None:
-                return False
+                return RunOutcome.IDLE
             try:
                 model_generation(connection, generation, settings)
             except ShutdownRequested as exc:
@@ -214,7 +229,8 @@ def process_next(settings: Settings) -> bool:
             except Exception as exc:
                 LOG.exception("Build Lab generation %s failed.", generation["Id"])
                 mark_failed_safely(connection, generation["Id"], str(exc), settings.lease_owner)
-            return True
+                return RunOutcome.FAILED
+            return RunOutcome.COMPLETED
         finally:
             release_modeling_lock(connection)
 

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -19,6 +19,7 @@ from build_lab_modeler.pipeline import (
     UNKNOWN_ARCHETYPE,
     UNVERIFIED_BORROW_WEIGHT,
     MODELING_LOCK_KEY,
+    RunOutcome,
     LeaseLost,
     PatchChangeSet,
     Settings,
@@ -1538,3 +1539,69 @@ def test_the_claim_is_committed_before_the_long_run_starts():
 
     assert connection.commits >= 1, "the lock SELECT's transaction must be closed"
     assert "connection.commit()" in inspect.getsource(pipeline.lease_generation)
+
+
+def test_process_next_reports_a_failed_generation_as_failed_not_success():
+    # A oneshot is observed by its exit code. A generation that blew up must not look like a healthy
+    # tick, or a permanently broken pipeline reports success forever.
+    assert RunOutcome.FAILED is not RunOutcome.COMPLETED
+    source = inspect.getsource(pipeline.process_next)
+    assert "return RunOutcome.FAILED" in source
+    assert "return RunOutcome.COMPLETED" in source
+    # Nothing pending, or another modeler already running, is a successful no-op.
+    assert source.count("return RunOutcome.IDLE") == 2
+
+
+def test_run_once_returns_the_outcome_for_the_exit_code():
+    source = inspect.getsource(pipeline.run)
+    assert "return outcome" in source, "run_once must hand the outcome to the caller"
+
+    from build_lab_modeler.__main__ import EXIT_CODES
+
+    assert EXIT_CODES[RunOutcome.IDLE] == 0
+    assert EXIT_CODES[RunOutcome.COMPLETED] == 0
+    assert EXIT_CODES[RunOutcome.FAILED] != 0
+    # Every outcome must map, or a new one would KeyError at the worst possible moment.
+    assert set(EXIT_CODES) == set(RunOutcome)
+
+
+def test_the_daemon_loop_only_sleeps_when_idle():
+    # COMPLETED and FAILED both mean work happened, so the loop should come straight back for the next
+    # pending generation rather than sitting out a poll interval.
+    source = inspect.getsource(pipeline.run)
+    assert "if outcome is RunOutcome.IDLE:" in source
+
+
+def test_the_oneshot_is_scheduled_by_systemd_and_not_by_the_deploy_poller():
+    ops = Path(__file__).resolve().parents[3] / "scripts/ops"
+    if not ops.is_dir():
+        pytest.skip("ops scripts are not present in this checkout")
+
+    unit = (ops / "transcendence-modeler.service").read_text(encoding="utf-8")
+    assert "Type=oneshot" in unit
+    assert "run --rm" in unit, "a fresh container per run leaves nothing to recreate"
+    assert " -T " in unit, "no TTY exists under systemd"
+    assert "pull" in unit, "the image must change between runs, never underneath one"
+    assert "TimeoutStartSec=0" in unit, "an hours-long run must not be killed by systemd"
+
+    timer = (ops / "transcendence-modeler.timer").read_text(encoding="utf-8")
+    assert "transcendence-modeler.service" in timer
+
+    # The regression this design exists to prevent: the poller recreating the modeler mid-generation.
+    poller = (ops / "poll-deploy.sh").read_text(encoding="utf-8")
+    assert "analytics-modeler:transcendence-analytics-modeler" not in poller
+
+
+def test_the_compose_service_is_a_oneshot_not_a_daemon():
+    compose = Path(__file__).resolve().parents[3] / "compose.yml"
+    if not compose.is_file():
+        pytest.skip("compose.yml is not present in this checkout")
+    text = compose.read_text(encoding="utf-8")
+    modeler = text[text.index("  analytics-modeler:"):]
+    modeler = modeler[: modeler.index("\n  pgadmin:")] if "\n  pgadmin:" in modeler else modeler
+
+    assert 'restart: "no"' in modeler, "a restart policy would relaunch a finished run"
+    assert "container_name: transcendence-analytics-modeler" not in modeler, (
+        "run --rm supplies its own container; a fixed name collides across invocations"
+    )
+    assert "BUILD_LAB_RUN_ONCE:-true" in modeler

--- a/compose.yml
+++ b/compose.yml
@@ -207,17 +207,24 @@ services:
     networks:
       - transcendence-net
 
+  # Run-to-completion, NOT a daemon. Invoked as `docker compose run --rm analytics-modeler` by
+  # scripts/ops/transcendence-modeler.{service,timer}; a modeling run takes hours, and while this was
+  # a long-lived container every image update recreated it mid-run and lost the generation. A process
+  # that exits on its own is deployed *between* runs instead of through one, and the exit code is the
+  # completion signal, so no liveness protocol is needed at all.
+  #
+  # Overlap is safe without extra machinery: a second invocation cannot take the modeling advisory
+  # lock and exits idle.
   analytics-modeler:
-    # Published like every other app service so prod can pull `:main` (the poll-deploy path);
-    # `build:` stays for local `--build` iteration exactly as web/webapi/service do.
     image: ${MODELER_IMAGE:-ghcr.io/luisgon-dev/transcendence-analytics-modeler:main}
     build:
       context: .
       dockerfile: analytics/modeler/Dockerfile
-    container_name: transcendence-analytics-modeler
     labels:
       wud.watch: "false"
-    restart: unless-stopped
+    # No restart policy and no container_name: `run --rm` supplies a fresh container per invocation,
+    # and a restart policy on a oneshot would relaunch a finished run.
+    restart: "no"
     profiles: ["analytics-modeling"]
     cpus: "${BUILD_LAB_MODELER_CPUS:-4.0}"
     mem_limit: "${BUILD_LAB_MODELER_MEMORY_LIMIT:-8g}"
@@ -233,7 +240,8 @@ services:
       BUILD_LAB_DEIDENTIFICATION_SALT: ${BUILD_LAB_DEIDENTIFICATION_SALT:-}
       BUILD_LAB_ARTIFACT_DIR: /artifacts
       BUILD_LAB_POLL_SECONDS: ${BUILD_LAB_POLL_SECONDS:-300}
-      BUILD_LAB_RUN_ONCE: ${BUILD_LAB_RUN_ONCE:-false}
+      # One generation per invocation, then exit. The scheduler decides cadence.
+      BUILD_LAB_RUN_ONCE: ${BUILD_LAB_RUN_ONCE:-true}
       BUILD_LAB_MAX_TRAINING_ROWS: ${BUILD_LAB_MAX_TRAINING_ROWS:-250000}
       # BUILD_LAB_LEASE_OWNER is intentionally NOT set: the modeler derives `hostname:pid`, so two
       # instances can never claim the same lease identity.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -356,14 +356,18 @@ release.
 
 **`analytics-modeler` is a fourth published image** (`transcendence-analytics-modeler`, path-filtered
 on `analytics/modeler/**`) with the same tags, labels, provenance, SBOM, and cosign signature as the
-app images. It sits behind the `analytics-modeling` Compose profile, so unless that profile is enabled
-on the host the container does not exist. **The poller does not deploy it yet** — `SERVICES` in
-`scripts/ops/poll-deploy.sh` still lists only `service`/`webapi`/`web`, and registering the modeler
-there needs two behaviours the script does not have: an *optional* service whose missing container is a
-skip rather than a resolution failure that aborts the poll cycle, and a health gate that tolerates a
-batch container with no healthcheck (`wait_for_healthy` currently fails any `no-healthcheck:*` state).
-Until that lands the modeler is released by hand; see `scripts/ops/README.md` →
-*`analytics-modeler` release*.
+app images — but it is **not a service the poller deploys**, and deliberately so.
+
+It is a **run-to-completion oneshot** owned by `transcendence-modeler.timer`, which pulls the image in
+`ExecStartPre` and then runs `docker compose run --rm`. A modeling run takes hours; while the modeler
+was a long-lived container, every image update recreated it mid-run and discarded the generation. A
+process that exits on its own is deployed *between* runs instead of through one, its exit code is the
+completion signal, and `--rm` leaves nothing for a poller to recreate. `SERVICES` in
+`scripts/ops/poll-deploy.sh` therefore lists only `service`/`webapi`/`web`.
+
+Overlap needs no scheduler-side guard: the timer fires every 10 minutes against runs that last hours,
+and a second invocation cannot take the modeling advisory lock, so it exits idle. See
+`scripts/ops/README.md` → *`analytics-modeler` — run-to-completion oneshot*.
 
 Hot-table index migrations remain the exception and must be applied out-of-band before deployment
 (see DEVELOPMENT.md); the CI `migration-apply` job additionally applies the full chain to ephemeral

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -477,12 +477,19 @@ corpus" below first: the flip costs a multi-day, rate-gated re-ingestion of the 
 
 The offline modeler is built and published like every other app service
 (`ghcr.io/luisgon-dev/transcendence-analytics-modeler`, path-filtered on `analytics/modeler/**`) and
-runs under an optional Compose profile so it never starts with the default stack:
+runs as a **run-to-completion oneshot** behind an optional Compose profile, so it never starts with
+the default stack and is never left running between generations:
 
 ```bash
-docker compose --profile analytics-modeling up -d analytics-modeler          # published :main image
-docker compose --profile analytics-modeling up --build analytics-modeler     # local iteration
+# one generation, then exit (what the systemd timer invokes on prod)
+docker compose --profile analytics-modeling run --rm analytics-modeler
+docker compose --profile analytics-modeling run --rm --build analytics-modeler   # local iteration
 ```
+
+On prod the schedule is `scripts/ops/transcendence-modeler.timer`, not the deploy poller: a run lasts
+hours, and a poller that recreated the container mid-run destroyed the generation every time it
+deployed. Exit code `0` means a generation completed or there was nothing pending; non-zero means the
+generation failed.
 
 Environment variables Compose actually supplies, and the code that reads each one:
 
@@ -646,11 +653,12 @@ against a low-rate Riot key. Do it in this order:
    so **every `Success` timeline in the retained corpus becomes stale and is re-fetched once**, at the
    job's normal rate-gated pace: a multi-day background sweep competing with new-match ingestion for the
    same Riot budget. Nothing else is required to start it — there is no `const` to bump.
-4. Start the modeler profile (`docker compose --profile analytics-modeling up -d analytics-modeler`).
-   Do not defer this: the same flag enables the daily create job, and once the first matches reach v2 a
-   `PendingDataset` generation appears that only the modeler can claim —
-   `trn-buildlab-unclaimed-generation` pages six hours later if it is not running. Early generations
-   will fail their evidence gates while coverage is thin, which is the intended behaviour.
+4. Install and enable the modeler timer (`cp scripts/ops/transcendence-modeler.{service,timer}
+   /etc/systemd/system/ && systemctl enable --now transcendence-modeler.timer`). Do not defer this: the
+   same flag enables the create job, and once the first matches reach v2 a `PendingDataset` generation
+   appears that only the modeler can claim — `trn-buildlab-unclaimed-generation` pages six hours later
+   if nothing is running. Early generations will fail their evidence gates while coverage is thin,
+   which is the intended behaviour.
 5. Leave `TRN_FEATURE_BUILD_LAB` (and the two sibling web flags) `false` until a generation has actually
    promoted. Backend enablement and public exposure are separate switches on purpose.
 

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -68,42 +68,47 @@ pin a service to an immutable `:sha-<short>` tag in the compose file and `compos
 > this poller is the app release source of truth and two independent recreators can race each other.
 > wud may continue watching public Docker Hub sidecars (portainer/dozzle/grafana/prometheus).
 
-### `analytics-modeler` release (manual, not polled)
+### `analytics-modeler` — run-to-completion oneshot
 
 `transcendence-analytics-modeler` is built, tagged, labelled, SBOM'd, and cosign-signed by the same
-`Docker Images` workflow as the three app images (path-filtered on `analytics/modeler/**`), but
-`SERVICES` in `poll-deploy.sh` still lists only `service`/`webapi`/`web`. Two properties of the script
-have to change before the modeler can be added, and both are real, not cosmetic:
+`Docker Images` workflow as the three app images (path-filtered on `analytics/modeler/**`), but it is
+deliberately **not** in `SERVICES` in `poll-deploy.sh`.
 
-- **Optional service.** The modeler lives behind the `analytics-modeling` Compose profile, so on a host
-  where the profile is off the container does not exist. `local_digest`/`local_revision` would return
-  empty, `record_resolution_failure` would fire, `deploy_one` would return non-zero, and `main` would
-  `break` — aborting the whole poll cycle and alerting every 60s. It needs an explicit optional flag
-  whose missing container is a silent skip (and it must be polled **last** so it can never gate the app
-  services).
-- **No healthcheck.** The modeler is a batch poller with no server to probe, so
-  `container_health_status` reports `no-healthcheck:running` and `wait_for_healthy` returns failure on
-  the `no-healthcheck:*` branch — every modeler deploy would "fail" and roll back. It needs a
-  running-after-grace verification path for services declared as healthcheck-less. Do **not** paper over
-  this by adding a trivially-passing healthcheck to Compose; a healthcheck that cannot fail is worse
-  than none.
-
-Until that lands, release it by hand on prod:
+It is not a daemon. A modeling run takes hours, and while the modeler was a long-lived container every
+image update recreated it mid-run and threw the generation away — that is exactly how generation #59
+died. It now runs to completion under systemd:
 
 ```bash
-cd "$COMPOSE_DIR"   # /var/lib/docker/volumes/portainer_data/_data/compose/2
-docker compose -p transcendence --env-file stack.env -f docker-compose.yml \
-  --profile analytics-modeling pull analytics-modeler
-docker compose -p transcendence --env-file stack.env -f docker-compose.yml \
-  --profile analytics-modeling up -d --no-deps analytics-modeler
-docker inspect transcendence-analytics-modeler \
-  --format '{{ index .Config.Labels "org.opencontainers.image.revision"}}'   # verify the build
-docker logs -f transcendence-analytics-modeler
+cp scripts/ops/transcendence-modeler.{service,timer} /etc/systemd/system/
+systemctl daemon-reload && systemctl enable --now transcendence-modeler.timer
+```
+
+The unit pulls its own image in `ExecStartPre` and runs `docker compose run --rm`, so:
+
+- the image can only change **between** invocations, never underneath a run;
+- `--rm` leaves no container for a deploy poller to find or recreate;
+- the exit code is the completion signal — `0` for a completed generation *or* nothing to do, non-zero
+  for a generation that failed, so `systemctl status` and `journalctl -u transcendence-modeler` are the
+  first place to look;
+- overlap is safe. The timer fires every 10 minutes and a run lasts hours; a second invocation cannot
+  take the modeling advisory lock and exits idle. That guard holds across reboots and manual
+  `systemctl start` too, which a systemd-only guard would not.
+
+Inspect a run:
+
+```bash
+systemctl list-timers transcendence-modeler.timer
+journalctl -u transcendence-modeler.service -f
+systemctl status transcendence-modeler.service      # last exit code
 ```
 
 Rollback is the same `MODELER_IMAGE=ghcr.io/luisgon-dev/transcendence-analytics-modeler:sha-<short>`
-pin used for the app images. Stopping the modeler mid-generation is safe: it marks the in-flight
-generation `Failed` on SIGTERM, and the worker's lease reaper would have done so anyway.
+pin used for the app images; set it in `stack.env` and the next invocation picks it up.
+
+Interrupting a run is safe. The process holds a PostgreSQL session advisory lock for its duration, so
+killing it drops the lock with the session and the worker's reaper fails the row on its next tick — no
+heartbeat, no timeout, nothing to wait out. To stop the schedule entirely,
+`systemctl disable --now transcendence-modeler.timer`.
 
 ## `install-matchup-performance-db.sql` — online matchup source preparation
 

--- a/scripts/ops/poll-deploy.sh
+++ b/scripts/ops/poll-deploy.sh
@@ -60,11 +60,14 @@ export COMPOSE_PROFILES="${COMPOSE_PROFILES:+${COMPOSE_PROFILES},}analytics-mode
 # "optional" = the service ships no container healthcheck, may not be deployed on this host
 # (compose profile), and must never gate an app rollout. Optional entries therefore go LAST: the loop
 # in main() aborts on the first failure, so anything before them could block their siblings.
+# analytics-modeler is deliberately absent. It is a run-to-completion oneshot owned by
+# transcendence-modeler.timer, which pulls its own image before each invocation, so there is no
+# long-lived container to recreate. Managing it here is what made every modeler deploy kill an
+# in-flight generation: a run takes hours and the poller recreated the container mid-run.
 SERVICES=(
   "service:transcendence-service:transcendence-service"
   "webapi:transcendence-webapi:transcendence-webapi"
   "web:transcendence-web:transcendence-web"
-  "analytics-modeler:transcendence-analytics-modeler:transcendence-analytics-modeler:optional"
 )
 
 # Set per-service by deploy_one: 1 when the image declares no healthcheck, so a running container —

--- a/scripts/ops/transcendence-modeler.service
+++ b/scripts/ops/transcendence-modeler.service
@@ -1,0 +1,41 @@
+[Unit]
+# Runs the Build Lab modeler to completion, once per invocation.
+#
+# Why a oneshot and not the long-lived container it replaced: a modeling run takes hours, and while
+# the modeler was a daemon every image update recreated it mid-run and threw the generation away. A
+# process that exits on its own is deployed *between* runs instead of through one. It also means the
+# exit code is the completion signal, so there is no heartbeat or lease to maintain — liveness for the
+# duration of a run is a PostgreSQL session advisory lock the process holds.
+#
+# Install:
+#   cp scripts/ops/transcendence-modeler.{service,timer} /etc/systemd/system/
+#   systemctl daemon-reload && systemctl enable --now transcendence-modeler.timer
+Description=Transcendence Build Lab modeler (run to completion)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/var/lib/docker/volumes/portainer_data/_data/compose/2
+
+# Pulled here rather than by poll-deploy: the image can only change between invocations, never
+# underneath a run. This is the whole point of the oneshot.
+ExecStartPre=-/usr/bin/docker compose -p transcendence \
+  --env-file /var/lib/docker/volumes/portainer_data/_data/compose/2/stack.env \
+  -f /var/lib/docker/volumes/portainer_data/_data/compose/2/docker-compose.yml \
+  --profile analytics-modeling pull --quiet analytics-modeler
+
+# --rm: a fresh container per run, so nothing is left for a deploy poller to find or recreate.
+# -T: no TTY exists under systemd, and `run` would otherwise try to allocate one.
+# Exit 0 = a generation completed or there was nothing to do; non-zero = the generation failed.
+ExecStart=/usr/bin/docker compose -p transcendence \
+  --env-file /var/lib/docker/volumes/portainer_data/_data/compose/2/stack.env \
+  -f /var/lib/docker/volumes/portainer_data/_data/compose/2/docker-compose.yml \
+  --profile analytics-modeling run --rm -T --no-deps analytics-modeler
+
+# A run is hours long by design; systemd must not kill it. Overlap is prevented by the advisory lock,
+# not by a timeout, so there is nothing to tune here.
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ops/transcendence-modeler.timer
+++ b/scripts/ops/transcendence-modeler.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Poll for a pending Build Lab generation and model it to completion
+
+[Timer]
+# Cadence only decides how soon a *pending* generation is picked up, not how often work happens:
+# generations are created by the worker's own recurring job, and an invocation with nothing pending
+# exits idle in well under a second. 10 minutes keeps pickup latency low at negligible cost.
+OnUnitActiveSec=10min
+OnBootSec=5min
+# The run is far longer than the interval, so overlap is the normal case. Refusing to start a second
+# unit while the first is active is the cheap guard; the advisory lock is the correct one, and it
+# holds even across a reboot or a manual `systemctl start`.
+AccuracySec=30s
+Unit=transcendence-modeler.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This is the deferred step 2 from the architecture review, done properly. I argued against it at the time on the grounds that a Hangfire-invoked trigger would add moving parts — that reasoning was right about *Hangfire* and wrong about the conclusion, because generation #59 then died exactly the way a daemon guarantees.

## The failure this closes

Generation #59 was the first run under the advisory lock. It got further than any before it — 407s and climbing, lock held, no timeout — and then died at 05:55:56 because **poll-deploy recreated the modeler container mid-run** to ship an unrelated modeler change. `exit=0`, `oom=false`, and the traceback line moved from `pipeline.py:668` to `:677`: the image changed underneath it.

A run takes hours. A long-running container therefore means **every modeler deploy destroys an in-flight generation.** That is not a tuning problem — a daemon is the wrong shape for a job that runs occasionally and takes a long time.

## What changed

- `BUILD_LAB_RUN_ONCE` defaults to **true**; the Compose service is `restart: "no"` with no `container_name`, invoked as `docker compose run --rm -T`. A fresh container per invocation leaves nothing for a poller to recreate. (`-T` because no TTY exists under systemd.)
- **`scripts/ops/transcendence-modeler.{service,timer}`** own the schedule. The unit pulls the image in `ExecStartPre`, so the image can only change **between** runs, never underneath one. `TimeoutStartSec=0` because an hours-long run must not be killed by systemd.
- **`analytics-modeler` removed from `SERVICES`** in `poll-deploy.sh`. The poller no longer touches it — that is what actually closes the failure mode.
- `process_next` returns a `RunOutcome` instead of a bool, and `__main__` maps it to an exit code: `0` for a completed generation *or* nothing to do, non-zero for a failed one. A oneshot is observed through its exit code, so a permanently broken pipeline must not keep reporting success. The daemon loop also now only sleeps on `IDLE`, instead of treating a finished run as a reason to wait a poll interval.

## Why this needs no overlap guard

The timer fires every 10 minutes against runs that last hours, so overlap is the normal case. A second invocation cannot take the modeling advisory lock and exits idle. That guard holds across reboots and manual `systemctl start` too — which a systemd-only interlock would not.

This is the second thing the advisory lock bought us: it made the oneshot safe to schedule naively.

## Deliberately *not* Hangfire

Hangfire owning invocation would need either a docker socket in the worker or a new HTTP trigger surface — both add a moving part and a failure mode to replace a schedule systemd already does correctly, and `poll-deploy.timer` is the existing precedent on this host. Scheduling moves to systemd; the worker keeps owning generation *creation*.

## Verification

76 modeler tests; `dotnet build` clean; `docker compose --profile analytics-modeling config` valid. New tests pin the exit-code mapping, that **every** `RunOutcome` maps (so a new one cannot `KeyError` at the worst moment), that the unit is a oneshot which pulls and uses `--rm -T` with no start timeout, and that `poll-deploy.sh` no longer lists the modeler.

## Install step (not automatic)

```bash
cp scripts/ops/transcendence-modeler.{service,timer} /etc/systemd/system/
systemctl daemon-reload && systemctl enable --now transcendence-modeler.timer
```

The currently-running daemon container must also be stopped once, since nothing will recreate it. Runbook updated in `scripts/ops/README.md`.