### PR TITLE
Read the cohort's timeline once instead of once per champion

### DIFF
--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -479,6 +479,19 @@ def _sweep_worker_setup(
         else psycopg.connect(settings.database_url, row_factory=dict_row)
     )
     _WORKER["bundle"] = bundle if bundle is not None else joblib.load(bundle_path)
+    # Drawn once per process rather than once per champion -- see compact_timeline_events for why this
+    # is the sweep's dominant cost. In the pool each worker draws its own copy, which is one read per
+    # worker against 173 before; sharing one frame across spawned interpreters would mean pickling it
+    # through initargs, and the pool is opt-in and already the slower path on this hardware.
+    _WORKER["timeline_events"] = compact_timeline_events(
+        load_timeline_state_events(
+            _WORKER["connection"], cohort["included_patches"], cohort["cutoff"]
+        )
+    )
+    LOG.info(
+        "Preloaded %d cohort timeline events; the sweep slices these instead of re-reading per champion.",
+        len(_WORKER["timeline_events"]),
+    )
 
 
 def sweep_champion(champion_id: int) -> dict:
@@ -499,6 +512,7 @@ def sweep_champion(champion_id: int) -> dict:
             cohort["current_patch"],
             cohort["changed_items"],
             champion_id=champion_id,
+            timeline_events=_WORKER["timeline_events"],
         ),
         cohort["current_patch"],
         cohort["included_patches"],
