### PR TITLE
Fix the two blocking promotion gates, and make the modeler answerable on demand

### DIFF
--- a/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Implementations/BuildLabGenerationCoordinator.cs
@@ -774,11 +774,20 @@ public sealed class BuildLabGenerationCoordinator(
             return false;
         }
 
+        // A single-patch cohort cannot be split across a patch boundary, so there is no test to pass.
+        // Reading that absence as a failure blocks every generation until a second patch accumulates
+        // coverage. It is safe to waive precisely because the gate guards *borrowing*: with one patch
+        // in scope every row carries full weight, no prior-patch row is borrowed, and the staleness the
+        // gate exists to catch cannot occur. The chronological holdout still applies -- train,
+        // calibration and test remain disjoint match sets ordered by date, and both baseline
+        // comparisons below are measured on it.
+        var patchHoldoutSatisfied =
+            metrics.HeldOutPatchPassed.Value || metrics.HeldOutPatchApplicable == false;
         if (metrics.OverallEce.Value > options.MaximumOverallEce ||
             metrics.MaxTimeBandEce.Value > options.MaximumTimeBandEce ||
             metrics.BrierScore.Value >= metrics.BaselineBrierScore.Value ||
             metrics.LogLoss.Value >= metrics.BaselineLogLoss.Value ||
-            !metrics.HeldOutPatchPassed.Value ||
+            !patchHoldoutSatisfied ||
             !metrics.LeakageCheckPassed.Value)
         {
             failureReason = "The candidate model did not pass calibration, baseline, patch, and leakage gates.";

--- a/Transcendence.Service.Core/Services/Analytics/Models/BuildLabModelingOptions.cs
+++ b/Transcendence.Service.Core/Services/Analytics/Models/BuildLabModelingOptions.cs
@@ -27,4 +27,9 @@ public sealed record BuildLabValidationMetrics(
     double? LogLoss,
     double? BaselineLogLoss,
     bool? HeldOutPatchPassed,
-    bool? LeakageCheckPassed);
+    bool? LeakageCheckPassed,
+    // Whether a held-out-patch test was possible at all. A cohort covering one patch cannot be split
+    // across a patch boundary, so HeldOutPatchPassed is false there for want of a test rather than
+    // because a test failed. Null means the modeler predates the field, which is read as "applicable"
+    // so an old manifest still has to clear the gate.
+    bool? HeldOutPatchApplicable = null);

--- a/analytics/modeler/src/build_lab_modeler/__main__.py
+++ b/analytics/modeler/src/build_lab_modeler/__main__.py
@@ -1,6 +1,27 @@
+"""Entry point for the Build Lab modeler.
+
+`run` is the production path a scheduler invokes. The other subcommands exist because the production
+path is the worst possible way to answer a question about the model: it leases a generation, spends
+tens of minutes drawing its cohort, sweeps every champion, and publishes -- so a question as small as
+"did that calibration change help?" used to cost a full run and could only be watched by tailing a
+container's log.
+
+Every subcommand below is on-demand, needs no pending generation, writes nothing to the database, and
+shares the cohort-keyed training cache with `run`. Once a draw is cached, `train` is seconds.
+"""
+
+import argparse
+import json
+import logging
+import os
 import sys
 
-from .pipeline import RunOutcome, run
+import psycopg
+from psycopg.rows import dict_row
+
+from . import pipeline
+from .cache import TrainingCache
+from .pipeline import RunOutcome, Settings, run
 
 # The exit code is the only thing a oneshot scheduler sees, so map the outcome onto it rather than
 # always exiting 0. `idle` and `completed` are both successful ticks; a generation that failed its
@@ -11,5 +32,253 @@ EXIT_CODES = {
     RunOutcome.FAILED: 1,
 }
 
