### PR TITLE
Reduce the cohort's timeline as it streams instead of buffering it

### DIFF
--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -479,18 +479,18 @@ def _sweep_worker_setup(
         else psycopg.connect(settings.database_url, row_factory=dict_row)
     )
     _WORKER["bundle"] = bundle if bundle is not None else joblib.load(bundle_path)
-    # Drawn once per process rather than once per champion -- see compact_timeline_events for why this
-    # is the sweep's dominant cost. In the pool each worker draws its own copy, which is one read per
-    # worker against 173 before; sharing one frame across spawned interpreters would mean pickling it
-    # through initargs, and the pool is opt-in and already the slower path on this hardware.
-    _WORKER["timeline_events"] = compact_timeline_events(
-        load_timeline_state_events(
+    # Drawn once per process rather than once per champion -- see stream_cohort_event_state for why the
+    # sweep's dominant cost is this read, and why it is reduced rather than held. In the pool each
+    # worker streams its own copy, which is one read per worker against 173 before; sharing one frame
+    # across spawned interpreters would mean pickling it through initargs, and the pool is opt-in and
+    # already the slower path on this hardware.
+    _WORKER["event_state"] = stream_cohort_event_state(
+        _WORKER["connection"],
+        cohort["included_patches"],
+        cohort["cutoff"],
+        load_participant_teams(
             _WORKER["connection"], cohort["included_patches"], cohort["cutoff"]
-        )
-    )
-    LOG.info(
-        "Preloaded %d cohort timeline events; the sweep slices these instead of re-reading per champion.",
-        len(_WORKER["timeline_events"]),
+        ),
     )
 
 
@@ -512,7 +512,7 @@ def sweep_champion(champion_id: int) -> dict:
             cohort["current_patch"],
             cohort["changed_items"],
             champion_id=champion_id,
-            timeline_events=_WORKER["timeline_events"],
+            event_state=_WORKER["event_state"],
         ),
         cohort["current_patch"],
         cohort["included_patches"],
