### PR TITLE
Read frames with a tuple cursor, and stop writing a dropped column

### DIFF
--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -24,7 +24,7 @@ import numpy as np
 from scipy.special import erfc
 import pandas as pd
 import psycopg
-from psycopg.rows import dict_row
+from psycopg.rows import dict_row, tuple_row
 from sklearn.isotonic import IsotonicRegression
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import brier_score_loss, log_loss
@@ -527,8 +527,7 @@ def model_generation(
                 "ValidationMetricsJson" = %s::jsonb,
                 "CompletedAtUtc" = NOW(),
                 "FailureReason" = NULL,
-                "LeaseOwner" = NULL,
-                "LeaseExpiresAtUtc" = NULL
+                "LeaseOwner" = NULL
             WHERE "Id" = %s AND "Status" = 1 AND "LeaseOwner" = %s
             """,
             (
@@ -875,6 +874,23 @@ CHAMPION_MATCH_CTE = """champion_matches AS MATERIALIZED (
 )"""
 
 
+def read_sql_frame(connection, sql: str, params: dict) -> pd.DataFrame:
+    """Run a query and build a DataFrame from it, with an explicitly tuple-shaped cursor.
+
+    `pd.read_sql_query` must not be used on this connection. The run's connection is opened with
+    `row_factory=dict_row` because the generation row is read by column name, and pandas' DBAPI2
+    fallback feeds whatever `fetchall()` returns straight into `DataFrame.from_records`. Handed dicts
+    it iterates each one -- which yields its KEYS -- so every cell in the frame comes back equal to its
+    own column name. That is silent: the row count is right, the dtypes are just `object`, and the
+    corruption only surfaces much later as `int('event_type')`. Naming the row factory here removes the
+    coupling to the connection's, and skips pandas' "not tested" DBAPI2 path entirely.
+    """
+    with connection.cursor(row_factory=tuple_row) as cursor:
+        cursor.execute(sql, params)
+        columns = [column.name for column in cursor.description or []]
+        return pd.DataFrame.from_records(cursor.fetchall(), columns=columns)
+
+
 def champion_match_cte(champion_id: int | None, *, leading: bool) -> str:
     """The champion_matches CTE, or nothing when the load is not champion-scoped.
 
@@ -980,7 +996,8 @@ def load_item_events(
     }
     champion_scope = scope_predicates(champion_id, match_sample_modulus, match_scoped=False)
     champion_cte = champion_match_cte(champion_id, leading=True)
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         f"""
         WITH {champion_cte}eligible AS (
             SELECT
@@ -1085,7 +1102,6 @@ def load_item_events(
         WHERE e.role IN ('TOP', 'JUNGLE', 'MIDDLE', 'BOTTOM', 'UTILITY')
         ORDER BY e.match_date, e.match_id, e.participant_id, item_event."TimestampMs", item_event."EventIndex"
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1223,7 +1239,8 @@ def load_timeline_state_events(
     match_sample_modulus: int | None = None,
     match_sample_residue: int = 0,
 ) -> pd.DataFrame:
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         champion_match_cte(champion_id, leading=False)
         + """
         SELECT
@@ -1249,7 +1266,6 @@ def load_timeline_state_events(
         + """
         ORDER BY payload."MatchId", payload."TimestampMs", payload."EventIndex"
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1269,7 +1285,8 @@ def load_participant_teams(
     match_sample_modulus: int | None = None,
     match_sample_residue: int = 0,
 ) -> pd.DataFrame:
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         champion_match_cte(champion_id, leading=False)
         + """
         SELECT
@@ -1287,7 +1304,6 @@ def load_participant_teams(
         + scope_predicates(champion_id, match_sample_modulus, match_scoped=True)
         + """
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1426,7 +1442,8 @@ def load_rune_decisions(
     }
     champion_scope = scope_predicates(champion_id, match_sample_modulus, match_scoped=False)
     champion_cte = champion_match_cte(champion_id, leading=False)
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         f"""
         {champion_cte}SELECT
             m."Id" AS match_id,
@@ -1480,7 +1497,6 @@ def load_rune_decisions(
           AND COALESCE(p."GameEndedInEarlySurrender", FALSE) = FALSE
 {champion_scope}        ORDER BY m."MatchDate", m."Id", p."ParticipantId", rune."SelectionTree", rune."SelectionIndex"
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1508,7 +1524,8 @@ def load_spell_decisions(
     }
     champion_scope = scope_predicates(champion_id, match_sample_modulus, match_scoped=False)
     champion_cte = champion_match_cte(champion_id, leading=False)
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         f"""
         {champion_cte}SELECT
             m."Id" AS match_id,
@@ -1559,7 +1576,6 @@ def load_spell_decisions(
           AND UPPER(COALESCE(p."TeamPosition", '')) IN ('TOP', 'JUNGLE', 'MIDDLE', 'BOTTOM', 'UTILITY')
           AND COALESCE(p."GameEndedInEarlySurrender", FALSE) = FALSE
 {champion_scope}        """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -2840,8 +2856,7 @@ def mark_failed(connection, generation_id, message: str, lease_owner: str) -> No
         SET "Status" = 4,
             "FailureReason" = %s,
             "CompletedAtUtc" = NOW(),
-            "LeaseOwner" = NULL,
-            "LeaseExpiresAtUtc" = NULL
+            "LeaseOwner" = NULL
         WHERE "Id" = %s
           AND "Status" = 1
           AND "LeaseOwner" = %s

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1853,3 +1853,100 @@ def test_the_estimate_sweep_scopes_every_load_to_one_champion(monkeypatch, tmp_p
     assert sorted(scope["match_sample_residue"] for scope in training) == list(
         range(pipeline.TRAINING_SAMPLE_SLICES)
     )
+
+
+class DictRowCursor:
+    """A cursor shaped like psycopg's, whose row factory decides the row type.
+
+    Mirrors the property that broke prod: a connection opened with `row_factory=dict_row` hands
+    `fetchall()` dicts unless a cursor names a different factory.
+    """
+
+    class Column:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    def __init__(self, columns: list[str], rows: list[tuple], row_factory) -> None:
+        self._columns = columns
+        self._rows = rows
+        self._row_factory = row_factory
+        self.executed: list[tuple[str, dict | None]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        return self
+
+    @property
+    def description(self):
+        return [self.Column(name) for name in self._columns]
+
+    def fetchall(self):
+        if self._row_factory is pipeline.dict_row:
+            return [dict(zip(self._columns, row, strict=True)) for row in self._rows]
+        return list(self._rows)
+
+
+class DictRowConnection:
+    def __init__(self, columns: list[str], rows: list[tuple]) -> None:
+        self._columns = columns
+        self._rows = rows
+        self.cursors: list[DictRowCursor] = []
+
+    def cursor(self, row_factory=None):
+        # Default to the connection's factory, exactly as psycopg does.
+        cursor = DictRowCursor(self._columns, self._rows, row_factory or pipeline.dict_row)
+        self.cursors.append(cursor)
+        return cursor
+
+
+def test_the_frame_reader_returns_values_not_column_names_on_a_dict_row_connection():
+    # The bug this pins cost a production run: pandas' DBAPI2 fallback iterates each dict row, which
+    # yields its KEYS, so every cell came back equal to its own column name. The row count and shape
+    # were right, dtypes were merely object, and it only surfaced later as int('event_type').
+    columns = ["match_id", "event_index", "event_type", "action_id"]
+    rows = [("match-a", 0, 0, 6672), ("match-a", 1, 2, 3031)]
+    connection = DictRowConnection(columns, rows)
+
+    frame = pipeline.read_sql_frame(connection, "SELECT ...", {"patches": ["16.15"]})
+
+    assert list(frame.columns) == columns
+    assert frame["event_type"].tolist() == [0, 2]
+    assert frame["match_id"].tolist() == ["match-a", "match-a"]
+    # The corruption signature: a cell equal to its own column name.
+    for column in columns:
+        assert not (frame[column].astype(str) == column).any(), column
+    # Numeric columns must stay numeric, or every downstream int() cast is a coin flip.
+    assert int(frame["event_type"].iloc[0]) == 0
+    # It must ask for tuples rather than inherit the connection's dict factory.
+    assert connection.cursors[-1]._row_factory is pipeline.tuple_row
+
+
+def test_no_loader_uses_the_pandas_dbapi_fallback():
+    # pd.read_sql_query on the run's dict_row connection is silently wrong, so no loader may reach for
+    # it. Keeping this a source assertion catches a reintroduction that no fake connection would.
+    source = inspect.getsource(pipeline)
+    assert "pd.read_sql_query" not in source.replace("`pd.read_sql_query` must not", "")
+    for loader in (
+        load_item_events,
+        load_rune_decisions,
+        load_spell_decisions,
+        load_timeline_state_events,
+        load_participant_teams,
+    ):
+        assert "read_sql_frame(" in inspect.getsource(loader), loader.__name__
+
+
+def test_no_status_write_references_a_dropped_lease_column():
+    # 20260801025434_DropModelingLeaseColumns removed LeaseExpiresAtUtc and HeartbeatAtUtc when the
+    # lease became a session advisory lock. A stale reference in the TERMINAL write is invisible until
+    # a run actually succeeds, and then it fails the publish it was supposed to record.
+    for function in (model_generation, mark_failed):
+        source = inspect.getsource(function)
+        for dropped in ("LeaseExpiresAtUtc", "HeartbeatAtUtc"):
+            assert dropped not in source, f"{function.__name__} still writes {dropped}"


### PR DESCRIPTION
Two bugs that between them made a successful generation **impossible**. Both were found by running the modeler against prod, not by reading it. Follow-up to #157, which fixed the memory ceiling and thereby got far enough to expose these.

## 1. Every loaded frame was corrupt

The run's connection is opened with `row_factory=dict_row`, because the generation row is read by column name. `pd.read_sql_query` on a raw DBAPI2 connection feeds whatever `fetchall()` returns straight into `DataFrame.from_records`; handed **dicts** it iterates each one — which yields its **keys** — so every cell in every frame came back equal to its own column name.

Verified against psycopg 3.3.4 on prod, same query both ways:

```
FIXED  dtypes: {'participant_id': 'int64', 'event_index': 'int64', 'event_type': 'int64', ...}
FIXED  rows:   [{'event_index': 0, 'event_type': 0, 'action_id': 1056.0}, ...]
BROKEN rows:   [{'event_index': 'event_index', 'event_type': 'event_type', ...}]   # all 2,881 rows
```

This failure is **silent**: the row count is right, the shape is right, and the only tell is that dtypes are `object`. It surfaced hours downstream as `int('event_type')` inside `undone_purchase_indexes`.

It also explains part of the memory profile chased for days — a 31M-row frame of short strings is far larger than the numeric frame it was meant to be — and, more importantly, **no run ever got past the load**, which is why the corruption was never reached. The published estimates could not have been correct even with unlimited memory.

Loads now go through `read_sql_frame`, which names `row_factory=tuple_row` on its own cursor. That removes the coupling to the connection's factory and skips pandas' "not tested" DBAPI2 path entirely.

## 2. The terminal write referenced a dropped column

`20260801025434_DropModelingLeaseColumns` removed `LeaseExpiresAtUtc` when the lease became a session advisory lock, but both the success write in `model_generation` and `mark_failed` still set it to NULL.

The failure path is what exposed it: every previous failure was an OOM, i.e. SIGKILL, so `mark_failed_safely` had not run since that migration. **The success path carries the same reference**, so a run that completed everything else still could not have published — and a run that failed could not record why. Prod currently has one generation stuck in `Modeling` for exactly this reason, waiting on the .NET reaper's lock probe.

Confirmed against the prod schema: only `LeaseOwner` survives, which is still the guard.

## Tests

- A fake connection whose cursor honours a row factory pins that the reader returns **values, not column names**, keeps numeric columns numeric, and asks for `tuple_row` rather than inheriting the connection's factory.
- A source assertion stops any loader reaching for `pd.read_sql_query` again — no fake connection would catch its reintroduction, which is precisely how this survived.
- Both status writes are pinned against the dropped column names.

89 modeler tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)