### PR TITLE
Reserve the summoner hero's form row so the page stops shifting under it

### DIFF
--- a/apps/web/app/lol/summoners/[region]/[riotId]/loading.tsx
+++ b/apps/web/app/lol/summoners/[region]/[riotId]/loading.tsx
@@ -1,3 +1,7 @@
+import {
+  MATCH_PLACEHOLDER_ROWS,
+  RECENT_FORM_SLOTS
+} from "@/components/lol-profile/shared";
 import { Card } from "@/components/ui/Card";
 import { Skeleton } from "@/components/ui/Skeleton";
 
@@ -24,7 +28,7 @@ export default function Loading() {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2 border-t border-border/70 pt-3">
-          {Array.from({ length: 10 }).map((_, i) => (
+          {Array.from({ length: RECENT_FORM_SLOTS }).map((_, i) => (
             <Skeleton key={i} className="h-2.5 w-7 rounded-full" />
           ))}
         </div>
@@ -54,7 +58,7 @@ export default function Loading() {
           <Card className="profile-section-card rounded-panel p-5 md:p-6">
             <Skeleton className="h-6 w-40" />
             <div className="mt-5 flex flex-col gap-4">
-              {Array.from({ length: 4 }).map((_, i) => (
+              {Array.from({ length: MATCH_PLACEHOLDER_ROWS }).map((_, i) => (
                 <Skeleton key={i} className="h-28 w-full rounded-panel" />
               ))}
             </div>

--- a/apps/web/components/SummonerProfileUnified.tsx
+++ b/apps/web/components/SummonerProfileUnified.tsx
@@ -10,6 +10,8 @@ import { ProfileHeroCard } from "@/components/lol-profile/ProfileHeroCard";
 import { ProfileSidebar } from "@/components/lol-profile/ProfileSidebar";
 import { StaticDataProvider } from "@/components/lol-profile/StaticDataContext";
 import {
+  MATCH_PLACEHOLDER_ROWS,
+  RECENT_FORM_SLOTS,
   type ApiErrorResponse,
   type ChampionStatic,
   type ItemStatic,
@@ -49,12 +51,16 @@ const MatchHistorySection = dynamic(
       (module) => module.MatchHistorySection
     ),
   {
+    // Mirrors the route-level skeleton (app/lol/summoners/[region]/[riotId]/loading.tsx)
+    // and the section's own first-load state. All three render in sequence on a cold
+    // load, so any difference in reserved height is a layout shift at each handoff.
     loading: () => (
-      <Card className="profile-section-card p-5">
-        <div className="grid gap-3">
-          <Skeleton className="h-11 w-full" />
-          <Skeleton className="h-40 w-full" />
-          <Skeleton className="h-40 w-full" />
+      <Card className="profile-section-card rounded-panel p-5 md:p-6">
+        <Skeleton className="h-6 w-40" />
+        <div className="mt-5 flex flex-col gap-4">
+          {Array.from({ length: MATCH_PLACEHOLDER_ROWS }).map((_, i) => (
+            <Skeleton key={i} className="h-28 w-full rounded-panel" />
+          ))}
         </div>
       </Card>
     )
@@ -157,7 +163,7 @@ export function SummonerProfileClient({
   ]);
 
   const recentForm = useMemo(
-    () => (matches.history?.items ?? []).slice(0, 10).map((match) => match.win),
+    () => (matches.history?.items ?? []).slice(0, RECENT_FORM_SLOTS).map((match) => match.win),
     [matches.history?.items]
   );
   const rankedEntries = useMemo(() => {

--- a/apps/web/components/lol-profile/MatchHistorySection.tsx
+++ b/apps/web/components/lol-profile/MatchHistorySection.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/staticData";
 
 import {
+  MATCH_PLACEHOLDER_ROWS,
   matchKdaRatio,
   normalizeInitialSort,
   sortRuneSelections,
@@ -439,9 +440,18 @@ export function MatchHistorySection({
         </div>
 
         {historyError ? <p className="mt-4 text-sm text-danger">{historyError}</p> : null}
-        {historyBusy && !history ? <Skeleton className="mt-4 h-16 w-full" /> : null}
 
         <div className="mt-5 flex flex-col gap-4">
+          {/* First load only (`!history`). Reserves the same rows as the dynamic-import
+              fallback and the route skeleton, so each handoff between them is a repaint
+              rather than a reflow. A refetch (paging, filters) keeps the previous page
+              on screen and needs no placeholder. */}
+          {historyBusy && !history
+            ? Array.from({ length: MATCH_PLACEHOLDER_ROWS }).map((_, i) => (
+                <Skeleton key={i} className="h-28 w-full rounded-panel" />
+              ))
+            : null}
+
           {visibleMatches.map((match) => (
             <MatchHistoryCard
               key={match.matchId}

--- a/apps/web/components/lol-profile/ProfileHeroCard.tsx
+++ b/apps/web/components/lol-profile/ProfileHeroCard.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 
 import { FavoriteButton } from "@/components/FavoriteButton";
 import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
 import { Toolbar } from "@/components/ui/Toolbar";
 import { formatPercent } from "@/lib/format";
 import { profileIconUrl } from "@/lib/staticData";
@@ -9,6 +10,7 @@ import { profileIconUrl } from "@/lib/staticData";
 import {
   friendlyAcceptedMessage,
   rankColorClass,
+  RECENT_FORM_SLOTS,
   type AcceptedResponse,
   type ApiErrorResponse,
   type ChampionStatic,
@@ -106,34 +108,55 @@ export function ProfileHeroCard({
           </>
         }
         filters={
-          recentForm.length > 0 ? (
+          // Gated on the profile, not on recentForm: form is derived from match history,
+          // which is fetched on the client and is empty on the first paint. Keying the row
+          // off the data made the Toolbar drop it (border, padding, and the parent's gap)
+          // and re-insert it on arrival — a ~45px insertion above every other element on
+          // the page, which is what drove this route's CLS to p75 0.77. The row now exists
+          // for the whole lifetime of a profile and only its contents swap.
+          profile ? (
             <>
               <span className="type-overline text-muted">Recent form</span>
               {/* Wins render solid, losses render outlined: a fill/shape cue that
                   survives red/green color blindness, with color as a redundant
                   signal. The whole strip is one labelled image for screen readers;
                   the individual pips are decorative (aria-hidden). */}
-              <div
-                className="flex flex-wrap items-center gap-1"
-                role="img"
-                aria-label={`Recent form, latest first: ${recentForm
-                  .map((win) => (win ? "Win" : "Loss"))
-                  .join(", ")}`}
-              >
-                {recentForm.map((win, idx) => (
-                  <span
-                    key={`${win ? "w" : "l"}-${idx}`}
-                    aria-hidden="true"
-                    className={`h-2.5 w-7 rounded-full ${
-                      win ? "bg-win/80" : "border border-loss/70 bg-loss/25"
-                    }`}
-                    title={win ? "Win" : "Loss"}
-                  />
-                ))}
-              </div>
+              {recentForm.length > 0 ? (
+                <div
+                  className="flex flex-wrap items-center gap-1"
+                  role="img"
+                  aria-label={`Recent form, latest first: ${recentForm
+                    .map((win) => (win ? "Win" : "Loss"))
+                    .join(", ")}`}
+                >
+                  {recentForm.map((win, idx) => (
+                    <span
+                      key={`${win ? "w" : "l"}-${idx}`}
+                      aria-hidden="true"
+                      className={`h-2.5 w-7 rounded-full ${
+                        win ? "bg-win/80" : "border border-loss/70 bg-loss/25"
+                      }`}
+                      title={win ? "Win" : "Loss"}
+                    />
+                  ))}
+                </div>
+              ) : (
+                // Same pip geometry as the loaded strip, so the swap is a repaint and not
+                // a reflow — and the same primitive the route skeleton uses, so the
+                // handoff from loading.tsx into this component is invisible. Decorative
+                // while empty: there is no form to announce yet.
+                <div className="flex flex-wrap items-center gap-1" aria-hidden="true">
+                  {Array.from({ length: RECENT_FORM_SLOTS }).map((_, idx) => (
+                    <Skeleton key={idx} className="h-2.5 w-7 rounded-full" />
+                  ))}
+                </div>
+              )}
+              {/* Same element and typography in both states so the line box — which sets
+                  the row's height — is identical. Right-aligned, so its width can vary. */}
               <span className="type-caption ml-auto text-muted">
-                Last {recentForm.length}
-                {recentWr ? ` · ${recentWr} WR` : ""} · {dataAge}
+                {recentForm.length > 0
+                  ? `Last ${recentForm.length}${recentWr ? ` · ${recentWr} WR` : ""} · ${dataAge}`
+                  : dataAge}
               </span>
             </>
           ) : undefined

--- a/apps/web/components/lol-profile/shared.ts
+++ b/apps/web/components/lol-profile/shared.ts
@@ -282,6 +282,24 @@ export type QueueOption = {
 
 export type MatchSortOption = "DATE_DESC" | "KDA_DESC" | "DMG_DESC";
 
+/**
+ * How many recent-form pips the profile hero shows, and therefore how many
+ * placeholders it reserves while match history is still in flight.
+ *
+ * Shared so the data window and the reserved geometry cannot drift apart: the hero
+ * row sits above every other element on the page, so a mismatch between them
+ * reflows the entire document.
+ */
+export const RECENT_FORM_SLOTS = 10;
+
+/**
+ * Match rows reserved by every pre-data state of the match list — the route-level
+ * skeleton, the dynamic-import fallback, and the section's own first-load state.
+ * All three render in sequence on a cold load, so they must reserve the same height
+ * or each handoff is its own layout shift.
+ */
+export const MATCH_PLACEHOLDER_ROWS = 4;
+
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
 }


### PR DESCRIPTION
Real-user CLS p75 on /lol/summoners/[region]/[riotId] is 0.773 against a "good"
threshold of 0.1, and 492 of 2353 samples (21%) land in the 0.5-1.0 bucket. Every
other route on the site measures 0.007-0.021, so this one page is what trips the
trn-web-vital-p75 alert: it is also the busiest route, so its p75 sets the global one.

The hero's recent-form row was keyed off the data rather than the profile:

    filters={recentForm.length > 0 ? (...) : undefined}

recentForm derives from match history, which 970375c moved to a client fetch to keep
the first streamed response off two extra backend reads. That tradeoff is worth
keeping, but it means the row is empty on every first paint — so Toolbar rendered no
filters row at all, then inserted one when the fetch landed. The row carries a
border-top, pt-3, and the parent's gap-3, so roughly 45px appears above every other
element on the page and pushes the entire document down. Nothing else on the page can
shift as much, because nothing else sits that high.

The row is now gated on the profile and lives for as long as the profile does; only
its contents swap. While history is in flight it renders RECENT_FORM_SLOTS placeholder
pips using the same Skeleton primitive and classes the route skeleton already uses, so
the swap is a repaint rather than a reflow. The trailing caption keeps its element and
typography in both states — it sets the row's line box — and only its text changes.

Separately, the three states that precede data reserved three different heights:
448px in the route skeleton, 364px in the dynamic-import fallback, and 64px in the
section's own first-load branch. All three render in sequence on a cold load, so each
handoff was its own shift before a single match had arrived. They now reserve the same
geometry, driven by MATCH_PLACEHOLDER_ROWS.

Both counts live in shared.ts and are consumed by the data window as well as the
placeholders (recentForm's slice reads RECENT_FORM_SLOTS), so the reserved geometry
cannot silently drift away from what eventually renders — which is how this regressed.

Not addressed: PerformanceCard still returns null when it has neither roles, averages,
nor form. overviewStats is server-provided so it renders from the first paint in the
common case, but a profile lacking all three would still see it appear late. Changing
that is a behavioural change to its empty state rather than a spacing fix.

Verified: tsc --noEmit clean, eslint --max-warnings=0 clean, and the full web suite
passes 285 tests across 55 files, including MatchHistorySection's loading/empty-history
/empty-filter case, which covers the branch this rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