@@ -780,12 +794,17 @@ def load_decision_frame(
     *,
     champion_id: int | None = None,
     match_sample_range: tuple | None = None,
+    timeline_events: pd.DataFrame | None = None,
 ) -> pd.DataFrame:
     """Load one scope of the frozen cohort and turn it into unweighted decision rows.
 
     The scope is either a champion (the estimate sweep) or a deterministic sample of matches (the
     structural fit). Item events are participant-scoped, while team composition and kill state are
     match-scoped, because a kill diff is a fact about the match rather than about one participant.
+
+    `timeline_events` is the sweep's preloaded cohort-wide event frame. Supplying it replaces this
+    scope's timeline query with a pandas slice; omitting it queries per scope as before, which is what
+    the structural fit does since its match sample is drawn once rather than 173 times.
     """
     scope = {"champion_id": champion_id, "match_sample_range": match_sample_range}
     item_events = load_item_events(
@@ -797,7 +816,11 @@ def load_decision_frame(
     del item_events
     item_decisions = enrich_with_predecision_event_state(
         item_decisions,
-        load_timeline_state_events(connection, included_patches, cutoff, **scope),
+        (
+            champion_timeline_events(timeline_events, item_decisions["match_id"])
+            if timeline_events is not None
+            else load_timeline_state_events(connection, included_patches, cutoff, **scope)
+        ),
         load_participant_teams(connection, included_patches, cutoff, **scope),
     )
     item_decisions = exclude_incompatible_prior_item_rows(
@@ -1591,6 +1614,53 @@ def load_timeline_state_events(
             "match_sample_until": match_sample_range[1] if match_sample_range else None,
         },
     )
+
+
+# The sweep's dominant cost, and the reason a 173-champion run projected to 17 days on prod rather
+# than the ~7 hours its per-champion measurement implied.
+#
+# `load_timeline_state_events` is match-scoped: it returns every kill event in every match the champion
+# played, because a kill diff is a fact about the match. A match has ten participants, so each match's
+# events were re-read once per champion in it -- ~56M event rows read where the cohort holds 5.6M, each
+# read a fresh index scan plus jsonb extraction against an HDD-backed database. Nothing about the events
+# depends on the champion, so they are drawn once per process here and sliced in pandas instead.
+#
+# Slicing is sound because a superset is inert, not because the slice is exact:
+# `enrich_with_predecision_event_state` derives `has_event_state` from the decisions' own match ids, and
+# `merge_cumulative_state` merges asof `by=["match_id", "team_id"]`, so an event belonging to a match the
+# champion never played cannot reach a published column. The slice exists to stop
+# `attribute_events_to_teams` re-scoring all 5.6M rows once per champion, which would simply move the
+# amplification from Postgres into pandas.
+def compact_timeline_events(events: pd.DataFrame) -> pd.DataFrame:
+    """Hold the cohort's events at a fraction of the memory the loader's dtypes would cost.
+
+    Only `match_id` and `event_type` repeat enough to be worth encoding, and `match_id` dominates:
+    `normalise_uuid_columns` gives every one of the 5.6M rows its own 36-character `str`, roughly 475MB
+    as objects against ~30MB as categories over ~110k distinct ids. That difference is what decides
+    whether the cohort-wide frame fits beside the champion's own working set.
+    """
+    if events.empty:
+        return events
+    compacted = events.copy()
+    for column in ("match_id", "event_type"):
+        compacted[column] = compacted[column].astype("category")
+    return compacted
+
+
+def champion_timeline_events(events: pd.DataFrame, match_ids) -> pd.DataFrame:
+    """One champion's slice of the preloaded cohort events, in the dtypes the query would have returned.
+
+    Casting the categories back is not cosmetic. `attribute_events_to_teams` compares `event_type` to
+    string literals and merges `match_id` against frames carrying plain strings, and a categorical key
+    still carrying every unobserved category does not merge like the object column it replaced. Handing
+    back the loader's own dtypes keeps this a caching change and nothing else.
+    """
+    if events.empty:
+        return events
+    sliced = events[events["match_id"].isin(set(match_ids))].copy()
+    for column in ("match_id", "event_type"):
+        sliced[column] = sliced[column].astype(object)
+    return sliced
 
 
 def load_participant_teams(

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -41,7 +41,9 @@ from build_lab_modeler.pipeline import (
     build_path_estimates,
     build_rune_decisions,
     build_spell_decisions,
+    champion_timeline_events,
     clustered_standard_error,
+    compact_timeline_events,
     deidentified_export,
     design_matrix,
     direction_is_stable,
@@ -1875,6 +1877,117 @@ def test_the_estimate_sweep_scopes_every_load_to_one_champion(monkeypatch, tmp_p
     assert len(set(drawn)) == len(drawn), drawn
 
 
+def cohort_timeline_fixture() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Two matches' worth of events, of which one champion played only the first.
+
+    Shaped like the loader's output, including the payload scalars arriving as text.
+    """
+    events = pd.DataFrame(
+        [
+            {"match_id": "mine", "event_index": 0, "timestamp_ms": 500, "event_type": "CHAMPION_KILL", "killer_participant_id": "1", "killer_team_id": None, "owner_team_id": None},
+            {"match_id": "mine", "event_index": 1, "timestamp_ms": 900, "event_type": "BUILDING_KILL", "killer_participant_id": "0", "killer_team_id": None, "owner_team_id": "200"},
+            {"match_id": "theirs", "event_index": 0, "timestamp_ms": 400, "event_type": "CHAMPION_KILL", "killer_participant_id": "6", "killer_team_id": None, "owner_team_id": None},
+            {"match_id": "theirs", "event_index": 1, "timestamp_ms": 700, "event_type": "ELITE_MONSTER_KILL", "killer_participant_id": "6", "killer_team_id": None, "owner_team_id": None},
+        ]
+    )
+    decisions = pd.DataFrame(
+        [{"match_id": "mine", "participant_id": 1, "timestamp_ms": 2000}]
+    )
+    teams = pd.DataFrame(
+        [
+            {"match_id": "mine", "participant_id": 1, "team_id": 100},
+            {"match_id": "mine", "participant_id": 6, "team_id": 200},
+        ]
+    )
+    return events, decisions, teams
+
+
+def test_slicing_the_preloaded_events_matches_what_a_champion_scoped_query_returned():
+    # The whole safety argument for reading the cohort's timeline once instead of once per champion.
+    # If these ever diverge, the sweep is publishing different numbers than the per-champion loads did.
+    cohort_events, decisions, teams = cohort_timeline_fixture()
+    scoped = cohort_events[cohort_events["match_id"] == "mine"].reset_index(drop=True)
+
+    from_query = enrich_with_predecision_event_state(decisions, scoped, teams)
+    from_slice = enrich_with_predecision_event_state(
+        decisions,
+        champion_timeline_events(compact_timeline_events(cohort_events), decisions["match_id"]),
+        teams,
+    )
+
+    pd.testing.assert_frame_equal(from_query, from_slice)
+    # Not a vacuous comparison: the fixture has to actually exercise the diff columns.
+    assert from_query["team_kill_diff"].tolist() == [1.0]
+    assert from_query["team_tower_diff"].tolist() == [1.0]
+    assert from_query["has_event_state"].tolist() == [1.0]
+
+
+def test_an_unrelated_match_s_events_cannot_reach_a_published_column():
+    # Why the slice is an optimisation rather than a correctness requirement: `merge_asof` carries
+    # match_id in `by`, so a superset is inert. Asserting it directly means a future change to the
+    # merge keys fails here rather than silently mixing matches together.
+    cohort_events, decisions, teams = cohort_timeline_fixture()
+    scoped = cohort_events[cohort_events["match_id"] == "mine"].reset_index(drop=True)
+
+    pd.testing.assert_frame_equal(
+        enrich_with_predecision_event_state(decisions, scoped, teams),
+        enrich_with_predecision_event_state(decisions, cohort_events, teams),
+    )
+
+
+def test_a_preloaded_slice_hands_back_the_loader_s_own_dtypes():
+    # Compaction is storage-only. `attribute_events_to_teams` compares event_type to string literals
+    # and merges match_id against frames of plain strings, so a categorical leaking through would
+    # change merge behaviour rather than fail loudly.
+    cohort_events, _, _ = cohort_timeline_fixture()
+    compacted = compact_timeline_events(cohort_events)
+    assert isinstance(compacted["match_id"].dtype, pd.CategoricalDtype)
+
+    sliced = champion_timeline_events(compacted, ["mine"])
+    assert sliced["match_id"].dtype == object
+    assert sliced["event_type"].dtype == object
+    assert sliced["match_id"].tolist() == ["mine", "mine"]
+    # A category that survived the slice would otherwise reappear in groupby/merge results.
+    assert set(sliced["event_type"]) == {"CHAMPION_KILL", "BUILDING_KILL"}
+
+
+def test_an_empty_cohort_timeline_survives_compaction_and_slicing():
+    empty = pd.DataFrame(
+        columns=["match_id", "event_index", "timestamp_ms", "event_type", "killer_participant_id", "killer_team_id", "owner_team_id"]
+    )
+    assert compact_timeline_events(empty).empty
+    assert champion_timeline_events(empty, ["mine"]).empty
+
+
+def test_the_sweep_never_reads_the_timeline_once_per_champion(monkeypatch, tmp_path):
+    # The regression this guards: `load_timeline_state_events` is match-scoped, so a champion-scoped
+    # call re-read every match that champion played -- ten times over the cohort across the sweep, which
+    # is what projected a 173-champion run to 17 days on prod. One unscoped preload replaces all of them.
+    monkeypatch.setenv("BUILD_LAB_SWEEP_WORKERS", "1")
+    settings, generation = publishing_generation(monkeypatch, tmp_path)
+    champions = [22, 51, 103]
+    monkeypatch.setattr(pipeline, "load_cohort_champions", lambda *_: champions)
+    calls: list[dict] = []
+    real_loader = pipeline.load_timeline_state_events
+
+    def recording(connection, patches, cutoff, champion_id=None, match_sample_range=None):
+        calls.append({"champion_id": champion_id, "match_sample_range": match_sample_range})
+        return real_loader(connection, patches, cutoff, champion_id, match_sample_range)
+
+    monkeypatch.setattr(pipeline, "load_timeline_state_events", recording)
+    model_generation(FakeConnection(), generation, settings)
+
+    assert calls, "the sweep must still read the timeline at all"
+    # Not "once in total": the structural fit draws per match-sample range, and those are unamplified.
+    assert all(call["champion_id"] is None for call in calls), calls
+    preloads = [
+        call
+        for call in calls
+        if call["champion_id"] is None and call["match_sample_range"] is None
+    ]
+    assert len(preloads) == 1, preloads
+
+
 class DictRowCursor:
     """A cursor shaped like psycopg's, whose row factory decides the row type.
 
@@ -2623,13 +2736,27 @@ def test_the_sequential_sweep_reuses_the_connection_it_was_given(monkeypatch, tm
     # the live app, and would make the publish path untestable without a real server.
     settings = modeler_settings(monkeypatch, BUILD_LAB_ARTIFACT_DIR=str(tmp_path))
     sentinel = FakeConnection()
+    # What the preload draws is another test's business; this one is about the wiring, so it is stubbed
+    # rather than serviced by a fake cursor.
+    monkeypatch.setattr(
+        pipeline, "load_timeline_state_events", lambda *_, **__: pd.DataFrame()
+    )
+    # The cohort carries the patches and cutoff because setup also draws the sweep's one timeline
+    # preload here, on this same connection -- which is the point of reusing it.
     pipeline._sweep_worker_setup(
-        settings, {"artifact_path": str(tmp_path)}, "unused.joblib",
+        settings,
+        {
+            "artifact_path": str(tmp_path),
+            "included_patches": ["16.15"],
+            "cutoff": datetime(2026, 8, 8, 2, 15, tzinfo=timezone.utc),
+        },
+        "unused.joblib",
         connection=sentinel, bundle={"model": None},
     )
     assert pipeline._WORKER["connection"] is sentinel
     assert pipeline._WORKER["owns_connection"] is False
     assert pipeline._WORKER["bundle"] == {"model": None}
+    assert "timeline_events" in pipeline._WORKER
 
 
 def test_the_sweep_worker_count_is_configurable_and_floored(monkeypatch, tmp_path):


### PR DESCRIPTION
The first end-to-end run of the oneshot modeler on prod swept 2 of 173 champions in
4h33m and projected to roughly 17 days. It was not stuck: the container held 308% CPU
throughout and Postgres sat idle-in-transaction on ClientRead, so the work was real and
there was simply far too much of it.

#162 named the cause without fixing it:

  The sweep's remaining cost is the match-scoped timeline load being fetched once per
  champion in every match that champion appears in: ~56M event rows read where the
  cohort holds 5.6M. Hoisting it out of the loop is what makes the sweep practical.

load_timeline_state_events is match-scoped by necessity -- a kill diff is a fact about
the match, not about one participant -- so a champion-scoped call returns every kill
event in every match that champion played. Ten participants per match means the cohort's
events were read ten times over across a sweep, each read a fresh index scan plus jsonb
extraction against an HDD-backed database.

Measured on the 16.15 cohort (110,376 matches) with EXPLAIN (ANALYZE, BUFFERS): one
champion-scoped read of champion 22 is 282,571ms over 5,881 matches. Multiplied across
173 champions that is ~13.6 hours of timeline reads alone, before item events, runes,
spells or team composition -- which is the shape of the 12m-to-3h per-champion times
observed on the live run. The events do not depend on the champion, so they are now
drawn once per process and sliced in pandas.

The slice is sound because a superset is inert, not because it is exact.
enrich_with_predecision_event_state derives has_event_state from the decisions' own
match ids, and merge_cumulative_state merges asof by=["match_id", "team_id"], so an
event belonging to a match the champion never played cannot reach a published column.
The slice exists only to stop attribute_events_to_teams re-scoring all 5.6M rows once
per champion, which would move the amplification from Postgres into pandas rather than
remove it. A test asserts the inertness directly, so a future change to the merge keys
fails there rather than silently mixing matches.

Held as categories for match_id and event_type: normalise_uuid_columns gives each of the
5.6M rows its own 36-character str, ~475MB as objects against ~30MB encoded, and that
difference decides whether the cohort frame fits beside the champion's working set. The
slice casts back to the loader's own dtypes, because attribute_events_to_teams compares
event_type to string literals and merges match_id against frames of plain strings.

Scope: the structural fit still queries per match-sample range, since those are drawn
once rather than 173 times, and the `champion` CLI subcommand still queries per champion,
which is cheaper for the one-to-three champions it is used with.

Not done here: the preload keeps the loader's ORDER BY, which sorts 5.6M rows for a
consumer that re-sorts them anyway. Dropping it is very likely worth another chunk of the
one-time cost, but it changes shared loader SQL and wants its own measurement.

Tests: the sliced enrichment equals what the champion-scoped query produced; an unrelated
match's events cannot change a published column; the slice hands back the loader's dtypes;
an empty cohort survives both; and no call to load_timeline_state_events during a
generation carries a champion_id, with exactly one unscoped preload. 130 pass in the
modeler image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
