### PR TITLE
Cap BLAS threads on the sweep path the default actually takes

### DIFF
--- a/analytics/modeler/Dockerfile
+++ b/analytics/modeler/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /app
 # "failed to Lchown ...: no such file or directory".
 RUN pip install --no-compile "numpy>=2.1,<3"
 RUN pip install --no-compile "pandas>=2.2,<3"
-RUN pip install --no-compile "scikit-learn>=1.6,<2" "joblib>=1.4,<2"
+RUN pip install --no-compile "scikit-learn>=1.6,<2" "joblib>=1.4,<2" "threadpoolctl>=3.5,<4"
 RUN pip install --no-compile "pyarrow>=18,<21"
 RUN pip install --no-compile "boto3>=1.35,<2" "psycopg[binary]>=3.2,<4"
 

--- a/analytics/modeler/pyproject.toml
+++ b/analytics/modeler/pyproject.toml
@@ -10,7 +10,8 @@ dependencies = [
   "pandas>=2.2,<3",
   "psycopg[binary]>=3.2,<4",
   "pyarrow>=18,<21",
-  "scikit-learn>=1.6,<2"
+  "scikit-learn>=1.6,<2",
+  "threadpoolctl>=3.5,<4"
 ]
 
 [project.optional-dependencies]

--- a/analytics/modeler/src/build_lab_modeler/pipeline.py
+++ b/analytics/modeler/src/build_lab_modeler/pipeline.py
@@ -27,6 +27,7 @@ from scipy.special import erfc
 import pandas as pd
 import psycopg
 from psycopg.rows import dict_row, tuple_row
+from threadpoolctl import threadpool_limits
 
 from .cache import TrainingCache
 from sklearn.isotonic import IsotonicRegression
@@ -153,6 +154,7 @@ class Settings:
     cache_training_draw: bool
     training_draw_max_age_hours: float
     sweep_workers: int
+    sweep_blas_threads: int
     calibration_bands: int
     retained_generations: int
 
@@ -209,6 +211,23 @@ class Settings:
             # was 3x SLOWER. The pool is kept because it is correct and the arithmetic changes on SSD or
             # once the timeline amplification is removed, but it must be opted into.
             sweep_workers=max(1, int(os.getenv("BUILD_LAB_SWEEP_WORKERS", "1"))),