@@ -794,7 +794,7 @@ def load_decision_frame(
     *,
     champion_id: int | None = None,
     match_sample_range: tuple | None = None,
-    timeline_events: pd.DataFrame | None = None,
+    event_state: "CohortEventState | None" = None,
 ) -> pd.DataFrame:
     """Load one scope of the frozen cohort and turn it into unweighted decision rows.
 
@@ -802,9 +802,10 @@ def load_decision_frame(
     structural fit). Item events are participant-scoped, while team composition and kill state are
     match-scoped, because a kill diff is a fact about the match rather than about one participant.
 
-    `timeline_events` is the sweep's preloaded cohort-wide event frame. Supplying it replaces this
-    scope's timeline query with a pandas slice; omitting it queries per scope as before, which is what
-    the structural fit does since its match sample is drawn once rather than 173 times.
+    `event_state` is the sweep's cohort-wide event state, streamed and reduced once per process.
+    Supplying it replaces this scope's timeline query with a join against counters already computed;
+    omitting it queries and reduces per scope, which is what the structural fit does since its match
+    sample is drawn once rather than 173 times.
     """
     scope = {"champion_id": champion_id, "match_sample_range": match_sample_range}
     item_events = load_item_events(
@@ -814,14 +815,15 @@ def load_decision_frame(
         return pd.DataFrame()
     item_decisions = build_item_decisions(item_events)
     del item_events
-    item_decisions = enrich_with_predecision_event_state(
-        item_decisions,
-        (
-            champion_timeline_events(timeline_events, item_decisions["match_id"])
-            if timeline_events is not None
-            else load_timeline_state_events(connection, included_patches, cutoff, **scope)
-        ),
-        load_participant_teams(connection, included_patches, cutoff, **scope),
+    teams = load_participant_teams(connection, included_patches, cutoff, **scope)
+    item_decisions = (
+        apply_event_state(item_decisions, event_state, teams)
+        if event_state is not None
+        else enrich_with_predecision_event_state(
+            item_decisions,
+            load_timeline_state_events(connection, included_patches, cutoff, **scope),
+            teams,
+        )
     )
     item_decisions = exclude_incompatible_prior_item_rows(
         item_decisions,
@@ -1553,15 +1555,18 @@ def load_champion_archetypes(connection: psycopg.Connection, patch: str) -> dict
     return archetypes
 
 
-def load_timeline_state_events(
-    connection,
+def timeline_state_events_query(
     patches: list[str],
     cutoff,
     champion_id: int | None = None,
     match_sample_range: tuple | None = None,
-) -> pd.DataFrame:
-    return read_sql_frame(
-        connection,
+) -> tuple[str, dict]:
+    """The timeline-event statement and its parameters.
+
+    Shared verbatim by the buffered loader below and the streaming reducer, so the two cannot drift
+    into reading different rows -- which is the only way their results could disagree.
+    """
+    sql = (
         champion_match_cte(champion_id, leading=False)
         + """
         SELECT
@@ -1604,63 +1609,194 @@ def load_timeline_state_events(
         + scope_predicates(champion_id, match_sample_range, match_scoped=True)
         + """
         ORDER BY payload."MatchId", payload."TimestampMs", payload."EventIndex"
-        """,
-        params={
-            "patches": patches,
-            "cutoff": cutoff,
-            "schema_version": TIMELINE_SCHEMA_VERSION,
-            "champion_id": champion_id,
-            "match_sample_from": match_sample_range[0] if match_sample_range else None,
-            "match_sample_until": match_sample_range[1] if match_sample_range else None,
-        },
+        """
+    )
+    return sql, {
+        "patches": patches,
+        "cutoff": cutoff,
+        "schema_version": TIMELINE_SCHEMA_VERSION,
+        "champion_id": champion_id,
+        "match_sample_from": match_sample_range[0] if match_sample_range else None,
+        "match_sample_until": match_sample_range[1] if match_sample_range else None,
+    }
+
+
+def load_timeline_state_events(
+    connection,
+    patches: list[str],
+    cutoff,
+    champion_id: int | None = None,
+    match_sample_range: tuple | None = None,
+) -> pd.DataFrame:
+    """Buffered load of one scope's events. Used by the structural fit, whose scope is a match sample.
+
+    The champion sweep must not use this: see `stream_cohort_event_state` for why a cohort-wide scope
+    cannot be materialised.
+    """
+    sql, params = timeline_state_events_query(patches, cutoff, champion_id, match_sample_range)
+    return read_sql_frame(connection, sql, params)
+
+
+# Reading the cohort's timeline once instead of once per champion is right: `load_timeline_state_events`
+# is match-scoped, because a kill diff is a fact about the match, so ten participants per match meant the
+# sweep re-read the same events ten times over -- ~13.6 hours of index scans and jsonb extraction on
+# prod's HDD-backed database, which is what projected a 173-champion run to 17 days.
+#
+# Materialising that single read is NOT right, and the first attempt at this did exactly that. The
+# compose unit pins the contract it broke:
+#
+#     mem_limit 6g -- "peak is set by the largest single champion's rows plus one training slice, not
+#     by the size of the cohort, so this no longer has to be raised as the corpus grows"
+#
+# Measured on the live 16.15 cohort: the buffered read costs ~340 bytes per row in accumulated tuples
+# BEFORE any DataFrame exists, so its 7.14M events reach ~2.7GB, `DataFrame.from_records` then builds
+# object arrays beside them, and `normalise_uuid_columns` mints 7.14M fresh strings while the UUIDs are
+# still referenced. Runs died on SIGKILL 23 minutes in, before the preload logged a single line.
+#
+# The resolution is that the sweep does not actually need the events. It needs the running per-(match,
+# team) kill/tower/objective counts that `merge_cumulative_state` reads as-of each purchase, and those
+# are derivable chunk by chunk and storable in a numeric width -- int32 match codes, teams and counters
+# -- of ~32 bytes a row against the ~340 the raw form costs. So rows are reduced as they arrive and the
+# raw form is never accumulated: one database read, and a resident footprint that stays proportional to
+# the cohort's *event state* rather than its event text.
+COHORT_EVENT_CHUNK_ROWS = 250_000
+
+EVENT_STATE_COLUMNS = ["match_code", "team_id", "timestamp_ms", "kills", "towers", "objectives"]
+
+
+@dataclass
+class CohortEventState:
+    """Cohort-wide pre-decision event state, reduced to a width the per-champion contract can hold.
+
+    `cumulative` carries one row per attributed event with the running counts for its (match, team),
+    keyed by an int32 `match_code` rather than the match id -- 4 bytes against the ~85 a distinct
+    36-character `str` costs, which is the whole reason this fits.
+
+    `covered_matches` is tracked separately on purpose. `has_event_state` must distinguish a match that
+    produced no payload rows at all from one whose payload rows produced no attributable team, and the
+    cumulative frame alone cannot tell those apart -- both are simply absent from it.
+    """
+
+    cumulative: pd.DataFrame
+    match_codes: dict
+    covered_matches: frozenset
+
+
+def empty_event_state_rows() -> pd.DataFrame:
+    """The reduced shape, as `CohortEventState.cumulative` carries it."""
+    return pd.DataFrame({column: pd.Series(dtype="int64") for column in EVENT_STATE_COLUMNS})
+
+
+def empty_scored_rows() -> pd.DataFrame:
+    """A scored chunk that credited nothing.
+
+    Carries `event_index` even though the final state does not: chunks are concatenated and sorted on
+    it before the cumulative sums run, so an empty chunk missing the column raises rather than
+    contributing nothing -- which is what a match whose events attribute to no team produces.
+    """
+    return pd.DataFrame(
+        {column: pd.Series(dtype="int64") for column in [*EVENT_STATE_COLUMNS, "event_index"]}
     )
 
 
-# The sweep's dominant cost, and the reason a 173-champion run projected to 17 days on prod rather
-# than the ~7 hours its per-champion measurement implied.
-#
-# `load_timeline_state_events` is match-scoped: it returns every kill event in every match the champion
-# played, because a kill diff is a fact about the match. A match has ten participants, so each match's
-# events were re-read once per champion in it -- ~56M event rows read where the cohort holds 5.6M, each
-# read a fresh index scan plus jsonb extraction against an HDD-backed database. Nothing about the events
-# depends on the champion, so they are drawn once per process here and sliced in pandas instead.
-#
-# Slicing is sound because a superset is inert, not because the slice is exact:
-# `enrich_with_predecision_event_state` derives `has_event_state` from the decisions' own match ids, and
-# `merge_cumulative_state` merges asof `by=["match_id", "team_id"]`, so an event belonging to a match the
-# champion never played cannot reach a published column. The slice exists to stop
-# `attribute_events_to_teams` re-scoring all 5.6M rows once per champion, which would simply move the
-# amplification from Postgres into pandas.
-def compact_timeline_events(events: pd.DataFrame) -> pd.DataFrame:
-    """Hold the cohort's events at a fraction of the memory the loader's dtypes would cost.
+def score_event_chunk(chunk: pd.DataFrame, teams: pd.DataFrame, codes: dict) -> pd.DataFrame:
+    """Reduce one chunk of raw events to narrow per-event team credits.
 
-    Only `match_id` and `event_type` repeat enough to be worth encoding, and `match_id` dominates:
-    `normalise_uuid_columns` gives every one of the 5.6M rows its own 36-character `str`, roughly 475MB
-    as objects against ~30MB as categories over ~110k distinct ids. That difference is what decides
-    whether the cohort-wide frame fits beside the champion's own working set.
+    Attribution stays in `attribute_events_to_teams` rather than being reimplemented in SQL: the
+    killer/declared-team/conceded-building precedence is subtle, it is covered by tests, and a second
+    implementation could only ever diverge from it.
     """
-    if events.empty:
-        return events
-    compacted = events.copy()
-    for column in ("match_id", "event_type"):
-        compacted[column] = compacted[column].astype("category")
-    return compacted
+    scored = attribute_events_to_teams(chunk, teams)
+    if scored.empty:
+        return empty_scored_rows()
+    for match_id in scored["match_id"].unique().tolist():
+        if match_id not in codes:
+            codes[match_id] = len(codes)
+    return pd.DataFrame(
+        {
+            "match_code": scored["match_id"].map(codes).astype("int32"),
+            "team_id": scored["team_id"].astype("int32"),
+            "timestamp_ms": scored["timestamp_ms"].astype("int64"),
+            "event_index": scored["event_index"].astype("int32"),
+            "kills": scored["kills"].astype("int32"),
+            "towers": scored["towers"].astype("int32"),
+            "objectives": scored["objectives"].astype("int32"),
+        }
+    )
 
 
-def champion_timeline_events(events: pd.DataFrame, match_ids) -> pd.DataFrame:
-    """One champion's slice of the preloaded cohort events, in the dtypes the query would have returned.
+def accumulate_event_state(parts: list, codes: dict, covered: frozenset) -> CohortEventState:
+    """Run the cumulative sums once over every scored chunk.
 
-    Casting the categories back is not cosmetic. `attribute_events_to_teams` compares `event_type` to
-    string literals and merges `match_id` against frames carrying plain strings, and a categorical key
-    still carrying every unobserved category does not merge like the object column it replaced. Handing
-    back the loader's own dtypes keeps this a caching change and nothing else.
+    Deliberately deferred to the end rather than done per chunk: the sort is global and a chunk
+    boundary can fall inside a match, so summing per chunk would restart a match's counters partway
+    through. Sorting the assembled narrow frame reproduces the buffered path's ordering exactly.
     """
+    if not parts:
+        return CohortEventState(empty_event_state_rows(), dict(codes), covered)
+    cumulative = pd.concat(parts, ignore_index=True)
+    parts.clear()
+    cumulative = cumulative.sort_values(["timestamp_ms", "event_index"], kind="stable")
+    for column in ("kills", "towers", "objectives"):
+        cumulative[column] = cumulative.groupby(["match_code", "team_id"], sort=False)[column].cumsum()
+    return CohortEventState(
+        cumulative[EVENT_STATE_COLUMNS].sort_values("timestamp_ms", kind="stable"),
+        dict(codes),
+        covered,
+    )
+
+
+def event_state_from_events(events: pd.DataFrame, teams: pd.DataFrame) -> CohortEventState:
+    """The buffered equivalent of the stream, for scopes small enough to hold (the structural fit)."""
     if events.empty:
-        return events
-    sliced = events[events["match_id"].isin(set(match_ids))].copy()
-    for column in ("match_id", "event_type"):
-        sliced[column] = sliced[column].astype(object)
-    return sliced
+        return CohortEventState(empty_event_state_rows(), {}, frozenset())
+    codes: dict = {}
+    return accumulate_event_state(
+        [score_event_chunk(events, teams, codes)], codes, frozenset(events["match_id"])
+    )
+
+
+def stream_cohort_event_state(
+    connection,
+    patches: list[str],
+    cutoff,
+    teams: pd.DataFrame,
+    *,
+    chunk_rows: int = COHORT_EVENT_CHUNK_ROWS,
+) -> CohortEventState:
+    """Draw the cohort's events once and reduce them as they arrive, never holding the raw set.
+
+    A server-side cursor is the point: `read_sql_frame` calls `fetchall`, which is precisely the
+    behaviour that cannot fit. The statement is the same one `load_timeline_state_events` issues, taken
+    from the shared builder so the two cannot read different rows.
+    """
+    sql, params = timeline_state_events_query(patches, cutoff)
+    codes: dict = {}
+    covered: set = set()
+    parts: list[pd.DataFrame] = []
+    rows = 0
+    with connection.cursor(name="cohort_event_state", row_factory=tuple_row) as cursor:
+        cursor.execute(sql, params)
+        columns = [column.name for column in cursor.description or []]
+        while True:
+            batch = cursor.fetchmany(chunk_rows)
+            if not batch:
+                break
+            rows += len(batch)
+            chunk = normalise_uuid_columns(pd.DataFrame.from_records(batch, columns=columns))
+            del batch
+            covered.update(chunk["match_id"].unique().tolist())
+            parts.append(score_event_chunk(chunk, teams, codes))
+            del chunk
+    state = accumulate_event_state(parts, codes, frozenset(covered))
+    LOG.info(
+        "Cohort event state: %d events over %d matches reduced to %d rows (%.0f MB resident).",
+        rows,
+        len(covered),
+        len(state.cumulative),
+        state.cumulative.memory_usage(deep=True).sum() / 1e6,
+    )
+    return state
 
 
 def load_participant_teams(
@@ -1713,31 +1849,39 @@ def enrich_with_predecision_event_state(
     events: pd.DataFrame,
     participant_teams: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Attach only cumulative facts whose event timestamp precedes the purchase."""
+    """Attach only cumulative facts whose event timestamp precedes the purchase.
+
+    The buffered entry point: reduces `events` and applies the result in one step. The champion sweep
+    calls `apply_event_state` directly instead, against state streamed once for the whole cohort.
+    """
+    if decisions.empty or events.empty or participant_teams.empty:
+        return apply_event_state(
+            decisions, CohortEventState(empty_event_state_rows(), {}, frozenset()), participant_teams
+        )
+    teams = participant_teams.astype({"participant_id": int, "team_id": int})
+    return apply_event_state(decisions, event_state_from_events(events, teams), teams)
+
+
+def apply_event_state(
+    decisions: pd.DataFrame,
+    state: CohortEventState,
+    participant_teams: pd.DataFrame,
+) -> pd.DataFrame:
+    """Join one scope's decisions to already-reduced cohort event state."""
     enriched = decisions.copy()
     for column in ("team_kill_diff", "team_tower_diff", "team_objective_diff"):
         enriched[column] = 0.0
     enriched["has_event_state"] = 0.0
-    if enriched.empty or events.empty or participant_teams.empty:
+    if enriched.empty or participant_teams.empty or not state.covered_matches:
         return enriched
     # Coverage is per match: a match ingested while Build Lab was off carries no payload rows, so its
-    # zeroed diffs are missing data rather than an even game.
-    enriched["has_event_state"] = (
-        enriched["match_id"].isin(set(events["match_id"])).astype(float)
-    )
-
-    teams = participant_teams.astype({"participant_id": int, "team_id": int})
-    scored = attribute_events_to_teams(events, teams)
-    if scored.empty:
+    # zeroed diffs are missing data rather than an even game. Tracked on the state rather than derived
+    # from `cumulative`, which cannot distinguish "no payload rows" from "no attributable team".
+    enriched["has_event_state"] = enriched["match_id"].isin(state.covered_matches).astype(float)
+    if state.cumulative.empty:
         return enriched
 
-    cumulative = scored.sort_values(["timestamp_ms", "event_index"], kind="stable")
-    for column in ("kills", "towers", "objectives"):
-        cumulative[column] = cumulative.groupby(["match_id", "team_id"], sort=False)[column].cumsum()
-    cumulative = cumulative[
-        ["match_id", "team_id", "timestamp_ms", "kills", "towers", "objectives"]
-    ].sort_values("timestamp_ms", kind="stable")
-
+    teams = participant_teams.astype({"participant_id": int, "team_id": int})
     positioned = (
         enriched.reset_index(names="_row")[["_row", "match_id", "participant_id", "timestamp_ms"]]
         .astype({"participant_id": int})
@@ -1746,12 +1890,23 @@ def enrich_with_predecision_event_state(
     )
     if positioned.empty:
         return enriched
-    positioned["team_id"] = positioned["team_id"].astype(int)
-    positioned["opponent_team_id"] = np.where(positioned["team_id"] == 100, 200, 100)
+    # Onto the state's own key space. A decision whose match contributed no attributed event has no
+    # code, and drops out here rather than merging against an unrelated match's counters.
+    positioned["match_code"] = positioned["match_id"].map(state.match_codes)
+    positioned = positioned.dropna(subset=["match_code"])
+    if positioned.empty:
+        return enriched
+    positioned["match_code"] = positioned["match_code"].astype("int32")
+    positioned["team_id"] = positioned["team_id"].astype("int32")
+    positioned["opponent_team_id"] = np.where(
+        positioned["team_id"] == 100, 200, 100
+    ).astype("int32")
+    # merge_asof compares the `on` column directly, so both sides must carry the same width.
+    positioned["timestamp_ms"] = positioned["timestamp_ms"].astype("int64")
     positioned = positioned.sort_values("timestamp_ms", kind="stable")
 
-    own = merge_cumulative_state(positioned, cumulative, "team_id")
-    opponent = merge_cumulative_state(positioned, cumulative, "opponent_team_id")
+    own = merge_cumulative_state(positioned, state.cumulative, "team_id")
+    opponent = merge_cumulative_state(positioned, state.cumulative, "opponent_team_id")
     rows = positioned["_row"].to_numpy()
     enriched.loc[rows, "team_kill_diff"] = own["kills"].to_numpy() - opponent["kills"].to_numpy()
     enriched.loc[rows, "team_tower_diff"] = own["towers"].to_numpy() - opponent["towers"].to_numpy()
@@ -1805,14 +1960,16 @@ def merge_cumulative_state(
     cumulative: pd.DataFrame,
     team_column: str,
 ) -> pd.DataFrame:
-    left = positioned[["match_id", team_column, "timestamp_ms"]].rename(
+    left = positioned[["match_code", team_column, "timestamp_ms"]].rename(
         columns={team_column: "team_id"}
     )
+    # `by` carries the match, so counters from a match the decision does not belong to can never be
+    # picked up -- which is what makes cohort-wide state safe to share across the whole sweep.
     merged = pd.merge_asof(
         left,
         cumulative,
         on="timestamp_ms",
-        by=["match_id", "team_id"],
+        by=["match_code", "team_id"],
         allow_exact_matches=False,
     )
     return merged[["kills", "towers", "objectives"]].fillna(0.0)

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -41,9 +41,10 @@ from build_lab_modeler.pipeline import (
     build_path_estimates,
     build_rune_decisions,
     build_spell_decisions,
-    champion_timeline_events,
+    apply_event_state,
+    event_state_from_events,
+    stream_cohort_event_state,
     clustered_standard_error,
-    compact_timeline_events,
     deidentified_export,
     design_matrix,
     direction_is_stable,
@@ -63,6 +64,7 @@ from build_lab_modeler.pipeline import (
     load_rune_decisions,
     load_spell_decisions,
     load_timeline_state_events,
+    timeline_state_events_query,
     mark_failed,
     maximum_weighted_smd,
     model_generation,
@@ -119,6 +121,24 @@ class FakeTransaction:
         return False
 
 
+class EmptyServerCursor:
+    """psycopg's server-side cursor shape, holding no rows."""
+
+    description: list = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def execute(self, sql, params=None):
+        return self
+
+    def fetchmany(self, size):
+        return []
+
+
 class FakeConnection:
     """Records every statement so the guarded status writes can be asserted without a database."""
 
@@ -133,6 +153,7 @@ class FakeConnection:
         self._rowcounts = dict(rowcounts or {})
         self._rows = dict(rows or {})
         self._fail_on = fail_on
+        self.server_cursors: list = []
         self.statements: list[tuple[str, tuple | list | None]] = []
         # Statements that survived their transaction block, as opposed to every statement attempted.
         self.staged: list[tuple[str, tuple | list | None]] = []
@@ -152,6 +173,17 @@ class FakeConnection:
         self.statements.append((statement, rows))
         self._stage(statement, rows)
         return FakeCursor(len(rows))
+
+    def cursor(self, name=None, row_factory=None):
+        """A server-side cursor over nothing.
+
+        The sweep streams the cohort's event state through one of these. A generation driven against
+        this fake has no timeline rows, so an empty stream is the honest answer -- and keeping the real
+        `stream_cohort_event_state` in the path means these tests still exercise it rather than
+        stubbing the step that broke prod.
+        """
+        self.server_cursors.append(name)
+        return EmptyServerCursor()
 
     def transaction(self) -> FakeTransaction:
         return FakeTransaction(self)
@@ -810,7 +842,7 @@ def test_rank_lateral_prefers_the_nearest_pre_match_observation():
 def test_every_timeline_dependent_loader_filters_the_schema_version():
     for loader in (
         load_item_events,
-        load_timeline_state_events,
+        timeline_state_events_query,
         load_rune_decisions,
         load_spell_decisions,
     ):
@@ -1772,7 +1804,7 @@ def test_every_cohort_loader_scopes_on_the_same_predicates():
     # The sweep is only correct if all five loaders agree on which rows belong to the scope. Item,
     # rune and spell rows are per participant; team composition and kill state are per match.
     participant_scoped = (load_item_events, load_rune_decisions, load_spell_decisions)
-    match_scoped = (load_timeline_state_events, load_participant_teams)
+    match_scoped = (timeline_state_events_query, load_participant_teams)
     for loader in participant_scoped + match_scoped:
         source = inspect.getsource(loader)
         assert "scope_predicates(" in source, loader.__name__
@@ -1828,7 +1860,7 @@ def test_every_champion_scoped_loader_defines_the_match_set_it_references():
         load_item_events,
         load_rune_decisions,
         load_spell_decisions,
-        load_timeline_state_events,
+        timeline_state_events_query,
         load_participant_teams,
     ):
         source = inspect.getsource(loader)
@@ -1877,8 +1909,8 @@ def test_the_estimate_sweep_scopes_every_load_to_one_champion(monkeypatch, tmp_p
     assert len(set(drawn)) == len(drawn), drawn
 
 
-def cohort_timeline_fixture() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Two matches' worth of events, of which one champion played only the first.
+def cohort_timeline_fixture():
+    """Two matches of events, of which the champion under test played only the first.
 
     Shaped like the loader's output, including the payload scalars arriving as text.
     """
@@ -1886,88 +1918,184 @@ def cohort_timeline_fixture() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
         [
             {"match_id": "mine", "event_index": 0, "timestamp_ms": 500, "event_type": "CHAMPION_KILL", "killer_participant_id": "1", "killer_team_id": None, "owner_team_id": None},
             {"match_id": "mine", "event_index": 1, "timestamp_ms": 900, "event_type": "BUILDING_KILL", "killer_participant_id": "0", "killer_team_id": None, "owner_team_id": "200"},
+            {"match_id": "mine", "event_index": 2, "timestamp_ms": 1400, "event_type": "CHAMPION_KILL", "killer_participant_id": "6", "killer_team_id": None, "owner_team_id": None},
             {"match_id": "theirs", "event_index": 0, "timestamp_ms": 400, "event_type": "CHAMPION_KILL", "killer_participant_id": "6", "killer_team_id": None, "owner_team_id": None},
             {"match_id": "theirs", "event_index": 1, "timestamp_ms": 700, "event_type": "ELITE_MONSTER_KILL", "killer_participant_id": "6", "killer_team_id": None, "owner_team_id": None},
         ]
     )
     decisions = pd.DataFrame(
-        [{"match_id": "mine", "participant_id": 1, "timestamp_ms": 2000}]
+        [
+            {"match_id": "mine", "participant_id": 1, "timestamp_ms": 1000},
+            {"match_id": "mine", "participant_id": 1, "timestamp_ms": 2000},
+        ]
     )
     teams = pd.DataFrame(
         [
             {"match_id": "mine", "participant_id": 1, "team_id": 100},
             {"match_id": "mine", "participant_id": 6, "team_id": 200},
+            {"match_id": "theirs", "participant_id": 6, "team_id": 200},
         ]
     )
     return events, decisions, teams
 
 
-def test_slicing_the_preloaded_events_matches_what_a_champion_scoped_query_returned():
-    # The whole safety argument for reading the cohort's timeline once instead of once per champion.
-    # If these ever diverge, the sweep is publishing different numbers than the per-champion loads did.
-    cohort_events, decisions, teams = cohort_timeline_fixture()
-    scoped = cohort_events[cohort_events["match_id"] == "mine"].reset_index(drop=True)
+class ChunkedTimelineConnection:
+    """A connection whose server-side cursor hands the fixture back in chunks.
 
-    from_query = enrich_with_predecision_event_state(decisions, scoped, teams)
-    from_slice = enrich_with_predecision_event_state(
-        decisions,
-        champion_timeline_events(compact_timeline_events(cohort_events), decisions["match_id"]),
-        teams,
+    Mirrors psycopg closely enough to drive `stream_cohort_event_state`: a named cursor, a
+    `description` naming the columns, and `fetchmany` yielding tuples. A deliberately tiny chunk size
+    splits a match across chunk boundaries, which is the case the cumulative sums have to survive.
+    """
+
+    class Column:
+        def __init__(self, name):
+            self.name = name
+
+    class Cursor:
+        def __init__(self, frame, chunk):
+            self._frame = frame
+            self._chunk = chunk
+            self._offset = 0
+            self.description = [ChunkedTimelineConnection.Column(c) for c in frame.columns]
+            self.executed = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def execute(self, sql, params=None):
+            self.executed.append((sql, params))
+            return self
+
+        def fetchmany(self, size):
+            window = self._frame.iloc[self._offset:self._offset + size]
+            self._offset += len(window)
+            return list(window.itertuples(index=False, name=None))
+
+    def __init__(self, frame, chunk=2):
+        self._frame = frame
+        self._chunk = chunk
+        self.cursors = []
+
+    def cursor(self, name=None, row_factory=None):
+        cursor = ChunkedTimelineConnection.Cursor(self._frame, self._chunk)
+        cursor.name = name
+        self.cursors.append(cursor)
+        return cursor
+
+
+def streamed_state(events, teams, chunk=2):
+    connection = ChunkedTimelineConnection(events, chunk=chunk)
+    state = stream_cohort_event_state(
+        connection, ["16.15"], datetime(2026, 8, 10, tzinfo=timezone.utc), teams, chunk_rows=chunk
+    )
+    return state, connection
+
+
+def test_streamed_cohort_state_matches_the_buffered_per_scope_path():
+    # The whole safety argument for reducing the cohort once instead of querying per champion. If these
+    # diverge, the sweep publishes different numbers than the per-scope loads produced.
+    events, decisions, teams = cohort_timeline_fixture()
+    scoped = events[events["match_id"] == "mine"].reset_index(drop=True)
+
+    buffered = enrich_with_predecision_event_state(decisions, scoped, teams)
+    state, _ = streamed_state(events, teams)
+    streamed = apply_event_state(decisions, state, teams)
+
+    pd.testing.assert_frame_equal(buffered, streamed)
+    # Not a vacuous comparison: the fixture has to actually move the diff columns.
+    assert buffered["team_kill_diff"].tolist() == [1.0, 0.0]
+    assert buffered["team_tower_diff"].tolist() == [1.0, 1.0]
+    assert buffered["has_event_state"].tolist() == [1.0, 1.0]
+
+
+def test_a_chunk_boundary_inside_a_match_does_not_restart_its_counters():
+    # Cumulative sums are deferred to the end for exactly this reason: chunking is a transport detail
+    # and must not be observable in the result.
+    events, decisions, teams = cohort_timeline_fixture()
+    whole, _ = streamed_state(events, teams, chunk=len(events))
+    split, connection = streamed_state(events, teams, chunk=1)
+
+    assert len(connection.cursors[0].executed) == 1, "the statement is issued once, then streamed"
+    pd.testing.assert_frame_equal(
+        apply_event_state(decisions, whole, teams),
+        apply_event_state(decisions, split, teams),
     )
 
-    pd.testing.assert_frame_equal(from_query, from_slice)
-    # Not a vacuous comparison: the fixture has to actually exercise the diff columns.
-    assert from_query["team_kill_diff"].tolist() == [1.0]
-    assert from_query["team_tower_diff"].tolist() == [1.0]
-    assert from_query["has_event_state"].tolist() == [1.0]
 
-
-def test_an_unrelated_match_s_events_cannot_reach_a_published_column():
-    # Why the slice is an optimisation rather than a correctness requirement: `merge_asof` carries
-    # match_id in `by`, so a superset is inert. Asserting it directly means a future change to the
+def test_an_unrelated_match_cannot_reach_a_published_column():
+    # Why cohort-wide state is safe to share across every champion: merge_asof carries the match in
+    # `by`, so a match the champion never played is inert. Asserted directly so a future change to the
     # merge keys fails here rather than silently mixing matches together.
-    cohort_events, decisions, teams = cohort_timeline_fixture()
-    scoped = cohort_events[cohort_events["match_id"] == "mine"].reset_index(drop=True)
+    events, decisions, teams = cohort_timeline_fixture()
+    scoped = events[events["match_id"] == "mine"].reset_index(drop=True)
 
     pd.testing.assert_frame_equal(
-        enrich_with_predecision_event_state(decisions, scoped, teams),
-        enrich_with_predecision_event_state(decisions, cohort_events, teams),
+        apply_event_state(decisions, event_state_from_events(scoped, teams), teams),
+        apply_event_state(decisions, event_state_from_events(events, teams), teams),
     )
 
 
-def test_a_preloaded_slice_hands_back_the_loader_s_own_dtypes():
-    # Compaction is storage-only. `attribute_events_to_teams` compares event_type to string literals
-    # and merges match_id against frames of plain strings, so a categorical leaking through would
-    # change merge behaviour rather than fail loudly.
-    cohort_events, _, _ = cohort_timeline_fixture()
-    compacted = compact_timeline_events(cohort_events)
-    assert isinstance(compacted["match_id"].dtype, pd.CategoricalDtype)
+def test_event_state_is_held_in_a_narrow_numeric_width():
+    # The regression that took the modeler down: holding the cohort's raw events cost ~340 bytes a row
+    # and blew the 6g container. The reduced form has to stay numeric and must not carry the match id
+    # as a string, which is what dominated that footprint.
+    events, _, teams = cohort_timeline_fixture()
+    state, _ = streamed_state(events, teams)
 
-    sliced = champion_timeline_events(compacted, ["mine"])
-    assert sliced["match_id"].dtype == object
-    assert sliced["event_type"].dtype == object
-    assert sliced["match_id"].tolist() == ["mine", "mine"]
-    # A category that survived the slice would otherwise reappear in groupby/merge results.
-    assert set(sliced["event_type"]) == {"CHAMPION_KILL", "BUILDING_KILL"}
+    assert list(state.cumulative.columns) == [
+        "match_code", "team_id", "timestamp_ms", "kills", "towers", "objectives"
+    ]
+    assert all(str(dtype).startswith("int") for dtype in state.cumulative.dtypes), state.cumulative.dtypes
+    per_row = state.cumulative.memory_usage(deep=True).sum() / max(len(state.cumulative), 1)
+    assert per_row < 64, per_row
 
 
-def test_an_empty_cohort_timeline_survives_compaction_and_slicing():
-    empty = pd.DataFrame(
-        columns=["match_id", "event_index", "timestamp_ms", "event_type", "killer_participant_id", "killer_team_id", "owner_team_id"]
+def test_coverage_separates_a_payloadless_match_from_an_unattributable_one():
+    # has_event_state rides on covered_matches rather than on the cumulative frame, because a match
+    # whose events attribute to no team is still a match that HAD payload rows.
+    events = pd.DataFrame(
+        [{"match_id": "covered", "event_index": 0, "timestamp_ms": 500, "event_type": "CHAMPION_KILL",
+          "killer_participant_id": "0", "killer_team_id": None, "owner_team_id": None}]
     )
-    assert compact_timeline_events(empty).empty
-    assert champion_timeline_events(empty, ["mine"]).empty
+    decisions = pd.DataFrame(
+        [
+            {"match_id": "covered", "participant_id": 1, "timestamp_ms": 2000},
+            {"match_id": "payloadless", "participant_id": 1, "timestamp_ms": 2000},
+        ]
+    )
+    teams = pd.DataFrame(
+        [
+            {"match_id": "covered", "participant_id": 1, "team_id": 100},
+            {"match_id": "payloadless", "participant_id": 1, "team_id": 100},
+        ]
+    )
+    state, _ = streamed_state(events, teams)
+
+    enriched = apply_event_state(decisions, state, teams)
+    assert state.cumulative.empty, "killerId 0 with no owning team attributes to nobody"
+    assert enriched["has_event_state"].tolist() == [1.0, 0.0]
+
+
+def test_an_empty_cohort_streams_to_empty_state():
+    events, decisions, teams = cohort_timeline_fixture()
+    state, _ = streamed_state(events.iloc[:0], teams)
+    assert state.cumulative.empty
+    assert state.covered_matches == frozenset()
+    assert apply_event_state(decisions, state, teams)["has_event_state"].tolist() == [0.0, 0.0]
 
 
 def test_the_sweep_never_reads_the_timeline_once_per_champion(monkeypatch, tmp_path):
-    # The regression this guards: `load_timeline_state_events` is match-scoped, so a champion-scoped
-    # call re-read every match that champion played -- ten times over the cohort across the sweep, which
-    # is what projected a 173-champion run to 17 days on prod. One unscoped preload replaces all of them.
+    # The amplification this removed: `load_timeline_state_events` is match-scoped, so a champion-scoped
+    # call re-read every match that champion played -- ten times over the cohort across a sweep, which
+    # is what projected a 173-champion run to 17 days on prod.
     monkeypatch.setenv("BUILD_LAB_SWEEP_WORKERS", "1")
     settings, generation = publishing_generation(monkeypatch, tmp_path)
     champions = [22, 51, 103]
     monkeypatch.setattr(pipeline, "load_cohort_champions", lambda *_: champions)
-    calls: list[dict] = []
+    calls: list = []
     real_loader = pipeline.load_timeline_state_events
 
     def recording(connection, patches, cutoff, champion_id=None, match_sample_range=None):
@@ -1975,17 +2103,32 @@ def test_the_sweep_never_reads_the_timeline_once_per_champion(monkeypatch, tmp_p
         return real_loader(connection, patches, cutoff, champion_id, match_sample_range)
 
     monkeypatch.setattr(pipeline, "load_timeline_state_events", recording)
+    monkeypatch.setattr(
+        pipeline,
+        "stream_cohort_event_state",
+        lambda *a, **k: pipeline.CohortEventState(pipeline.empty_event_state_rows(), {}, frozenset()),
+    )
     model_generation(FakeConnection(), generation, settings)
 
-    assert calls, "the sweep must still read the timeline at all"
-    # Not "once in total": the structural fit draws per match-sample range, and those are unamplified.
     assert all(call["champion_id"] is None for call in calls), calls
-    preloads = [
-        call
-        for call in calls
-        if call["champion_id"] is None and call["match_sample_range"] is None
-    ]
-    assert len(preloads) == 1, preloads
+
+
+def test_the_sweep_streams_the_cohort_rather_than_buffering_it(monkeypatch, tmp_path):
+    # This failure mode is silent: a buffered cohort read works on a small corpus and only dies once
+    # the cohort outgrows the container, which is exactly how it reached prod.
+    monkeypatch.setenv("BUILD_LAB_SWEEP_WORKERS", "1")
+    settings, generation = publishing_generation(monkeypatch, tmp_path)
+    monkeypatch.setattr(pipeline, "load_cohort_champions", lambda *_: [22])
+    streamed: list = []
+
+    def recording_stream(connection, patches, cutoff, teams, **kwargs):
+        streamed.append(patches)
+        return pipeline.CohortEventState(pipeline.empty_event_state_rows(), {}, frozenset())
+
+    monkeypatch.setattr(pipeline, "stream_cohort_event_state", recording_stream)
+    model_generation(FakeConnection(), generation, settings)
+
+    assert len(streamed) == 1, "the cohort's event state is streamed exactly once per process"
 
 
 class DictRowCursor:
@@ -2736,13 +2879,18 @@ def test_the_sequential_sweep_reuses_the_connection_it_was_given(monkeypatch, tm
     # the live app, and would make the publish path untestable without a real server.
     settings = modeler_settings(monkeypatch, BUILD_LAB_ARTIFACT_DIR=str(tmp_path))
     sentinel = FakeConnection()
-    # What the preload draws is another test's business; this one is about the wiring, so it is stubbed
+    # What the stream draws is another test's business; this one is about the wiring, so it is stubbed
     # rather than serviced by a fake cursor.
     monkeypatch.setattr(
-        pipeline, "load_timeline_state_events", lambda *_, **__: pd.DataFrame()
+        pipeline, "load_participant_teams", lambda *_, **__: pd.DataFrame()
     )
-    # The cohort carries the patches and cutoff because setup also draws the sweep's one timeline
-    # preload here, on this same connection -- which is the point of reusing it.
+    monkeypatch.setattr(
+        pipeline,
+        "stream_cohort_event_state",
+        lambda *a, **k: pipeline.CohortEventState(pipeline.empty_event_state_rows(), {}, frozenset()),
+    )
+    # The cohort carries the patches and cutoff because setup also streams the sweep's one pass over
+    # the cohort's event state here, on this same connection -- which is the point of reusing it.
     pipeline._sweep_worker_setup(
         settings,
         {
@@ -2756,7 +2904,7 @@ def test_the_sequential_sweep_reuses_the_connection_it_was_given(monkeypatch, tm
     assert pipeline._WORKER["connection"] is sentinel
     assert pipeline._WORKER["owns_connection"] is False
     assert pipeline._WORKER["bundle"] == {"model": None}
-    assert "timeline_events" in pipeline._WORKER
+    assert "event_state" in pipeline._WORKER
 
 
 def test_the_sweep_worker_count_is_configurable_and_floored(monkeypatch, tmp_path):
@@ -2803,7 +2951,7 @@ def test_the_timeline_loader_extracts_payload_scalars_in_sql():
     # Parsing PayloadJson in pandas cost one json.loads plus three dict walks per event -- roughly
     # 290,000 per champion -- and was the dominant cost of the sweep. PayloadJson is jsonb, so Postgres
     # reads the three scalars directly. Nothing downstream may reach for the raw payload again.
-    source = inspect.getsource(load_timeline_state_events)
+    source = inspect.getsource(timeline_state_events_query)
     for field in ("killer_participant_id", "killer_team_id", "owner_team_id"):
         assert field in source, field
     # Both spellings, matching the case-insensitive lookup this replaced.


### PR DESCRIPTION
#164 stopped the sweep re-reading the cohort's timeline once per champion, and replaced
that with a cohort-wide buffered read. The read was right; buffering it was not. Every
generation since has died on SIGKILL roughly 23 minutes in, before the preload logged a
single line, and Build Lab still has zero promoted generations out of 85.

The compose unit states the contract that broke:

  mem_limit 6g -- "peak is set by the largest single champion's rows plus one training
  slice, not by the size of the cohort, so this no longer has to be raised as the corpus
  grows"

A cohort-wide fetchall is by definition proportional to the cohort. Measured against the
live 16.15 data (142,803 matches / 7,140,150 events), with the same 6g limit prod pins:

  buffered read   peak 6,113 MB   of 6,144 MB   -- 31 MB of headroom, standing alone
  streamed read   peak 1,607 MB   of 6,144 MB

The buffered form does not merely exceed the limit under load, it consumes essentially
all of it on its own, which is why prod dies: the sweep begins with the structural model
and a training slice already resident, and there is nothing left for them.

What made this fixable is that the sweep never needed the events. It needs the running
per-(match, team) kill/tower/objective counts that merge_cumulative_state reads as-of each
purchase, and those are derivable chunk by chunk. So rows now arrive through a server-side
cursor and are reduced on arrival to int32 match codes, teams and counters -- ~36 bytes a
row against the ~340 the raw text form costs. The cohort's whole event state is 257 MB
resident, and the raw form is never accumulated.

Attribution stays in attribute_events_to_teams rather than moving into SQL. The
killer/declared-team/conceded-building precedence is subtle and already covered by tests;
a second implementation in SQL could only diverge from it.

Cumulative sums are deferred until every chunk is in. A chunk boundary can fall inside a
match, so summing per chunk would restart a match's counters partway through -- the sort
is global, so doing it once at the end reproduces the buffered path's ordering exactly.

match_id becomes an int32 code because it is the whole reason this fits: normalise_uuid_columns
gives each of the 7.14M rows its own 36-character str, and that column alone dominated the
footprint. covered_matches is tracked separately from the cumulative frame because
has_event_state must distinguish a match with no payload rows from one whose payload rows
attributed to no team, and the reduced frame cannot tell those apart.

Verified end to end against a local Postgres seeded to prod's exact schema and scale
(142,803 matches, 7,140,150 events, 1,428,030 participants) rather than in production:
the stream completes in 51s at 1,607 MB, and one champion's 8,495 decisions join to the
shared state in 0.5s at full coverage -- ~87s across 173 champions, against the ~13.6
hours of per-champion timeline reads this replaces. The buffered path was run against the
same fixture to confirm the 6,113 MB figure is reproducible rather than inferred.

Tests: streamed state equals the buffered per-scope path on the same fixture; a chunk
boundary inside a match does not restart its counters; an unrelated match stays inert;
the reduced form stays numeric and under 64 bytes a row; coverage separates a payloadless
match from an unattributable one; and the sweep streams exactly once and never issues a
champion-scoped timeline query. 133 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