+# Mirrors BuildLabModelingOptions so a local run can report the same verdict the promoter will reach.
+# The .NET options remain authoritative -- these are for seeing the answer without a deploy, and are
+# asserted against the committed defaults in the test suite so they cannot drift silently.
+GATE_LIMITS = {"maximumOverallEce": 0.015, "maximumTimeBandEce": 0.025}
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(message)s",
+        stream=sys.stderr,
+        force=True,
+    )
+
+
+def connect(settings: Settings) -> psycopg.Connection:
+    return psycopg.connect(settings.database_url, row_factory=dict_row)
+
+
+def resolve_cohort(connection, arguments) -> tuple[str, list[str], object]:
+    """The cohort to work on: an explicit one, or the newest generation's."""
+    if arguments.patches:
+        patches = [patch.strip() for patch in arguments.patches.split(",") if patch.strip()]
+        return patches[0], patches, arguments.cutoff
+    row = connection.execute(
+        """
+        SELECT "Patch", "IncludedPatchesJson", "SourceCutoffUtc"
+        FROM "BuildLabGenerations"
+        ORDER BY "CreatedAtUtc" DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    if row is None:
+        raise SystemExit("No generation exists to take a cohort from; pass --patches and --cutoff.")
+    return (
+        str(row["Patch"]),
+        pipeline.json_value(row["IncludedPatchesJson"]),
+        arguments.cutoff or row["SourceCutoffUtc"],
+    )
+
+
+def cohort_context(connection, settings: Settings, arguments):
+    """Everything the loaders and `prepare` need, resolved once."""
+    current_patch, included_patches, cutoff = resolve_cohort(connection, arguments)
+    rank_offset = pipeline.resolve_rank_offset_column(connection)
+    changes = pipeline.load_patch_change_set(connection, included_patches)
+    archetypes = pipeline.load_champion_archetypes(connection, current_patch)
+
+    def prepare(frame, *, exclude_drift: bool = True):
+        return pipeline.prepare_decisions(
+            frame,
+            current_patch,
+            included_patches,
+            rank_offset,
+            changes,
+            archetypes,
+            exclude_drift=exclude_drift,
+        )
+
+    return {
+        "current_patch": current_patch,
+        "included_patches": included_patches,
+        "cutoff": cutoff,
+        "rank_offset": rank_offset,
+        "changes": changes,
+        "archetypes": archetypes,
+        "changed_items": set(changes.items),
+        "prepare": prepare,
+    }
+
+
+def training_cache(connection, settings: Settings, context, arguments) -> TrainingCache:
+    shape = pipeline.training_draw_shape(
+        connection, context["included_patches"], context["cutoff"], settings
+    )
+    cache = TrainingCache.for_cohort(
+        settings.artifact_dir / "_cache",
+        context["included_patches"],
+        context["cutoff"],
+        *shape,
+        enabled=not arguments.no_cache,
+    )
+    if getattr(arguments, "refresh", False):
+        removed = cache.clear()
+        logging.getLogger("build_lab_modeler").info(
+            "Cleared %d cached slices for cohort %s.", removed, cache.key
+        )
+    return cache
+
+
+def draw(connection, settings: Settings, context, cache):
+    return pipeline.build_training_frame(
+        connection,
+        context["included_patches"],
+        context["cutoff"],
+        context["rank_offset"],
+        context["current_patch"],
+        context["changed_items"],
+        settings,
+        context["prepare"],
+        cache=cache,
+    )
+
+
+def report_gates(metrics: dict) -> bool:
+    """Print the promoter's verdict for each gate and whether the set would promote."""
+    applicable = metrics.get("heldOutPatchApplicable")
+    checks = [
+        ("overallEce", metrics["overallEce"], GATE_LIMITS["maximumOverallEce"],
+         metrics["overallEce"] <= GATE_LIMITS["maximumOverallEce"]),
+        ("maxTimeBandEce", metrics["maxTimeBandEce"], GATE_LIMITS["maximumTimeBandEce"],
+         metrics["maxTimeBandEce"] <= GATE_LIMITS["maximumTimeBandEce"]),
+        ("brier < baseline", metrics["brierScore"], metrics["baselineBrierScore"],
+         metrics["brierScore"] < metrics["baselineBrierScore"]),
+        ("logLoss < baseline", metrics["logLoss"], metrics["baselineLogLoss"],
+         metrics["logLoss"] < metrics["baselineLogLoss"]),
+        ("patch holdout", metrics["heldOutPatchPassed"],
+         "waived (single-patch cohort)" if applicable is False else True,
+         bool(metrics["heldOutPatchPassed"]) or applicable is False),
+        ("leakage", metrics["leakageCheckPassed"], True, bool(metrics["leakageCheckPassed"])),
+    ]
+    print("=== promotion gates ===")
+    for name, got, limit, ok in checks:
+        print(f"{'PASS' if ok else 'FAIL'}  {name}: got={got} limit={limit}")
+    passed = all(ok for *_, ok in checks)
+    print(f"=== {'WOULD PROMOTE' if passed else 'WOULD BE REJECTED'} ===")
+    return passed
+
+
+def command_dataset(settings: Settings, arguments) -> int:
+    with connect(settings) as connection:
+        context = cohort_context(connection, settings, arguments)
+        cache = training_cache(connection, settings, context, arguments)
+        frame = draw(connection, settings, context, cache)
+    print(f"cohort={','.join(context['included_patches'])} cutoff={context['cutoff']}")
+    print(f"cache={cache.directory}")
+    print(f"rows={len(frame)} outcomes={frame['won'].nunique() if len(frame) else 0}")
+    return 0 if len(frame) else 1
+
+
+def command_train(settings: Settings, arguments) -> int:
+    with connect(settings) as connection:
+        context = cohort_context(connection, settings, arguments)
+        cache = training_cache(connection, settings, context, arguments)
+        frame = draw(connection, settings, context, cache)
+    if frame.empty:
+        print("no rows drawn")
+        return 1
+    bundle, metrics = pipeline.train_structural_model(frame, settings.max_training_rows)
+    print(json.dumps({k: v for k, v in metrics.items() if k != "leakageDetail"}, indent=2))
+    passed = report_gates(metrics)
+    # Scoring must route through the calibrator the gates were measured on, so exercise it here too.
+    scored = pipeline.structural_win_probability(bundle, frame.head(min(len(frame), 20_000)))
+    print(f"scored {len(scored)} rows: min={scored.min():.4f} mean={scored.mean():.4f} max={scored.max():.4f}")
+    return 0 if passed else 2
+
+
+def command_champion(settings: Settings, arguments) -> int:
+    with connect(settings) as connection:
+        context = cohort_context(connection, settings, arguments)
+        cache = training_cache(connection, settings, context, arguments)
+        frame = draw(connection, settings, context, cache)
+        if frame.empty:
+            print("no rows drawn")
+            return 1
+        bundle, _ = pipeline.train_structural_model(frame, settings.max_training_rows)
+        del frame
+        champions = (
+            [int(value) for value in arguments.champions.split(",")]
+            if arguments.champions
+            else pipeline.load_cohort_champions(
+                connection, context["included_patches"], context["cutoff"]
+            )[: arguments.limit]
+        )
+        actions, paths, rows = [], [], 0
+        for champion_id in champions:
+            champion = context["prepare"](
+                pipeline.load_decision_frame(
+                    connection,
+                    context["included_patches"],
+                    context["cutoff"],
+                    context["rank_offset"],
+                    context["current_patch"],
+                    context["changed_items"],
+                    champion_id=champion_id,
+                )
+            )
+            if champion.empty:
+                print(f"champion {champion_id}: no eligible rows")
+                continue
+            champion["baseline_win_probability"] = pipeline.structural_win_probability(
+                bundle, champion
+            )
+            champion_actions = pipeline.action_records(champion)
+            champion_paths = pipeline.path_records(champion)
+            actions += champion_actions
+            paths += champion_paths
+            rows += len(champion)
+            print(
+                f"champion {champion_id}: rows={len(champion)} "
+                f"actions={len(champion_actions)} paths={len(champion_paths)} "
+                f"event_state={champion['has_event_state'].mean():.3f}"
+            )
+            del champion
+    pipeline.apply_partial_pooling(actions, pipeline.ACTION_POOLING_LEVELS)
+    pipeline.apply_partial_pooling(paths, pipeline.PATH_POOLING_LEVELS)
+    print(f"total rows={rows} action records={len(actions)} path records={len(paths)}")
+    return 0 if actions else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="build_lab_modeler", description=__doc__)
+    subcommands = parser.add_subparsers(dest="command")
+
+    def add_cohort_arguments(target, *, cache: bool = True):
+        target.add_argument("--patches", help="Comma-separated cohort, newest first. Default: the newest generation's.")
+        target.add_argument("--cutoff", help="Source cutoff timestamp. Default: the newest generation's.")
+        if cache:
+            target.add_argument("--no-cache", action="store_true", help="Ignore and do not write the training cache.")
+            target.add_argument("--refresh", action="store_true", help="Discard the cached draw and redraw it.")
+
+    subcommands.add_parser("run", help="Production path: lease a pending generation and model it.")
+    add_cohort_arguments(subcommands.add_parser("dataset", help="Build and cache the training draw."))
+    add_cohort_arguments(subcommands.add_parser("train", help="Fit from the draw and report the promotion gates."))
+    champion = subcommands.add_parser("champion", help="Produce estimate records for a few champions.")
+    add_cohort_arguments(champion)
+    champion.add_argument("--champions", help="Comma-separated champion ids. Default: the first --limit in the cohort.")
+    champion.add_argument("--limit", type=int, default=3, help="How many champions to sweep when none are named.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    configure_logging()
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+    command = arguments.command or "run"
+    if command == "run":
+        return EXIT_CODES[run()]
+    settings = Settings.from_env()
+    settings.artifact_dir.mkdir(parents=True, exist_ok=True)
+    handlers = {
+        "dataset": command_dataset,
+        "train": command_train,
+        "champion": command_champion,
+    }
+    return handlers[command](settings, arguments)
+
+
 if __name__ == "__main__":
-    sys.exit(EXIT_CODES[run()])
+    sys.exit(main())

--- a/analytics/modeler/src/build_lab_modeler/cache.py
+++ b/analytics/modeler/src/build_lab_modeler/cache.py
@@ -1,0 +1,120 @@
+"""On-disk cache for the training draw, keyed by the cohort it was drawn from.
+
+A generation's cohort is frozen by `SourceCutoffUtc`, so a draw taken from it can be reused: the same
+cohort parameters always select the same matches. That matters twice over.
+
+In production, a run that fails after the draw no longer repays the full cost of the draw on retry --
+which on the live cohort is tens of minutes of query time before any modelling starts.
+
+In development it is the difference between iterating on calibration in seconds and in half-hours.
+Anything that only touches the model or the estimate stage can reuse a cached draw instead of asking
+Postgres for it again.
+
+The key deliberately covers only what changes *which rows are drawn*. It does not cover the borrowing
+weights or the drift exclusion, because those are applied after the draw is loaded, so a change to
+them must not silently reuse a stale frame -- see `TrainingCache.slice_path` for why the prepared
+frame is what gets stored and what that implies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+LOG = logging.getLogger("build_lab_modeler.cache")
+
+# Bumped when the stored frame's meaning changes -- new columns, a different preparation step, or a
+# change to how a slice is thinned. An old cache is then ignored rather than silently reused.
+CACHE_SCHEMA_VERSION = 1
+
+
+def cohort_key(
+    patches: list[str],
+    cutoff,
+    slice_modulus: int,
+    slice_rows: int,
+) -> str:
+    """Short stable digest of everything that decides which rows a slice contains."""
+    payload = json.dumps(
+        {
+            "schema": CACHE_SCHEMA_VERSION,
+            "patches": sorted(str(patch) for patch in patches),
+            "cutoff": str(cutoff),
+            "sliceModulus": int(slice_modulus),
+            "sliceRows": int(slice_rows),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+@dataclass
+class TrainingCache:
+    """Per-slice parquet under a cohort-keyed directory.
+
+    Stored per slice rather than as one frame so a partially completed draw is still worth something:
+    an interrupted run resumes from the slice it reached instead of starting over.
+    """
+
+    directory: Path
+    key: str
+    enabled: bool = True
+
+    @classmethod
+    def for_cohort(
+        cls,
+        root: Path,
+        patches: list[str],
+        cutoff,
+        slice_modulus: int,
+        slice_rows: int,
+        *,
+        enabled: bool = True,
+    ) -> "TrainingCache":
+        key = cohort_key(patches, cutoff, slice_modulus, slice_rows)
+        return cls(directory=root / "training-draw" / key, key=key, enabled=enabled)
+
+    def slice_path(self, residue: int) -> Path:
+        return self.directory / f"slice-{residue:03d}.parquet"
+
+    def read_slice(self, residue: int) -> pd.DataFrame | None:
+        if not self.enabled:
+            return None
+        path = self.slice_path(residue)
+        if not path.is_file():
+            return None
+        try:
+            return pd.read_parquet(path)
+        except Exception as exc:  # a truncated or unreadable file must not fail the run
+            LOG.warning("Ignoring unreadable cached slice %s: %s", path, exc)
+            return None
+
+    def write_slice(self, residue: int, frame: pd.DataFrame) -> None:
+        if not self.enabled:
+            return
+        self.directory.mkdir(parents=True, exist_ok=True)
+        path = self.slice_path(residue)
+        # Written beside the target and moved into place, so a crash mid-write cannot leave a
+        # half-parquet that the next run would read as a complete slice.
+        staging = path.with_suffix(".parquet.partial")
+        try:
+            frame.to_parquet(staging, index=False)
+            staging.replace(path)
+        except Exception as exc:
+            LOG.warning("Could not cache slice %s: %s", path, exc)
+            staging.unlink(missing_ok=True)
+
+    def clear(self) -> int:
+        if not self.directory.is_dir():
+            return 0
+        removed = 0
+        for path in sorted(self.directory.glob("slice-*.parquet*")):
+            path.unlink(missing_ok=True)
+            removed += 1
+        return removed

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -25,6 +25,8 @@ from scipy.special import erfc
 import pandas as pd
 import psycopg
 from psycopg.rows import dict_row, tuple_row
+
+from .cache import TrainingCache
 from sklearn.isotonic import IsotonicRegression
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import brier_score_loss, log_loss
@@ -146,6 +148,7 @@ class Settings:
     lease_owner: str
     max_training_rows: int
     training_sample_matches: int
+    cache_training_draw: bool
     retained_generations: int
 
     @classmethod
@@ -181,6 +184,10 @@ class Settings:
             ),
             # Mirrors BuildLabModelingOptions.RetainedGenerations and the Math.Max(2, ...) floor the
             # coordinator applies, so artifact retention and row retention keep the same set.
+            # On by default: a generation's cohort is frozen by its cutoff, so a cached draw is
+            # always the draw that cohort would produce, and a retry after a mid-run failure no longer
+            # repays tens of minutes of query time before modelling starts.
+            cache_training_draw=os.getenv("BUILD_LAB_CACHE_TRAINING_DRAW", "true").lower() == "true",
             retained_generations=max(2, int(os.getenv("BUILD_LAB_RETAINED_GENERATIONS", "4"))),
         )
 
@@ -318,6 +325,96 @@ def lease_generation(connection: psycopg.Connection, settings: Settings) -> dict
     return generation
 
 
+
+def training_draw_shape(
+    connection: psycopg.Connection,
+    included_patches: list[str],
+    cutoff,
+    settings: "Settings",
+) -> tuple[int, int]:
+    """(slice_modulus, slice_rows) for this cohort -- the two numbers that decide the draw."""
+    match_count = load_cohort_match_count(connection, included_patches, cutoff)
+    modulus = training_sample_modulus(match_count, settings.training_sample_matches)
+    return modulus * TRAINING_SAMPLE_SLICES, max(1, settings.max_training_rows // TRAINING_SAMPLE_SLICES)
+
+
+def build_training_frame(
+    connection: psycopg.Connection,
+    included_patches: list[str],
+    cutoff,
+    rank_offset: str | None,
+    current_patch: str,
+    changed_items: set[int],
+    settings: "Settings",
+    prepare,
+    *,
+    cache: "TrainingCache | None" = None,
+) -> pd.DataFrame:
+    """The draw the structural fit is trained on, one hash-disjoint slice at a time.
+
+    This model was always fit on at most `max_training_rows`; the shape this replaced reached that by
+    loading every decision row in the cohort and then discarding over 99% of them, which is what made
+    peak memory scale with the corpus. Sampling whole matches in the query keeps the same row budget --
+    whole matches, not rows, so the chronological train/calibration/test split still partitions by
+    match and `evaluate_leakage` still sees disjoint splits.
+
+    Each slice is thinned before the next is drawn, so the whole draw is never resident at once, and
+    cached on the way past, so a retry or a model-only iteration does not pay for the queries again.
+    """
+    slice_modulus, slice_rows = training_draw_shape(connection, included_patches, cutoff, settings)
+    LOG.info(
+        "Training draw: %d slices of 1/%d of the cohort, up to %d rows each%s.",
+        TRAINING_SAMPLE_SLICES,
+        slice_modulus,
+        slice_rows,
+        f" (cache {cache.key})" if cache and cache.enabled else " (uncached)",
+    )
+    slices = []
+    for residue in range(TRAINING_SAMPLE_SLICES):
+        cached = cache.read_slice(residue) if cache else None
+        if cached is not None:
+            LOG.info(
+                "Training slice %d/%d: %d rows from cache.",
+                residue + 1,
+                TRAINING_SAMPLE_SLICES,
+                len(cached),
+            )
+            slices.append(cached)
+            continue
+        drawn = prepare(
+            load_decision_frame(
+                connection,
+                included_patches,
+                cutoff,
+                rank_offset,
+                current_patch,
+                changed_items,
+                match_sample_modulus=slice_modulus,
+                match_sample_residue=residue,
+            ),
+            # `exclude_drifted_prior_actions` fires on cells with at least 100 observations in both
+            # the current and a prior patch. Those counts are divided by the sampling rate here, so
+            # applying it would drop an arbitrary subset of cells rather than a conservative one. It
+            # guards *borrowing into a per-cell estimate*, which is not what this model does: the
+            # model is P(win | pre-decision state) and is held to the calibration and held-out-patch
+            # gates instead.
+            exclude_drift=False,
+        )
+        kept = thin_chronologically(drawn, slice_rows)
+        LOG.info(
+            "Training slice %d/%d: %d rows drawn, %d kept.",
+            residue + 1,
+            TRAINING_SAMPLE_SLICES,
+            len(drawn),
+            len(kept),
+        )
+        del drawn
+        if cache:
+            cache.write_slice(residue, kept)
+        slices.append(kept)
+    return pd.concat(slices, ignore_index=True) if slices else pd.DataFrame()
+
+
 def model_generation(
     connection: psycopg.Connection,
     generation: dict,
@@ -357,56 +454,23 @@ def model_generation(
     artifact_path.mkdir(parents=True, exist_ok=True)
 
     # Phase 1 - the structural model, fit on a deterministic sample of whole matches.
-    #
-    # This model was always fit on at most `max_training_rows`; the previous shape of this function
-    # reached that by loading every decision row in the cohort and then discarding over 99% of them,
-    # which is what made peak memory scale with the corpus. Sampling matches in the query keeps the
-    # same row budget for the fit. Whole matches, not rows, so the chronological train/calibration/
-    # test split still partitions by match and `evaluate_leakage` still sees disjoint splits.
-    match_count = load_cohort_match_count(connection, included_patches, cutoff)
-    modulus = training_sample_modulus(match_count, settings.training_sample_matches)
-    slice_modulus = modulus * TRAINING_SAMPLE_SLICES
-    slice_rows = max(1, settings.max_training_rows // TRAINING_SAMPLE_SLICES)
-    LOG.info(
-        "Fitting the structural model on ~1/%d of %d cohort matches, drawn in %d slices.",
-        modulus,
-        match_count,
-        TRAINING_SAMPLE_SLICES,
+    training = build_training_frame(
+        connection,
+        included_patches,
+        cutoff,
+        rank_offset,
+        current_patch,
+        changed_items,
+        settings,
+        prepare,
+        cache=TrainingCache.for_cohort(
+            settings.artifact_dir / "_cache",
+            included_patches,
+            cutoff,
+            *training_draw_shape(connection, included_patches, cutoff, settings),
+            enabled=settings.cache_training_draw,
+        ),
     )
-    slices = []
-    for residue in range(TRAINING_SAMPLE_SLICES):
-        drawn = prepare(
-            load_decision_frame(
-                connection,
-                included_patches,
-                cutoff,
-                rank_offset,
-                current_patch,
-                changed_items,
-                match_sample_modulus=slice_modulus,
-                match_sample_residue=residue,
-            ),
-            # `exclude_drifted_prior_actions` fires on cells with at least 100 observations in both
-            # the current and a prior patch. Those counts are divided by the sampling rate here, so
-            # applying it would drop an arbitrary subset of cells rather than a conservative one. It
-            # guards *borrowing into a per-cell estimate*, which is not what this model does: the
-            # model is P(win | pre-decision state) and is held to the calibration and held-out-patch
-            # gates below.
-            exclude_drift=False,
-        )
-        # Thinned here rather than after the concat so the whole draw is never resident at once. Each
-        # slice spans the full cohort time range, so the union stays a chronological systematic sample.
-        slices.append(thin_chronologically(drawn, slice_rows))
-        LOG.info(
-            "Training slice %d/%d: %d rows drawn, %d kept.",
-            residue + 1,
-            TRAINING_SAMPLE_SLICES,
-            len(drawn),
-            len(slices[-1]),
-        )
-        del drawn
-    training = pd.concat(slices, ignore_index=True)
-    del slices
     if training.empty:
         raise RuntimeError("No eligible item decisions were available for this generation.")
     if training["won"].nunique() < 2:

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -24,7 +24,7 @@ import numpy as np
 from scipy.special import erfc
 import pandas as pd
 import psycopg
-from psycopg.rows import dict_row
+from psycopg.rows import dict_row, tuple_row
 from sklearn.isotonic import IsotonicRegression
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import brier_score_loss, log_loss
@@ -527,8 +527,7 @@ def model_generation(
                 "ValidationMetricsJson" = %s::jsonb,
                 "CompletedAtUtc" = NOW(),
                 "FailureReason" = NULL,
-                "LeaseOwner" = NULL,
-                "LeaseExpiresAtUtc" = NULL
+                "LeaseOwner" = NULL
             WHERE "Id" = %s AND "Status" = 1 AND "LeaseOwner" = %s
             """,
             (
@@ -875,6 +874,23 @@ CHAMPION_MATCH_CTE = """champion_matches AS MATERIALIZED (
 )"""
 
 
+def read_sql_frame(connection, sql: str, params: dict) -> pd.DataFrame:
+    """Run a query and build a DataFrame from it, with an explicitly tuple-shaped cursor.
+
+    `pd.read_sql_query` must not be used on this connection. The run's connection is opened with
+    `row_factory=dict_row` because the generation row is read by column name, and pandas' DBAPI2
+    fallback feeds whatever `fetchall()` returns straight into `DataFrame.from_records`. Handed dicts
+    it iterates each one -- which yields its KEYS -- so every cell in the frame comes back equal to its
+    own column name. That is silent: the row count is right, the dtypes are just `object`, and the
+    corruption only surfaces much later as `int('event_type')`. Naming the row factory here removes the
+    coupling to the connection's, and skips pandas' "not tested" DBAPI2 path entirely.
+    """
+    with connection.cursor(row_factory=tuple_row) as cursor:
+        cursor.execute(sql, params)
+        columns = [column.name for column in cursor.description or []]
+        return pd.DataFrame.from_records(cursor.fetchall(), columns=columns)
+
+
 def champion_match_cte(champion_id: int | None, *, leading: bool) -> str:
     """The champion_matches CTE, or nothing when the load is not champion-scoped.
 
@@ -980,7 +996,8 @@ def load_item_events(
     }
     champion_scope = scope_predicates(champion_id, match_sample_modulus, match_scoped=False)
     champion_cte = champion_match_cte(champion_id, leading=True)
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         f"""
         WITH {champion_cte}eligible AS (
             SELECT
@@ -1085,7 +1102,6 @@ def load_item_events(
         WHERE e.role IN ('TOP', 'JUNGLE', 'MIDDLE', 'BOTTOM', 'UTILITY')
         ORDER BY e.match_date, e.match_id, e.participant_id, item_event."TimestampMs", item_event."EventIndex"
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1223,7 +1239,8 @@ def load_timeline_state_events(
     match_sample_modulus: int | None = None,
     match_sample_residue: int = 0,
 ) -> pd.DataFrame:
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         champion_match_cte(champion_id, leading=False)
         + """
         SELECT
@@ -1249,7 +1266,6 @@ def load_timeline_state_events(
         + """
         ORDER BY payload."MatchId", payload."TimestampMs", payload."EventIndex"
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1269,7 +1285,8 @@ def load_participant_teams(
     match_sample_modulus: int | None = None,
     match_sample_residue: int = 0,
 ) -> pd.DataFrame:
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         champion_match_cte(champion_id, leading=False)
         + """
         SELECT
@@ -1287,7 +1304,6 @@ def load_participant_teams(
         + scope_predicates(champion_id, match_sample_modulus, match_scoped=True)
         + """
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1426,7 +1442,8 @@ def load_rune_decisions(
     }
     champion_scope = scope_predicates(champion_id, match_sample_modulus, match_scoped=False)
     champion_cte = champion_match_cte(champion_id, leading=False)
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         f"""
         {champion_cte}SELECT
             m."Id" AS match_id,
@@ -1480,7 +1497,6 @@ def load_rune_decisions(
           AND COALESCE(p."GameEndedInEarlySurrender", FALSE) = FALSE
 {champion_scope}        ORDER BY m."MatchDate", m."Id", p."ParticipantId", rune."SelectionTree", rune."SelectionIndex"
         """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -1508,7 +1524,8 @@ def load_spell_decisions(
     }
     champion_scope = scope_predicates(champion_id, match_sample_modulus, match_scoped=False)
     champion_cte = champion_match_cte(champion_id, leading=False)
-    return pd.read_sql_query(
+    return read_sql_frame(
+        connection,
         f"""
         {champion_cte}SELECT
             m."Id" AS match_id,
@@ -1559,7 +1576,6 @@ def load_spell_decisions(
           AND UPPER(COALESCE(p."TeamPosition", '')) IN ('TOP', 'JUNGLE', 'MIDDLE', 'BOTTOM', 'UTILITY')
           AND COALESCE(p."GameEndedInEarlySurrender", FALSE) = FALSE
 {champion_scope}        """,
-        connection,
         params={
             "patches": patches,
             "cutoff": cutoff,
@@ -2840,8 +2856,7 @@ def mark_failed(connection, generation_id, message: str, lease_owner: str) -> No
         SET "Status" = 4,
             "FailureReason" = %s,
             "CompletedAtUtc" = NOW(),
-            "LeaseOwner" = NULL,
-            "LeaseExpiresAtUtc" = NULL
+            "LeaseOwner" = NULL
         WHERE "Id" = %s
           AND "Status" = 1
           AND "LeaseOwner" = %s

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -1844,6 +1844,67 @@ def average_timing(rows: pd.DataFrame, family: str) -> float | None:
     return float(minutes.mean()) if not minutes.empty else None
 
 
+CALIBRATION_BANDS = 5
+# Below this an isotonic fit on one band memorises its calibration split instead of calibrating it,
+# which would show up as a band that looks perfect here and drifts in production.
+MINIMUM_BAND_CALIBRATION_ROWS = 200
+
+
+def calibration_band_edges(minutes: np.ndarray, bands: int) -> np.ndarray:
+    """Interior quantile edges of the decision-minute distribution, deduplicated."""
+    if minutes.size == 0 or bands < 2:
+        return np.asarray([], dtype=float)
+    quantiles = np.linspace(0, 1, bands + 1)[1:-1]
+    edges = np.unique(np.quantile(minutes, quantiles))
+    # An edge at or below the minimum splits nothing off, which is what a constant or heavily skewed
+    # minute column produces. Dropping those leaves no edges rather than one band holding every row.
+    return edges[edges > minutes.min()]
+
+
+def fit_banded_calibrator(minutes: np.ndarray, raw: np.ndarray, actual: np.ndarray) -> dict:
+    """Isotonic calibration per game-phase band, with a global calibrator as the fallback.
+
+    The promotion gate measures ECE *within* time bands, so calibrating globally is measuring one
+    thing and fitting another: a single monotone map cannot correct a bias that changes sign between
+    the early and late game, and the worst band carries the gate. Measured on the live 16.15 cohort, a
+    global fit gave an overall ECE of 0.0078 (well inside its 0.015 limit) while the worst time band
+    sat at 0.0529 against a 0.025 limit, and it barely improved when the training draw was quadrupled
+    -- a worst-of-N statistic does not shrink with sample size the way a mean does. Fitting each band
+    separately targets the criterion the gate actually applies.
+
+    Bands are quantiles of the *calibration* split, so the edges are fixed at fit time and travel with
+    the model rather than being re-derived from whatever is being scored.
+    """
+    fallback = IsotonicRegression(out_of_bounds="clip")
+    fallback.fit(raw, actual)
+    edges = calibration_band_edges(minutes, CALIBRATION_BANDS)
+    assignment = np.digitize(minutes, edges)
+    bands: dict[int, IsotonicRegression] = {}
+    for band in np.unique(assignment):
+        mask = assignment == band
+        # A band with one outcome has nothing to calibrate against and would collapse to a constant.
+        if int(mask.sum()) < MINIMUM_BAND_CALIBRATION_ROWS or np.unique(actual[mask]).size < 2:
+            continue
+        band_calibrator = IsotonicRegression(out_of_bounds="clip")
+        band_calibrator.fit(raw[mask], actual[mask])
+        bands[int(band)] = band_calibrator
+    return {"edges": edges, "bands": bands, "fallback": fallback}
+
+
+def apply_banded_calibrator(calibrator: dict, minutes: np.ndarray, raw: np.ndarray) -> np.ndarray:
+    """Route each row to the calibrator for its band, falling back to the global one."""
+    values = np.asarray(calibrator["fallback"].predict(raw), dtype=float)
+    edges = calibrator["edges"]
+    if len(edges) == 0 or not calibrator["bands"]:
+        return values
+    assignment = np.digitize(minutes, edges)
+    for band, band_calibrator in calibrator["bands"].items():
+        mask = assignment == band
+        if mask.any():
+            values[mask] = np.asarray(band_calibrator.predict(raw[mask]), dtype=float)
+    return values
+
+
 def train_structural_model(
     decisions: pd.DataFrame,
     max_training_rows: int = 250_000,
@@ -1893,10 +1954,15 @@ def train_structural_model(
     model = make_pipeline(StandardScaler(), LogisticRegression(max_iter=500, class_weight="balanced"))
     model.fit(train_x, train["won"].astype(int))
     calibration_raw = model.predict_proba(calibration_x)[:, 1]
-    calibrator = IsotonicRegression(out_of_bounds="clip")
-    calibrator.fit(calibration_raw, calibration["won"].astype(int))
+    calibrator = fit_banded_calibrator(
+        calibration["minute"].to_numpy(dtype=float),
+        calibration_raw,
+        calibration["won"].astype(int).to_numpy(),
+    )
     test_raw = model.predict_proba(test_x)[:, 1]
-    predicted = np.asarray(calibrator.predict(test_raw), dtype=float)
+    predicted = apply_banded_calibrator(
+        calibrator, test["minute"].to_numpy(dtype=float), test_raw
+    )
     actual = test["won"].astype(int).to_numpy()
     baseline_probability = float(train["won"].mean())
     baseline = np.full_like(predicted, baseline_probability)
@@ -1930,6 +1996,10 @@ def train_structural_model(
         "logLoss": float(log_loss(actual, np.clip(predicted, 1e-6, 1 - 1e-6))),
         "baselineLogLoss": float(log_loss(actual, np.clip(baseline, 1e-6, 1 - 1e-6))),
         "heldOutPatchPassed": bool(held_out_patch and beats_baseline),
+        # A cohort with a single patch cannot be split across a patch boundary, so there is nothing to
+        # pass or fail. Reported separately from the result so the promoter can tell "not testable"
+        # apart from "tested and failed" instead of reading False as a verdict.
+        "heldOutPatchApplicable": bool(held_out_patch),
         "leakageCheckPassed": leakage["passed"],
         "leakageDetail": leakage,
         "heldOutPatch": held_out_patch,
@@ -1937,6 +2007,8 @@ def train_structural_model(
         "calibrationMatchCount": len(set(calibration_matches)),
         "testMatchCount": len(set(test_matches)),
         "designColumnCount": len(design.columns),
+        "calibrationBandCount": len(calibrator["bands"]),
+        "calibrationBandEdges": [float(edge) for edge in calibrator["edges"]],
     }
     return (
         {"model": model, "calibrator": calibrator, "spec": spec, "features": design.columns.tolist()},
@@ -1987,7 +2059,11 @@ def structural_win_probability(
     for start in range(0, len(frame), chunk_rows):
         chunk = frame.iloc[start:start + chunk_rows]
         raw = bundle["model"].predict_proba(design_matrix(chunk, bundle["spec"]))[:, 1]
-        values[start:start + len(chunk)] = np.asarray(bundle["calibrator"].predict(raw), dtype=float)
+        # Routed by decision minute through the same band edges the calibrator was fit with, or every
+        # published number would be read off a different map than the one the gate measured.
+        values[start:start + len(chunk)] = apply_banded_calibrator(
+            bundle["calibrator"], chunk["minute"].to_numpy(dtype=float), raw
+        )
     return np.clip(values, 1e-4, 1 - 1e-4)
 
 

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1950,3 +1950,136 @@ def test_no_status_write_references_a_dropped_lease_column():
         source = inspect.getsource(function)
         for dropped in ("LeaseExpiresAtUtc", "HeartbeatAtUtc"):
             assert dropped not in source, f"{function.__name__} still writes {dropped}"
+
+
+def phase_flipped_calibration_data(seed: int = 7):
+    """Raw scores whose bias flips sign between early and late game.
+
+    A single monotone map cannot correct both halves: for any given raw score the two bands disagree
+    about the outcome rate in opposite directions, so a global isotonic fit averages them and leaves
+    each band wrong. This is the shape the promotion gate's per-band ECE is designed to catch.
+    """
+    rng = np.random.default_rng(seed)
+    raw, minutes, actual = [], [], []
+    for minute, shift in ((5.0, -0.25), (25.0, +0.25)):
+        scores = rng.uniform(0.15, 0.85, 4000)
+        raw.extend(scores)
+        minutes.extend([minute + rng.uniform(0, 4.0) for _ in scores])
+        actual.extend(rng.binomial(1, np.clip(scores + shift, 0.01, 0.99)))
+    return (
+        np.asarray(minutes, dtype=float),
+        np.asarray(raw, dtype=float),
+        np.asarray(actual, dtype=int),
+    )
+
+
+def worst_band_ece(minutes, actual, predicted) -> float:
+    early = minutes < 15
+    return max(
+        expected_calibration_error(actual[early], predicted[early]),
+        expected_calibration_error(actual[~early], predicted[~early]),
+    )
+
+
+def test_banded_calibration_beats_a_global_map_on_a_phase_dependent_bias():
+    minutes, raw, actual = phase_flipped_calibration_data()
+
+    from sklearn.isotonic import IsotonicRegression
+
+    global_only = IsotonicRegression(out_of_bounds="clip")
+    global_only.fit(raw, actual)
+    global_worst = worst_band_ece(minutes, actual, np.asarray(global_only.predict(raw), dtype=float))
+
+    banded = pipeline.fit_banded_calibrator(minutes, raw, actual)
+    banded_worst = worst_band_ece(
+        minutes, actual, pipeline.apply_banded_calibrator(banded, minutes, raw)
+    )
+
+    # The global map is what produced a 0.053 worst band against a 0.025 limit on the live cohort.
+    assert global_worst > 0.05, f"fixture must exhibit the bias it claims: {global_worst}"
+    assert banded_worst < global_worst / 2, f"global={global_worst} banded={banded_worst}"
+
+
+def test_a_calibration_split_too_small_to_band_falls_back_instead_of_memorising():
+    # Bands are quantiles, so they always hold roughly equal counts -- the minimum-rows guard fires on
+    # a SMALL calibration split, not on one lopsided band. A sparse cohort must therefore degrade to a
+    # single global map rather than fit five isotonic curves on a few dozen rows each.
+    rng = np.random.default_rng(3)
+    raw = rng.uniform(0.1, 0.9, 300)
+    minutes = rng.uniform(0.0, 40.0, 300)
+    actual = rng.binomial(1, raw)
+
+    calibrator = pipeline.fit_banded_calibrator(minutes, raw, actual)
+
+    assert calibrator["bands"] == {}, "300 rows over 5 bands must not be fit per band"
+    assert calibrator["fallback"] is not None
+    values = pipeline.apply_banded_calibrator(calibrator, minutes, raw)
+    assert np.isfinite(values).all() and values.shape == raw.shape
+    # With no per-band fit, routing must be a no-op rather than silently dropping rows.
+    assert np.allclose(values, calibrator["fallback"].predict(raw))
+
+
+def test_a_skewed_minute_column_produces_no_degenerate_single_band():
+    # Almost every row at one minute: the quantile edges all collapse onto that value, and an edge
+    # there splits nothing off. Keeping it would create a "band" holding the entire dataset.
+    minutes = np.concatenate([np.full(2000, 5.0), np.full(10, 40.0)])
+    edges = pipeline.calibration_band_edges(minutes, 5)
+    assert len(edges) == 0, edges
+
+
+def test_a_single_outcome_band_gets_no_calibrator_of_its_own():
+    rng = np.random.default_rng(11)
+    raw = rng.uniform(0.1, 0.9, 2000)
+    minutes = np.concatenate([np.full(1000, 5.0), np.full(1000, 30.0)])
+    # The late band won every game, so an isotonic fit there would collapse to the constant 1.0.
+    actual = np.concatenate([rng.binomial(1, raw[:1000]), np.ones(1000, dtype=int)])
+
+    calibrator = pipeline.fit_banded_calibrator(minutes, raw, actual)
+    assignment = np.digitize(minutes, calibrator["edges"])
+    late_band = int(assignment[-1])
+
+    assert late_band not in calibrator["bands"]
+
+
+def test_band_edges_are_interior_quantiles_and_survive_degenerate_input():
+    minutes = np.asarray([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+    edges = pipeline.calibration_band_edges(minutes, 5)
+    assert len(edges) == 4, edges
+    assert (np.diff(edges) > 0).all(), "edges must be strictly increasing after dedup"
+    assert edges.min() > minutes.min() and edges.max() < minutes.max(), "interior only"
+    # A constant column collapses to no usable edges rather than raising.
+    assert len(pipeline.calibration_band_edges(np.full(100, 12.0), 5)) == 0
+    assert len(pipeline.calibration_band_edges(np.asarray([]), 5)) == 0
+
+
+def test_scoring_routes_each_row_through_the_band_it_belongs_to():
+    # Published numbers must come off the same map the gate measured, so identical rows that differ
+    # only in decision minute must be able to calibrate differently.
+    minutes, raw, actual = phase_flipped_calibration_data()
+    calibrator = pipeline.fit_banded_calibrator(minutes, raw, actual)
+    probe = np.full(4, 0.5)
+    early = pipeline.apply_banded_calibrator(calibrator, np.full(4, 5.0), probe)
+    late = pipeline.apply_banded_calibrator(calibrator, np.full(4, 27.0), probe)
+    assert not np.allclose(early, late), "minute had no effect, so routing is not happening"
+    # And the direction matches the injected bias: late games were under-predicted.
+    assert late.mean() > early.mean()
+
+
+def test_the_manifest_separates_an_untestable_patch_holdout_from_a_failed_one():
+    # A single-patch cohort cannot be split across a patch boundary. Reporting only `False` makes
+    # "not testable" indistinguishable from "tested and failed", which is what blocked promotion.
+    decisions = synthetic_decisions()
+    single = decisions[decisions["patch"] == "26.14"]
+    _, metrics = train_structural_model(single, max_training_rows=100_000)
+    assert metrics["heldOutPatch"] is None
+    assert metrics["heldOutPatchApplicable"] is False
+    assert metrics["heldOutPatchPassed"] is False
+    # Two patches: the holdout is testable, so applicability is true whatever the verdict.
+    _, both = train_structural_model(decisions, max_training_rows=100_000)
+    assert both["heldOutPatch"] is not None
+    assert both["heldOutPatchApplicable"] is True
+    # Calibration provenance travels with the metrics, since the ECE gate is measured against it.
+    assert isinstance(both["calibrationBandEdges"], list)
+    # The fixture's calibration split is far too small to band, so zero per-band fits is the correct
+    # outcome here; what must hold is that the provenance is reported either way.
+    assert both["calibrationBandCount"] == 0

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import inspect
+import pathlib
 import json
 import logging
 import re
@@ -2083,3 +2084,99 @@ def test_the_manifest_separates_an_untestable_patch_holdout_from_a_failed_one():
     # The fixture's calibration split is far too small to band, so zero per-band fits is the correct
     # outcome here; what must hold is that the provenance is reported either way.
     assert both["calibrationBandCount"] == 0
+
+
+def test_the_cli_still_maps_run_outcomes_onto_exit_codes():
+    from build_lab_modeler import __main__ as entrypoint
+
+    # A scheduler sees only the exit code, so a failed generation must not look like a quiet tick.
+    assert entrypoint.EXIT_CODES[RunOutcome.IDLE] == 0
+    assert entrypoint.EXIT_CODES[RunOutcome.COMPLETED] == 0
+    assert entrypoint.EXIT_CODES[RunOutcome.FAILED] == 1
+
+
+def test_the_cli_gate_limits_match_the_committed_dotnet_options():
+    # The CLI reports the promoter's verdict locally. If these drift from BuildLabModelingOptions the
+    # local answer stops predicting the deployed one, which is the whole reason the subcommand exists.
+    from build_lab_modeler import __main__ as entrypoint
+
+    options = pathlib.Path(__file__).resolve().parents[3] / (
+        "Transcendence.Service.Core/Services/Analytics/Models/BuildLabModelingOptions.cs"
+    )
+    source = options.read_text(encoding="utf-8")
+    for field, limit in (
+        ("MaximumOverallEce", entrypoint.GATE_LIMITS["maximumOverallEce"]),
+        ("MaximumTimeBandEce", entrypoint.GATE_LIMITS["maximumTimeBandEce"]),
+    ):
+        assert f"public double {field} {{ get; set; }} = {limit};" in source, field
+
+
+def test_every_subcommand_is_on_demand_and_needs_no_pending_generation():
+    from build_lab_modeler import __main__ as entrypoint
+
+    parser = entrypoint.build_parser()
+    # An empty argv must keep meaning "production run", or the scheduler's invocation changes meaning.
+    assert parser.parse_args([]).command is None
+    for command in ("dataset", "train", "champion"):
+        parsed = parser.parse_args([command])
+        assert parsed.command == command
+        # Each must accept an explicit cohort so it can run with no generation row at all.
+        assert hasattr(parsed, "patches") and hasattr(parsed, "cutoff")
+        assert hasattr(parsed, "no_cache") and hasattr(parsed, "refresh")
+
+
+def test_the_training_cache_key_tracks_what_decides_which_rows_are_drawn():
+    from build_lab_modeler.cache import cohort_key
+
+    base = cohort_key(["16.15"], "2026-08-04T05:15:03Z", 40, 31_250)
+    # Patch order must not matter; the same cohort is the same cohort.
+    assert base == cohort_key(["16.15"], "2026-08-04T05:15:03Z", 40, 31_250)
+    # Everything that changes the drawn rows must change the key, or a stale frame gets reused.
+    assert base != cohort_key(["16.15", "16.14"], "2026-08-04T05:15:03Z", 40, 31_250)
+    assert base != cohort_key(["16.15"], "2026-08-05T05:15:03Z", 40, 31_250)
+    assert base != cohort_key(["16.15"], "2026-08-04T05:15:03Z", 24, 31_250)
+    assert base != cohort_key(["16.15"], "2026-08-04T05:15:03Z", 40, 10_000)
+
+
+def test_a_cached_slice_round_trips_and_a_truncated_one_is_ignored(tmp_path):
+    from build_lab_modeler.cache import TrainingCache
+
+    cache = TrainingCache.for_cohort(tmp_path, ["16.15"], "2026-08-04T05:15:03Z", 40, 31_250)
+    assert cache.read_slice(0) is None, "a cold cache must miss rather than raise"
+    frame = pd.DataFrame({"won": [True, False], "minute": [4.0, 21.0]})
+    cache.write_slice(0, frame)
+    restored = cache.read_slice(0)
+    assert restored is not None and len(restored) == 2
+    assert restored["won"].tolist() == [True, False]
+    # A crash mid-write must not leave something the next run reads as a complete slice.
+    cache.slice_path(0).write_bytes(b"not parquet")
+    assert cache.read_slice(0) is None
+    # Disabling the cache must neither read nor write.
+    disabled = TrainingCache(directory=cache.directory, key=cache.key, enabled=False)
+    disabled.write_slice(1, frame)
+    assert not disabled.slice_path(1).exists()
+    assert disabled.read_slice(0) is None
+
+
+def test_the_draw_reuses_cached_slices_instead_of_querying_again(tmp_path, monkeypatch):
+    from build_lab_modeler.cache import TrainingCache
+
+    settings = modeler_settings(monkeypatch, BUILD_LAB_ARTIFACT_DIR=str(tmp_path))
+    cache = TrainingCache.for_cohort(tmp_path, ["16.15"], "cutoff", 40, 500)
+    for residue in range(pipeline.TRAINING_SAMPLE_SLICES):
+        cache.write_slice(residue, pd.DataFrame({"won": [True, False], "minute": [4.0, 21.0]}))
+    queried = []
+    monkeypatch.setattr(
+        pipeline,
+        "load_decision_frame",
+        lambda *args, **kwargs: queried.append(kwargs) or pd.DataFrame(),
+    )
+    monkeypatch.setattr(pipeline, "training_draw_shape", lambda *_: (40, 500))
+
+    frame = pipeline.build_training_frame(
+        FakeConnection(), ["16.15"], "cutoff", None, "16.15", set(), settings,
+        lambda frame, exclude_drift=True: frame, cache=cache,
+    )
+
+    assert queried == [], "a fully cached draw must not touch the database"
+    assert len(frame) == 2 * pipeline.TRAINING_SAMPLE_SLICES

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -1853,3 +1853,100 @@ def test_the_estimate_sweep_scopes_every_load_to_one_champion(monkeypatch, tmp_p
     assert sorted(scope["match_sample_residue"] for scope in training) == list(
         range(pipeline.TRAINING_SAMPLE_SLICES)
     )
+
+
+class DictRowCursor:
+    """A cursor shaped like psycopg's, whose row factory decides the row type.
+
+    Mirrors the property that broke prod: a connection opened with `row_factory=dict_row` hands
+    `fetchall()` dicts unless a cursor names a different factory.
+    """
+
+    class Column:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    def __init__(self, columns: list[str], rows: list[tuple], row_factory) -> None:
+        self._columns = columns
+        self._rows = rows
+        self._row_factory = row_factory
+        self.executed: list[tuple[str, dict | None]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        return self
+
+    @property
+    def description(self):
+        return [self.Column(name) for name in self._columns]
+
+    def fetchall(self):
+        if self._row_factory is pipeline.dict_row:
+            return [dict(zip(self._columns, row, strict=True)) for row in self._rows]
+        return list(self._rows)
+
+
+class DictRowConnection:
+    def __init__(self, columns: list[str], rows: list[tuple]) -> None:
+        self._columns = columns
+        self._rows = rows
+        self.cursors: list[DictRowCursor] = []
+
+    def cursor(self, row_factory=None):
+        # Default to the connection's factory, exactly as psycopg does.
+        cursor = DictRowCursor(self._columns, self._rows, row_factory or pipeline.dict_row)
+        self.cursors.append(cursor)
+        return cursor
+
+
+def test_the_frame_reader_returns_values_not_column_names_on_a_dict_row_connection():
+    # The bug this pins cost a production run: pandas' DBAPI2 fallback iterates each dict row, which
+    # yields its KEYS, so every cell came back equal to its own column name. The row count and shape
+    # were right, dtypes were merely object, and it only surfaced later as int('event_type').
+    columns = ["match_id", "event_index", "event_type", "action_id"]
+    rows = [("match-a", 0, 0, 6672), ("match-a", 1, 2, 3031)]
+    connection = DictRowConnection(columns, rows)
+
+    frame = pipeline.read_sql_frame(connection, "SELECT ...", {"patches": ["16.15"]})
+
+    assert list(frame.columns) == columns
+    assert frame["event_type"].tolist() == [0, 2]
+    assert frame["match_id"].tolist() == ["match-a", "match-a"]
+    # The corruption signature: a cell equal to its own column name.
+    for column in columns:
+        assert not (frame[column].astype(str) == column).any(), column
+    # Numeric columns must stay numeric, or every downstream int() cast is a coin flip.
+    assert int(frame["event_type"].iloc[0]) == 0
+    # It must ask for tuples rather than inherit the connection's dict factory.
+    assert connection.cursors[-1]._row_factory is pipeline.tuple_row
+
+
+def test_no_loader_uses_the_pandas_dbapi_fallback():
+    # pd.read_sql_query on the run's dict_row connection is silently wrong, so no loader may reach for
+    # it. Keeping this a source assertion catches a reintroduction that no fake connection would.
+    source = inspect.getsource(pipeline)
+    assert "pd.read_sql_query" not in source.replace("`pd.read_sql_query` must not", "")
+    for loader in (
+        load_item_events,
+        load_rune_decisions,
+        load_spell_decisions,
+        load_timeline_state_events,
+        load_participant_teams,
+    ):
+        assert "read_sql_frame(" in inspect.getsource(loader), loader.__name__
+
+
+def test_no_status_write_references_a_dropped_lease_column():
+    # 20260801025434_DropModelingLeaseColumns removed LeaseExpiresAtUtc and HeartbeatAtUtc when the
+    # lease became a session advisory lock. A stale reference in the TERMINAL write is invisible until
+    # a run actually succeeds, and then it fails the publish it was supposed to record.
+    for function in (model_generation, mark_failed):
+        source = inspect.getsource(function)
+        for dropped in ("LeaseExpiresAtUtc", "HeartbeatAtUtc"):
+            assert dropped not in source, f"{function.__name__} still writes {dropped}"

--- a/tests/Transcendence.Service.Core.Tests/BuildLabGenerationCoordinatorTests.cs
+++ b/tests/Transcendence.Service.Core.Tests/BuildLabGenerationCoordinatorTests.cs
@@ -83,6 +83,77 @@ public sealed class BuildLabGenerationCoordinatorTests
         retired.RetiredAtUtc.Should().NotBeNull();
     }
 
+    [Fact]
+    public async Task PromoteCandidateAsync_PromotesWhenThePatchHoldoutWasNotTestable()
+    {
+        // A cohort covering one patch cannot be split across a patch boundary, so HeldOutPatchPassed is
+        // false for want of a test. Treating that as a failure blocked every generation on prod, where
+        // only one patch had timeline and Emerald+ coverage. It is safe to waive because the gate
+        // guards borrowing: with one patch in scope no prior-patch row is borrowed at all.
+        await using var harness = await BuildLabHarness.CreateAsync();
+        var candidate = Candidate();
+        candidate.ValidationMetricsJson = JsonSerializer.Serialize(
+            PassingMetrics() with { HeldOutPatchPassed = false, HeldOutPatchApplicable = false });
+        harness.Db.BuildLabGenerations.Add(candidate);
+        harness.Db.AdjustedActionEstimates.Add(PassingEstimate(candidate.Id));
+        await harness.Db.SaveChangesAsync();
+        using var telemetry = new BuildLabTelemetry();
+        var coordinator = Coordinator(harness, telemetry);
+
+        var promoted = await coordinator.PromoteCandidateAsync(candidate.Id, actor: "operator");
+
+        promoted.Should().BeTrue();
+        var reloaded = await Reload(harness, candidate.Id);
+        reloaded.Status.Should().Be(BuildLabGenerationStatus.Ready);
+        reloaded.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PromoteCandidateAsync_StillRejectsAPatchHoldoutThatWasTestedAndFailed()
+    {
+        // The waiver must be narrow: a cohort that COULD be split across patches and then failed the
+        // comparison is a real failure, not a missing test.
+        await using var harness = await BuildLabHarness.CreateAsync();
+        var candidate = Candidate();
+        candidate.ValidationMetricsJson = JsonSerializer.Serialize(
+            PassingMetrics() with { HeldOutPatchPassed = false, HeldOutPatchApplicable = true });
+        harness.Db.BuildLabGenerations.Add(candidate);
+        harness.Db.AdjustedActionEstimates.Add(PassingEstimate(candidate.Id));
+        await harness.Db.SaveChangesAsync();
+        using var telemetry = new BuildLabTelemetry();
+        var coordinator = Coordinator(harness, telemetry);
+
+        var promoted = await coordinator.PromoteCandidateAsync(candidate.Id, actor: "operator");
+
+        promoted.Should().BeFalse();
+        var reloaded = await Reload(harness, candidate.Id);
+        reloaded.Status.Should().Be(BuildLabGenerationStatus.Failed);
+    }
+
+    [Fact]
+    public async Task PromoteCandidateAsync_RejectsAFailedPatchHoldoutWhenApplicabilityIsUnreported()
+    {
+        // An older modeler does not emit the applicability field. Absent it, a false result must keep
+        // its old meaning and fail the gate, rather than being waived by a missing value.
+        await using var harness = await BuildLabHarness.CreateAsync();
+        var document = JsonSerializer.SerializeToNode(
+            PassingMetrics() with { HeldOutPatchPassed = false })!.AsObject();
+        document.Remove("HeldOutPatchApplicable");
+        var candidate = Candidate();
+        candidate.ValidationMetricsJson = document.ToJsonString();
+        harness.Db.BuildLabGenerations.Add(candidate);
+        harness.Db.AdjustedActionEstimates.Add(PassingEstimate(candidate.Id));
+        await harness.Db.SaveChangesAsync();
+        using var telemetry = new BuildLabTelemetry();
+        var coordinator = Coordinator(harness, telemetry);
+
+        var promoted = await coordinator.PromoteCandidateAsync(candidate.Id, actor: "operator");
+
+        promoted.Should().BeFalse();
+        var reloaded = await Reload(harness, candidate.Id);
+        reloaded.Status.Should().Be(BuildLabGenerationStatus.Failed);
+    }
+
     [Theory]
     [InlineData("overall-ece")]
     [InlineData("time-band-ece")]
@@ -99,7 +170,10 @@ public sealed class BuildLabGenerationCoordinatorTests
             "time-band-ece" => PassingMetrics() with { MaxTimeBandEce = 0.9 },
             "brier" => PassingMetrics() with { BrierScore = 0.24, BaselineBrierScore = 0.24 },
             "log-loss" => PassingMetrics() with { LogLoss = 0.66, BaselineLogLoss = 0.66 },
-            "held-out-patch" => PassingMetrics() with { HeldOutPatchPassed = false },
+            "held-out-patch" => PassingMetrics() with
+            {
+                HeldOutPatchPassed = false, HeldOutPatchApplicable = true
+            },
             "leakage" => PassingMetrics() with { LeakageCheckPassed = false },
             _ => throw new ArgumentOutOfRangeException(nameof(failingGate))
         };


### PR DESCRIPTION
Follow-up to #157/#158. Those got the modeler to produce real estimates; this clears the two gates that still blocked promotion, and removes the reason every question about the model cost half an hour.

## Context: measured gate results on the live 16.15 cohort

183,394 training rows, 9,279 / 1,989 / 1,989 disjoint match split:

| gate | value | limit | |
|---|---|---|---|
| overallEce | 0.0078 | ≤0.015 | ✅ |
| maxTimeBandEce | 0.0529 | ≤0.025 | ❌ |
| Brier vs baseline | 0.2033 vs 0.2499 | < | ✅ |
| log-loss vs baseline | 0.5869 vs 0.6929 | < | ✅ |
| leakageCheckPassed | true | true | ✅ |
| heldOutPatchPassed | false | true | ❌ |

## 1. Calibrate per time band

The gate measures ECE **within** time bands while the calibrator was fit **globally** — measuring one thing and fitting another. A single monotone map cannot correct a bias that changes sign between early and late game, and the worst band carries the gate.

That this is structural rather than a sample-size problem is measurable: quadrupling the training draw took overall ECE from 0.0161 → 0.0078 but the worst band only 0.0738 → 0.0529. A worst-of-N statistic does not shrink with sample size the way a mean does.

Calibration is now fitted per band, on quantiles of the **calibration split** so edges are fixed at fit time and travel with the model. Scoring routes each row through the same edges — otherwise published numbers come off a different map than the gate measured. Bands below a row floor, or with a single outcome, fall back to the global map rather than memorising a thin slice; the band count and edges are reported in the manifest.

## 2. Tell an untestable patch holdout from a failed one

A cohort covering one patch cannot be split across a patch boundary, so `HeldOutPatchPassed` was false for want of a test. On prod, only 16.15 has timeline-v2 **and** Emerald+ coverage:

| patch | eligible matches |
|---|---|
| 16.15 | 70,449 |
| 16.14 | 0 |
| 16.13 | 0 |

So `PriorPatchesToBorrow = 2` correctly resolves to nothing and **no generation could ever be promoted.**

The modeler now reports `heldOutPatchApplicable` separately and the promoter accepts a holdout that was not testable. The waiver is narrow and safe for a specific reason: the gate guards **borrowing**, and with one patch in scope nothing is borrowed — verified that recency and commensurability weights leave every row at 1.0 even when the change set marks both the champion and the item as changed, because blocking only applies to prior-patch rows. The chronological holdout still applies, and both baseline comparisons are measured on it. A holdout that *was* testable and failed is still a failure; a manifest omitting the field keeps the old meaning and fails closed.

⚠️ Once a second patch accumulates coverage, generations get held to this gate for the first time — worth watching at the next patch flip.

## 3. On-demand subcommands and a cached draw

Answering a question required the scheduler to fire, a generation to be pending, and the cohort to be re-drawn from Postgres (tens of minutes) before any modelling — observable only by tailing a container log.

- **The draw is cached, keyed by cohort.** Frozen by `SourceCutoffUtc`, so reuse is not a shortcut. Per-slice files written through a staging path: an interrupted draw resumes from the slice it reached, and a crash mid-write can't leave a half-parquet the next run mistakes for complete. Production benefit too — a run that fails after the draw no longer repays it on retry.
- **`dataset` / `train` / `champion`** need no generation and write nothing. `train` prints each gate's verdict so the local answer predicts the deployed one. With a cached draw it's seconds.
- `run` keeps its exact meaning, including bare argv (the systemd unit is unchanged) and the outcome→exit-code mapping.

CLI gate limits mirror `BuildLabModelingOptions` and are asserted against the committed defaults, since a local verdict that silently drifts is worse than none.

## Tests

102 modeler + 29 coordinator tests. Notable ones: banded calibration halves worst-band error on a fixture whose bias flips sign by phase (where a global map cannot); a calibration split too small to band falls back instead of fitting five curves on a few dozen rows; a skewed minute column yields no degenerate whole-dataset band; scoring demonstrably routes on minute; a truncated cached slice is ignored; a fully cached draw touches no database; and three promoter tests cover waived / tested-and-failed / unreported applicability.

Two bugs in my own new code were caught by these tests before shipping: degenerate band edges on a constant-or-skewed minute column, and a thin-band test premised on a misunderstanding (quantile bands hold equal counts, so the row floor fires on a small calibration split, not a lopsided band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)