+            # BLAS threads during the estimate sweep, and the single biggest lever on its runtime.
+            #
+            # Measured on the sweep's real fit shape -- 600 rows by DESIGN_MATRIX_MAX_COLUMNS (1,044)
+            # wide, 15 fits per (scope, path), under a 3-cpu quota:
+            #
+            #     cap=1   6 ms/fit      cap=4    65 ms/fit
+            #     cap=2   2 ms/fit      cap=8   112 ms/fit
+            #     cap=3   3 ms/fit      uncapped (24 threads)  2,744 ms/fit
+            #
+            # Threading helps up to the quota and collapses past it, and uncapped is 400x worse than
+            # any capped setting. Width is what makes it so violent: the same benchmark at 40 columns
+            # shows no difference at all, which is how this stayed invisible.
+            #
+            # Defaults to 1 rather than the measured-best 2 because `nproc` cannot be trusted to
+            # describe the quota -- it reports the host's cores -- so 1 is the only value that cannot
+            # oversubscribe whatever the container is actually given.
+            sweep_blas_threads=max(1, int(os.getenv("BUILD_LAB_SWEEP_BLAS_THREADS", "1"))),
             # How finely calibration is conditioned on game phase. The promotion gate scores ECE
             # within time bands, so this is the dial that moves the gate that is hardest to pass.
             calibration_bands=max(
@@ -654,56 +673,73 @@ def model_generation(
             result["rows"], len(result["actions"]), len(result["paths"]),
         )
 
-    if workers == 1:
-        # Kept as a real path, not a fallback nobody runs: it is what a constrained host uses, and it
-        # is the reference the parallel path is checked against.
-        _sweep_worker_setup(
-            settings,
-            cohort,
-            str(artifact_path / "win_probability.joblib"),
-            connection=connection,
-            bundle=structural_model,
+    # Applies to BOTH paths, which is the bug this closes. #162 capped BLAS threads for spawned
+    # workers and made sequential the default in the same change, so the cap landed on the branch the
+    # default never takes. Left uncapped, `nproc` reports the host's 46 cores (a cpu quota does not
+    # change it) and OpenBLAS sizes its pools to match: prod ran 92 threads against a 3-cpu quota,
+    # burning the quota on scheduling instead of arithmetic. Observed as ~300% cpu with almost no I/O,
+    # one champion incomplete after 80 minutes, and every stack sample inside a logistic fit.
+    #
+    # threadpoolctl rather than the environment, because the environment cannot fix this process:
+    # OpenBLAS reads those variables when it loads, and numpy is imported long before the sweep. This
+    # retunes pools that are already running. The environment is still set for the pool, whose
+    # children read it at import. Scoped to the sweep so the structural fit above keeps its threads --
+    # that one is a single large fit, which does thread well.
+    with threadpool_limits(limits=settings.sweep_blas_threads):
+        LOG.info(
+            "Sweep BLAS threads limited to %d (container quota is the binding constraint, not nproc).",
+            settings.sweep_blas_threads,
         )
-        for position, champion_id in enumerate(champions, start=1):
-            absorb(sweep_champion(champion_id), position)
-    else:
-        # A champion that raises must fail the generation rather than silently drop out: a missing
-        # champion is a quietly incomplete estimate set, which is worse than no estimate set.
-        # Workers get one BLAS thread each.
-        #
-        # `nproc` inside the container reports the HOST's cores -- a cpu quota does not change it -- so
-        # OpenBLAS sizes its pool at ~46 threads per process. Four interpreters doing that against a
-        # 3-cpu quota is not just oversubscription: it exhausted thread resources outright and the pool
-        # died with `std::system_error: Resource temporarily unavailable`. Workers only score with an
-        # already-fitted model, which is light linear algebra, so one thread each is right on the merits
-        # as well. Set before the pool starts so spawned children inherit it ahead of importing numpy,
-        # which is the only point at which OpenBLAS reads it. The structural fit above has already run,
-        # so its own threading is unaffected.
-        for variable in (
-            "OMP_NUM_THREADS",
-            "OPENBLAS_NUM_THREADS",
-            "MKL_NUM_THREADS",
-            "NUMEXPR_NUM_THREADS",
-        ):
-            os.environ.setdefault(variable, "1")
+        if workers == 1:
+            # Kept as a real path, not a fallback nobody runs: it is what a constrained host uses, and it
+            # is the reference the parallel path is checked against.
+            _sweep_worker_setup(
+                settings,
+                cohort,
+                str(artifact_path / "win_probability.joblib"),
+                connection=connection,
+                bundle=structural_model,
+            )
+            for position, champion_id in enumerate(champions, start=1):
+                absorb(sweep_champion(champion_id), position)
+        else:
+            # A champion that raises must fail the generation rather than silently drop out: a missing
+            # champion is a quietly incomplete estimate set, which is worse than no estimate set.
+            # Workers get one BLAS thread each.
+            #
+            # `nproc` inside the container reports the HOST's cores -- a cpu quota does not change it -- so
+            # OpenBLAS sizes its pool at ~46 threads per process. Four interpreters doing that against a
+            # 3-cpu quota is not just oversubscription: it exhausted thread resources outright and the pool
+            # died with `std::system_error: Resource temporarily unavailable`. Workers only score with an
+            # already-fitted model, which is light linear algebra, so one thread each is right on the merits
+            # as well. Set before the pool starts so spawned children inherit it ahead of importing numpy,
+            # which is the only point at which OpenBLAS reads it. The structural fit above has already run,
+            # so its own threading is unaffected.
+            for variable in (
+                "OMP_NUM_THREADS",
+                "OPENBLAS_NUM_THREADS",
+                "MKL_NUM_THREADS",
+                "NUMEXPR_NUM_THREADS",
+            ):
+                os.environ.setdefault(variable, "1")
 
-        # "spawn", never the Linux default of "fork".
-        #
-        # The structural fit immediately above runs BLAS/OpenMP threads. fork() copies only the calling
-        # thread but inherits every mutex in whatever state it was in, so a lock held by a BLAS thread at
-        # fork time is inherited already-locked and never released -- the child then deadlocks the first
-        # time it touches that runtime. Observed exactly that on prod: four workers connected, opened a
-        # transaction each, and sat idle-in-transaction for 45 minutes without completing one champion.
-        # spawn starts a fresh interpreter with no inherited lock state. It costs a re-import per worker,
-        # once, against a sweep measured in tens of minutes.
-        with ProcessPoolExecutor(
-            max_workers=workers,
-            mp_context=multiprocessing.get_context("spawn"),
-            initializer=_sweep_worker_setup,
-            initargs=(settings, cohort, str(artifact_path / "win_probability.joblib")),
-        ) as pool:
-            for position, result in enumerate(pool.map(sweep_champion, champions), start=1):
-                absorb(result, position)
+            # "spawn", never the Linux default of "fork".
+            #
+            # The structural fit immediately above runs BLAS/OpenMP threads. fork() copies only the calling
+            # thread but inherits every mutex in whatever state it was in, so a lock held by a BLAS thread at
+            # fork time is inherited already-locked and never released -- the child then deadlocks the first
+            # time it touches that runtime. Observed exactly that on prod: four workers connected, opened a
+            # transaction each, and sat idle-in-transaction for 45 minutes without completing one champion.
+            # spawn starts a fresh interpreter with no inherited lock state. It costs a re-import per worker,
+            # once, against a sweep measured in tens of minutes.
+            with ProcessPoolExecutor(
+                max_workers=workers,
+                mp_context=multiprocessing.get_context("spawn"),
+                initializer=_sweep_worker_setup,
+                initargs=(settings, cohort, str(artifact_path / "win_probability.joblib")),
+            ) as pool:
+                for position, result in enumerate(pool.map(sweep_champion, champions), start=1):
+                    absorb(result, position)
 
     if not action_pool:
         raise RuntimeError("No adjusted action estimates could be produced.")

--- a/analytics/modeler/tests/test_pipeline.py
+++ b/analytics/modeler/tests/test_pipeline.py
@@ -2131,6 +2131,69 @@ def test_the_sweep_streams_the_cohort_rather_than_buffering_it(monkeypatch, tmp_
     assert len(streamed) == 1, "the cohort's event state is streamed exactly once per process"
 
 
+def test_the_sequential_sweep_caps_blas_threads_like_the_pool_does(monkeypatch, tmp_path):
+    # #162 capped BLAS threads for spawned workers and made sequential the default in the same change,
+    # so the cap landed on the branch the default never takes. `nproc` reports the host's cores inside
+    # the container because a cpu quota does not change it, so OpenBLAS sized its pools for 46 cores
+    # against a 3-cpu quota: prod ran 92 threads, spent ~300% cpu with almost no I/O, and did not finish
+    # one champion in 80 minutes, with every stack sample inside a logistic fit.
+    #
+    # Asserted against the wrapper rather than live threadpool_info(), which reports an empty list when
+    # no accelerated backend happens to be loaded and would make this pass vacuously.
+    monkeypatch.setenv("BUILD_LAB_SWEEP_WORKERS", "1")
+    monkeypatch.setenv("BUILD_LAB_SWEEP_BLAS_THREADS", "1")
+    settings, generation = publishing_generation(monkeypatch, tmp_path)
+    monkeypatch.setattr(pipeline, "load_cohort_champions", lambda *_: [22, 51])
+    monkeypatch.setattr(
+        pipeline,
+        "stream_cohort_event_state",
+        lambda *a, **k: pipeline.CohortEventState(pipeline.empty_event_state_rows(), {}, frozenset()),
+    )
+
+    events: list = []
+
+    class RecordingLimits:
+        def __init__(self, limits=None):
+            self.limits = limits
+
+        def __enter__(self):
+            events.append(("enter", self.limits))
+            return self
+
+        def __exit__(self, *_):
+            events.append(("exit", self.limits))
+            return False
+
+    real_sweep = pipeline.sweep_champion
+
+    def recording_sweep(champion_id):
+        events.append(("champion", champion_id))
+        return real_sweep(champion_id)
+
+    monkeypatch.setattr(pipeline, "threadpool_limits", RecordingLimits)
+    monkeypatch.setattr(pipeline, "sweep_champion", recording_sweep)
+    model_generation(FakeConnection(), generation, settings)
+
+    assert ("enter", 1) in events, events
+    champions_seen = [name for name, _ in events].count("champion")
+    assert champions_seen == 2, events
+    # Every champion has to run INSIDE the limit, not merely after it was set up once.
+    opened = events.index(("enter", 1))
+    closed = events.index(("exit", 1))
+    swept = [i for i, (name, _) in enumerate(events) if name == "champion"]
+    assert all(opened < i < closed for i in swept), events
+
+
+def test_the_blas_thread_cap_is_configurable_and_floored(monkeypatch, tmp_path):
+    assert modeler_settings(monkeypatch, BUILD_LAB_ARTIFACT_DIR=str(tmp_path)).sweep_blas_threads == 1
+    assert modeler_settings(
+        monkeypatch, BUILD_LAB_ARTIFACT_DIR=str(tmp_path), BUILD_LAB_SWEEP_BLAS_THREADS="3"
+    ).sweep_blas_threads == 3
+    assert modeler_settings(
+        monkeypatch, BUILD_LAB_ARTIFACT_DIR=str(tmp_path), BUILD_LAB_SWEEP_BLAS_THREADS="0"
+    ).sweep_blas_threads == 1
+
+
 class DictRowCursor:
     """A cursor shaped like psycopg's, whose row factory decides the row type.
 


### PR DESCRIPTION
#162 found that `nproc` reports the host's cores inside the container -- a cpu quota does not
change it -- so OpenBLAS sizes its pools for 46 cores against a 3-cpu quota. It capped the
threads to fix that, and in the same change made the sequential sweep the default. The cap
went into the `else` branch. The default has been running uncapped ever since.

Prod showed it as 92 threads in the modeler process, ~300% cpu against a 3-cpu quota, almost
no block I/O, and one champion not completing in 80 minutes. Three consecutive py-spy dumps
of the live process all landed in the same place:

  sweep_champion -> path_records -> doubly_robust_binary
    -> LogisticRegression.fit -> scipy L-BFGS-B -> loss_gradient

Width is what makes the oversubscription so violent, and is why this was invisible. Measured
on the sweep's real fit shape -- DESIGN_MATRIX_MAX_COLUMNS is 1,044 -- under a 3-cpu quota:

  cap=1   6 ms/fit      cap=4    65 ms/fit
  cap=2   2 ms/fit      cap=8   112 ms/fit
  cap=3   3 ms/fit      uncapped (24 threads)  2,744 ms/fit

Threading helps up to the quota and collapses past it. The same benchmark at 40 columns shows
1.09x and no cliff at all, which is the shape a casual benchmark would pick and the reason
this went unnoticed for so long.

threadpoolctl rather than the environment, because the environment cannot fix this process:
OpenBLAS reads OMP_NUM_THREADS and friends when it loads, and numpy is imported long before
the sweep starts. The environment is still set for the pool, whose children read it at import.
The limit is scoped to the sweep so the structural fit above keeps its threads -- that one is
a single large fit, which does thread well.

Defaults to 1 rather than the measured-best 2 because `nproc` cannot be trusted to describe
the quota, so 1 is the only value that cannot oversubscribe whatever the container is given.
BUILD_LAB_SWEEP_BLAS_THREADS tunes it.

Measured end to end on real pipeline code against a local Postgres seeded to prod's schema and
scale (142,803 matches, 1,428,030 participants, 7.1M timeline events, 10.0M item events,
12.9M runes, 11.4M frames), one champion's path_records:

  uncapped   2.93 units/s
  capped=1  11.39 units/s     3.9x

3.9x, not the 388x the synthetic benchmark suggests: real scopes vary in size, so only the
large ones hit the pathology. The prod effect should be somewhat larger, since prod
oversubscribes 46 cores rather than the 24 this was measured on.

This does NOT make the sweep viable, and is not claimed to. The same run to completion is
10,800 (scope, path) units in 694s for one champion -- ~11.6 minutes, so ~33 hours across 173
champions, which still cannot finish inside a daily cadence. The remaining cost is the work
itself: expand_scopes quadruples the frame, scopes are champion x role x opponent x region, and
each (scope, path) fits 5 folds x 3 nuisance models on a 1,044-column design. That is ~28M
logistic fits per generation, and reducing it is a modelling decision rather than a
performance one.

Tests: the sequential sweep runs every champion inside the limit rather than merely after it
was set once, and the cap is configurable and floored. 135 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
